### PR TITLE
Reporting wrongly-cased file imports in case-insensitive operating systems

### DIFF
--- a/lib/core/resolve.js
+++ b/lib/core/resolve.js
@@ -1,9 +1,20 @@
 'use strict'
 
-var path = require('path')
+var fs = require('fs')
+  , path = require('path')
   , resolve = require('resolve')
   , assign = require('object-assign')
 
+// http://stackoverflow.com/a/27382838
+function fileExistsWithCaseSync(filepath) {
+  var dir = path.dirname(filepath)
+  if (dir === '/' || dir === '.') return true
+  var filenames = fs.readdirSync(dir)
+  if (filenames.indexOf(path.basename(filepath)) === -1) {
+      return false
+  }
+  return fileExistsWithCaseSync(dir)
+}
 
 function opts(basedir, settings) {
   // pulls all items from 'import/resolve'
@@ -22,8 +33,10 @@ function opts(basedir, settings) {
 module.exports = function (p, context) {
 
   try {
-    return resolve.sync(p, opts( path.dirname(context.getFilename())
-                               , context.settings))
+    var file = resolve.sync(p, opts( path.dirname(context.getFilename())
+                                 , context.settings))
+    if (!fileExistsWithCaseSync(file)) return null
+    return file
   } catch (err) {
     if (err.message.indexOf('Cannot find module') === 0) {
       return null
@@ -36,7 +49,9 @@ module.exports = function (p, context) {
 module.exports.relative = function (p, r, settings) {
   try {
 
-    return resolve.sync(p, opts(path.dirname(r), settings))
+    var file = resolve.sync(p, opts(path.dirname(r), settings))
+    if (!fileExistsWithCaseSync(file)) return null
+    return file
 
   } catch (err) {
 

--- a/tests/files/jsx/MyUnCoolComponent.jsx
+++ b/tests/files/jsx/MyUnCoolComponent.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+export default class MyCoolComponent extends React.Component {
+	render() {
+		return (<div>too cool for school</div>)
+	}
+}

--- a/tests/lib/core/resolve.js
+++ b/tests/lib/core/resolve.js
@@ -17,4 +17,13 @@ describe('resolve', function () {
 
     expect(file).to.equal(utils.testFilePath('./jsx/MyCoolComponent.jsx'))
   })
+
+  it('should test case sensitivity', function () {
+    // Note the spelling error 'MyUncoolComponent' vs 'MyUnCoolComponent'
+    var file = resolve( './jsx/MyUncoolComponent'
+                      , utils.testContext({ 'import/resolve': { 'extensions': ['.jsx'] }})
+                      )
+
+    expect(file).to.equal(null)
+  })
 })


### PR DESCRIPTION
This pull request fixes an issue we've dealt with internally. We primarily use OS X as our development OS and deploy to Linux. OS X is case-insensitive, meaning that given a file called `MyUnCoolComponent.jsx`, the following import will work without issue on OS X:

```js
// Note the casing error in the file name
import MyUnCoolComponent from "./MyUncoolComponent.jsx"
```

However, this import will fail on a case-sensitive OS such as Linux. This PR adds functionality to check the casing in the file path before reporting a successful file match.