### PR TITLE
optional case sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,6 @@ as defined by standard Node `require.resolve` behavior.
 See [settings](#settings) for customization options for the resolution (i.e.
 additional filetypes, `NODE_PATH`, etc.)
 
-If you are working in an environment with a case-insensitive filesystem (i.e. OSX)
-but deploying somewhere case-sensitive (i.e. Linux) and would like to ensure
-case-sensitive resolution checking, pass `case-sensitive` as the first option:
-
-```yaml
-# .eslintrc
-rules:
-  import/no-unresolved: [2, case-sensitive]
-```
 
 ### `named`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 eslint-plugin-import
 ---
 [![build status](https://travis-ci.org/benmosher/eslint-plugin-import.svg)](https://travis-ci.org/benmosher/eslint-plugin-import)
+[![win32 build status](https://ci.appveyor.com/api/projects/status/3mw2fifalmjlqf56/branch/master?svg=true)](https://ci.appveyor.com/project/benmosher/eslint-plugin-import/branch/master)
 [![npm](https://img.shields.io/npm/v/eslint-plugin-import.svg)](https://www.npmjs.com/package/eslint-plugin-import)
 
 This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, and prevent issues with misspelling of file paths and import names. All the goodness that the ES2015+ static module syntax intends to provide, marked up in your editor.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ as defined by standard Node `require.resolve` behavior.
 See [settings](#settings) for customization options for the resolution (i.e.
 additional filetypes, `NODE_PATH`, etc.)
 
+If you are working in an environment with a case-insensitive filesystem (i.e. OSX)
+but deploying somewhere case-sensitive (i.e. Linux) and would like to ensure
+case-sensitive resolution checking, pass `case-sensitive` as the first option:
+
+```yaml
+# .eslintrc
+rules:
+  import/no-unresolved: [2, case-sensitive]
+```
 
 ### `named`
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against this version of Node.js
+environment:
+  nodejs_version: "0.10"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,14 @@
 # Test against this version of Node.js
 environment:
-  nodejs_version: "0.10"
+  matrix:
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.12"
+  # - nodejs_version: "1"
+  # - nodejs_version: "2"
+
+# platform:
+#   - x86
+#   - x64
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "watch": "babel -d lib/ src/ --watch & mocha --recursive --reporter dot --compilers js:babel/register --watch tests/src/",
     "cover": "eslint ./src && istanbul cover --dir reports/coverage _mocha tests/src/ -- --recursive --reporter dot --compilers js:babel/register",
-    "test": "mocha --timeout 4000 --recursive --reporter dot --compilers js:babel/register tests/src/",
+    "test": "mocha --timeout 5000 --recursive --reporter dot --compilers js:babel/register tests/src/",
     "compile": "babel -d lib/ src/",
     "prepublish": "npm run compile",
     "pretest": "eslint ./src"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "watch": "babel -d lib/ src/ --watch & mocha --recursive --reporter dot --compilers js:babel/register --watch tests/src/",
     "cover": "eslint ./src && istanbul cover --dir reports/coverage _mocha tests/src/ -- --recursive --reporter dot --compilers js:babel/register",
-    "test": "mocha --recursive --reporter dot --compilers js:babel/register tests/src/",
+    "test": "mocha --timeout 4000 --recursive --reporter dot --compilers js:babel/register tests/src/",
     "compile": "babel -d lib/ src/",
     "prepublish": "npm run compile",
     "pretest": "eslint ./src"

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   },
   "scripts": {
     "watch": "babel -d lib/ src/ --watch & mocha --recursive --reporter dot --compilers js:babel/register --watch tests/src/",
-    "test": "eslint ./src && istanbul cover --dir reports/coverage _mocha tests/src/ -- --recursive --reporter dot --compilers js:babel/register",
+    "cover": "eslint ./src && istanbul cover --dir reports/coverage _mocha tests/src/ -- --recursive --reporter dot --compilers js:babel/register",
+    "test": "mocha --recursive --reporter dot --compilers js:babel/register tests/src/",
     "compile": "babel -d lib/ src/",
-    "prepublish": "npm run compile"
+    "prepublish": "npm run compile",
+    "pretest": "eslint ./src"
   },
   "repository": {
     "type": "git",

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -8,7 +8,7 @@ function fileExistsWithCaseSync(filepath) {
   if (!fs.existsSync(filepath)) return false
 
   var dir = path.dirname(filepath)
-  if (dir === '/' || dir === '.') return true
+  if (dir === '/' || dir === '.' || /^[A-Z]:\\$/.test(dir)) return true
   var filenames = fs.readdirSync(dir)
   if (filenames.indexOf(path.basename(filepath)) === -1) {
       return false

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -1,11 +1,12 @@
-'use strict'
-
 var fs = require('fs')
   , path = require('path')
   , resolve = require('resolve')
 
 // http://stackoverflow.com/a/27382838
 function fileExistsWithCaseSync(filepath) {
+  // shortcut exit
+  if (!fs.existsSync(filepath)) return false
+
   var dir = path.dirname(filepath)
   if (dir === '/' || dir === '.') return true
   var filenames = fs.readdirSync(dir)
@@ -13,6 +14,14 @@ function fileExistsWithCaseSync(filepath) {
       return false
   }
   return fileExistsWithCaseSync(dir)
+}
+
+function fileExists(filepath, caseSensitive = false) {
+  if (caseSensitive) {
+    return fileExistsWithCaseSync(filepath)
+  } else {
+    return fs.existsSync(filepath)
+  }
 }
 
 function opts(basedir, settings) {
@@ -29,12 +38,14 @@ function opts(basedir, settings) {
  * @param  {object} context - ESLint context
  * @return {string} - the full module filesystem path
  */
-module.exports = function (p, context) {
+module.exports = function (p, context, considerCase) {
+  // resolve just returns the core module id, which won't appear to exist
+  if (resolve.isCore(p)) return p
 
   try {
     var file = resolve.sync(p, opts( path.dirname(context.getFilename())
-                                 , context.settings))
-    if (!fileExistsWithCaseSync(file)) return null
+                                   , context.settings))
+    if (!fileExists(file, considerCase)) return null
     return file
   } catch (err) {
     if (err.message.indexOf('Cannot find module') === 0) {
@@ -49,7 +60,7 @@ module.exports.relative = function (p, r, settings) {
   try {
 
     var file = resolve.sync(p, opts(path.dirname(r), settings))
-    if (!fileExistsWithCaseSync(file)) return null
+    if (!fileExists(file)) return null
     return file
 
   } catch (err) {

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -2,6 +2,8 @@ var fs = require('fs')
   , path = require('path')
   , resolve = require('resolve')
 
+const CASE_INSENSITIVE = fs.existsSync(path.join(__dirname, 'reSOLVE.js'))
+
 // http://stackoverflow.com/a/27382838
 function fileExistsWithCaseSync(filepath) {
   // shortcut exit
@@ -16,8 +18,8 @@ function fileExistsWithCaseSync(filepath) {
   return fileExistsWithCaseSync(dir)
 }
 
-function fileExists(filepath, caseSensitive = false) {
-  if (caseSensitive) {
+function fileExists(filepath) {
+  if (CASE_INSENSITIVE) {
     return fileExistsWithCaseSync(filepath)
   } else {
     return fs.existsSync(filepath)
@@ -38,14 +40,14 @@ function opts(basedir, settings) {
  * @param  {object} context - ESLint context
  * @return {string} - the full module filesystem path
  */
-module.exports = function (p, context, considerCase) {
+module.exports = function (p, context) {
   // resolve just returns the core module id, which won't appear to exist
   if (resolve.isCore(p)) return p
 
   try {
     var file = resolve.sync(p, opts( path.dirname(context.getFilename())
                                    , context.settings))
-    if (!fileExists(file, considerCase)) return null
+    if (!fileExists(file)) return null
     return file
   } catch (err) {
     if (err.message.indexOf('Cannot find module') === 0) {

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -5,12 +5,11 @@
 import resolve from '../core/resolve'
 
 export default function (context) {
-  const caseSensitive = context.options[0] === 'case-sensitive'
 
   function checkSource(node) {
     if (node.source == null) return
 
-    if (resolve(node.source.value, context, caseSensitive) == null) {
+    if (resolve(node.source.value, context) == null) {
       context.report(node.source,
         'Unable to resolve path to module \'' + node.source.value + '\'.')
     }

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -2,16 +2,15 @@
  * @fileOverview Ensures that an imported path exists, given resolution rules.
  * @author Ben Mosher
  */
+import resolve from '../core/resolve'
 
-'use strict'
+export default function (context) {
+  const caseSensitive = context.options[0] === 'case-sensitive'
 
-var resolve = require('../core/resolve')
-
-module.exports = function (context) {
   function checkSource(node) {
     if (node.source == null) return
 
-    if (resolve(node.source.value, context) == null) {
+    if (resolve(node.source.value, context, caseSensitive) == null) {
       context.report(node.source,
         'Unable to resolve path to module \'' + node.source.value + '\'.')
     }

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -22,7 +22,6 @@ describe('resolve', function () {
     // Note the spelling error 'MyUncoolComponent' vs 'MyUnCoolComponent'
     var file = resolve( './jsx/MyUncoolComponent'
                       , utils.testContext({ 'import/resolve': { 'extensions': ['.jsx'] }})
-                      , true
                       )
 
     expect(file).to.equal(null)

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -22,6 +22,7 @@ describe('resolve', function () {
     // Note the spelling error 'MyUncoolComponent' vs 'MyUnCoolComponent'
     var file = resolve( './jsx/MyUncoolComponent'
                       , utils.testContext({ 'import/resolve': { 'extensions': ['.jsx'] }})
+                      , true
                       )
 
     expect(file).to.equal(null)

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -35,10 +35,10 @@ ruleTester.run('named', rule, {
          , args: [2, 'es6-only']}),
 
     test({ code: 'import { foo, bar } from "./common"'
-         , settings: { 'import/ignore': ['/common'] }
+         , settings: { 'import/ignore': ['common'] }
          }),
     test({ code: 'import { baz } from "./bar"'
-         , settings: { 'import/ignore': ['/bar'] }
+         , settings: { 'import/ignore': ['bar'] }
          }),
 
     // ignore core modules by default

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -49,6 +49,13 @@ ruleTester.run('no-unresolved', rule, {
   , test({ code: 'export bar from "./bar"'
          , parser: 'babel-eslint'
          })
+
+  , test({ code: 'import foo from "./jsx/MyUncoolComponent.jsx"'
+         , options: []
+         })
+  , test({ code: 'import foo from "./jsx/MyUnCoolComponent.jsx"'
+         , options: ['case-sensitive']
+         })
   ],
 
   invalid: [
@@ -103,6 +110,11 @@ ruleTester.run('no-unresolved', rule, {
          })
   , test({ code: 'export bar from "./does-not-exist"'
          , parser: 'babel-eslint'
+         , errors: 1
+         })
+
+  , test({ code: 'import foo from "./jsx/MyUncoolComponent.jsx"'
+         , options: ['case-sensitive']
          , errors: 1
          })
   ]

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -49,10 +49,6 @@ ruleTester.run('no-unresolved', rule, {
   , test({ code: 'export bar from "./bar"'
          , parser: 'babel-eslint'
          })
-
-  , test({ code: 'import foo from "./jsx/MyUncoolComponent.jsx"'
-         , options: []
-         })
   , test({ code: 'import foo from "./jsx/MyUnCoolComponent.jsx"'
          , options: ['case-sensitive']
          })


### PR DESCRIPTION
Attempted fix for #44, two-fold:

- `case-sensitive` option for `no-unresolved`. defaults to false.
- added an untested drive-letter regex base case to `fileExistsWithCaseSync`

@doctyper and @illinar, looking for comments from you two before I merge this to master and release.