### PR TITLE
Babel 6 + Babylon

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "optional": ["runtime"]
+  "presets": ["es2015"],
+  "plugins": ["transform-runtime"]
 }

--- a/config/README.md
+++ b/config/README.md
@@ -5,5 +5,7 @@ There are currently two configs provided:
 
 - `import` (index): just the bare-bones rules that catch misspelled/missing names.
 - `import/warnings`: the above, plus warnings for common mistakes.
+- `import/es7-jsx`: `import` + parser settings for stage 1 ES7 syntax and JSX.
 
-Both configure the plugin for you.
+All configure the plugin for you. You may opt to combine the latter two for
+maximum plugin goodness.

--- a/config/es7-jsx.js
+++ b/config/es7-jsx.js
@@ -1,0 +1,19 @@
+/**
+ * Parser options to allow ES7 + JSX syntax in imported files.
+ */
+module.exports = {
+  // see https://github.com/babel/babel/tree/master/packages/babylon#options
+  // plugins array is not merged with defaults, so include all desired plugins.
+  settings: {
+    'import/parse-options': { plugins: [ 'decorators'
+                                       , 'classProperties'
+                                       , 'objectRestSpread'
+                                       , 'exportExtensions'
+                                       , 'exponentiationOperator'
+                                       , 'trailingFunctionCommas'
+                                       // react
+                                       , 'jsx'
+                                       ]
+                            }
+  }
+}

--- a/config/es7-jsx.js
+++ b/config/es7-jsx.js
@@ -2,6 +2,7 @@
  * Parser options to allow ES7 + JSX syntax in imported files.
  */
 module.exports = {
+  extends: 'import',
   // see https://github.com/babel/babel/tree/master/packages/babylon#options
   // plugins array is not merged with defaults, so include all desired plugins.
   settings: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "watch": "babel -d lib/ src/ --watch & mocha --recursive --reporter dot --compilers js:babel/register --watch tests/src/",
-    "cover": "eslint ./src && istanbul cover --dir reports/coverage _mocha tests/src/ -- --recursive --reporter dot --compilers js:babel/register",
+    "cover": "eslint ./src && istanbul cover --dir reports/coverage _mocha tests/src/ -- --recursive --reporter dot --compilers js:babel-core/register",
     "test": "mocha --recursive --reporter dot tests/lib/",
     "debug": "mocha debug --recursive --reporter dot tests/lib/",
     "compile": "babel -d lib/ src/",
@@ -36,13 +36,10 @@
   "homepage": "https://github.com/benmosher/eslint-plugin-import",
   "devDependencies": {
     "acorn-to-esprima": "^1.0.5",
-    "babel": "^6.0.12",
     "babel-cli": "^6.0.12",
     "babel-eslint": "^4.1.3",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.0.12",
     "babel-plugin-transform-runtime": "^6.0.2",
     "babel-preset-es2015": "^6.0.12",
-    "babel-types": "^6.0.13",
     "chai": "^3.4.0",
     "eslint": ">=1.8.0",
     "istanbul": "^0.4.0",
@@ -52,7 +49,7 @@
     "eslint": ">=0.16.0"
   },
   "dependencies": {
-    "babel-runtime": "6.0.12",
+    "babel-runtime": "6.0.14",
     "babylon": "6.0.2",
     "resolve": "1.1.6"
   }

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "eslint": ">=0.16.0"
   },
   "dependencies": {
-    "babel-cli": "^6.0.12",
-    "babel-runtime": "^6.0.12",
+    "babel-runtime": "6.0.12",
+    "babylon": "6.0.2",
     "resolve": "1.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,8 +36,13 @@
   "homepage": "https://github.com/benmosher/eslint-plugin-import",
   "devDependencies": {
     "acorn-to-esprima": "^1.0.5",
-    "babel": "5.8.29",
+    "babel": "^6.0.12",
+    "babel-cli": "^6.0.12",
     "babel-eslint": "^4.1.3",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.0.12",
+    "babel-plugin-transform-runtime": "^6.0.2",
+    "babel-preset-es2015": "^6.0.12",
+    "babel-types": "^6.0.13",
     "chai": "^3.4.0",
     "eslint": ">=1.8.0",
     "istanbul": "^0.4.0",
@@ -47,8 +52,8 @@
     "eslint": ">=0.16.0"
   },
   "dependencies": {
-    "babel-core": "5.x",
-    "babel-runtime": "5.8.29",
+    "babel-cli": "^6.0.12",
+    "babel-runtime": "^6.0.12",
     "resolve": "1.1.6"
   }
 }

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -3,20 +3,13 @@ import fs from 'fs'
 const defaultParseOptions = { ecmaVersion: 6  // for espree, esprima. not needed
                                               // for babylon
                             , sourceType: "module"
-                              // default plugins
-                            , plugins: [ "decorators"
-                                       , "jsx"
-                                       , "classProperties"
-                                       , "objectRestSpread"
-                                       , "exportExtensions"
-                                       , "exponentiationOperator"
-                                       , "trailingFunctionCommas"
-                                       ]
                             }
 
 export default function parse(path, settings) {
   const parser = require(settings['import/parser'] || "babylon")
-      , options = settings['import/parse-options'] || defaultParseOptions
+      , options = Object.assign( {}
+                               , defaultParseOptions
+                               , settings['import/parse-options'])
 
   const ast = parser.parse( fs.readFileSync(path, {encoding: 'utf8'})
                           , options

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -13,6 +13,7 @@ export default function parse(path, settings) {
                                        , "objectRestSpread"
                                        , "exportExtensions"
                                        , "exponentiationOperator"
+                                       , "trailingFunctionCommas"
                                        ]
                             }
                           )

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -1,11 +1,21 @@
 import fs from 'fs'
 
 export default function parse(path, settings) {
-  var parser = require(settings['import/parser'] || "babel-core")
+  var parser = require(settings['import/parser'] || "babylon")
 
-  return parser.parse( fs.readFileSync(path, {encoding: 'utf8'})
-                     , { ecmaVersion: 6
-                       , sourceType: "module"
-                       }
-                     )
+  // todo: parser option setting
+  const ast = parser.parse( fs.readFileSync(path, {encoding: 'utf8'})
+                          , { ecmaVersion: 6
+                            , sourceType: "module"
+                            , plugins: [ "decorators"
+                                       , "jsx"
+                                       , "classProperties"
+                                       , "objectRestSpread"
+                                       , "exportExtensions"
+                                       ]
+                            }
+                          )
+
+  // bablyon returns top-level "File" node.
+  return ast.type === 'File' ? ast.program : ast
 }

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -1,12 +1,9 @@
 import fs from 'fs'
 
-export default function parse(path, settings) {
-  var parser = require(settings['import/parser'] || "babylon")
-
-  // todo: parser option setting
-  const ast = parser.parse( fs.readFileSync(path, {encoding: 'utf8'})
-                          , { ecmaVersion: 6
+const defaultParseOptions = { ecmaVersion: 6  // for espree, esprima. not needed
+                                              // for babylon
                             , sourceType: "module"
+                              // default plugins
                             , plugins: [ "decorators"
                                        , "jsx"
                                        , "classProperties"
@@ -16,6 +13,13 @@ export default function parse(path, settings) {
                                        , "trailingFunctionCommas"
                                        ]
                             }
+
+export default function parse(path, settings) {
+  const parser = require(settings['import/parser'] || "babylon")
+      , options = settings['import/parse-options'] || defaultParseOptions
+
+  const ast = parser.parse( fs.readFileSync(path, {encoding: 'utf8'})
+                          , options
                           )
 
   // bablyon returns top-level "File" node.

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -12,6 +12,7 @@ export default function parse(path, settings) {
                                        , "classProperties"
                                        , "objectRestSpread"
                                        , "exportExtensions"
+                                       , "exponentiationOperator"
                                        ]
                             }
                           )

--- a/src/rules/default.js
+++ b/src/rules/default.js
@@ -1,6 +1,6 @@
-import { get as getExports } from '../core/getExports'
+import Exports from '../core/getExports'
 
-export default function (context) {
+module.exports = function (context) {
 
   function checkDefault(specifierType, node) {
 
@@ -14,7 +14,7 @@ export default function (context) {
     })
 
     if (!defaultSpecifier) return
-    var imports = getExports(node.source.value, context)
+    var imports = Exports.get(node.source.value, context)
     if (imports == null) return
 
     if (!imports.hasDefault) {

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -1,6 +1,6 @@
 import ExportMap from '../core/getExports'
 
-export default function (context) {
+module.exports = function (context) {
   const defaults = new Set()
       , named = new Map()
 

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -1,4 +1,4 @@
-export default function (context) {
+module.exports = function (context) {
   return {
     "Program": function (n) {
       const body = n.body

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -1,6 +1,4 @@
-'use strict'
-
-var getExports = require('../core/getExports').get
+import Exports from '../core/getExports'
 
 module.exports = function (context) {
   function checkSpecifiers(key, type, node) {
@@ -11,7 +9,7 @@ module.exports = function (context) {
       return // no named imports/exports
     }
 
-    const imports = getExports(node.source.value, context)
+    const imports = Exports.get(node.source.value, context)
     if (imports == null) return
 
     var names = imports.named

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -1,14 +1,14 @@
-import { get as getExports } from '../core/getExports'
+import Exports from '../core/getExports'
 import importDeclaration from '../importDeclaration'
 
-export default function (context) {
+module.exports = function (context) {
 
   const namespaces = new Map()
 
   function getImportsAndReport(namespace) {
     var declaration = importDeclaration(context)
 
-    var imports = getExports(declaration.source.value, context)
+    var imports = Exports.get(declaration.source.value, context)
     if (imports == null) return null
 
     if (!imports.hasNamed) {

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -1,6 +1,6 @@
 import resolve from '../core/resolve'
 
-export default function (context) {
+module.exports = function (context) {
   const imported = new Map()
   return {
     "ImportDeclaration": function (n) {

--- a/src/rules/no-errors.js
+++ b/src/rules/no-errors.js
@@ -1,6 +1,4 @@
-'use strict'
-
-var getExports = require('../core/getExports').get
+import Exports from '../core/getExports'
 
 module.exports = function (context) {
   function message(node, errors) {
@@ -19,7 +17,7 @@ module.exports = function (context) {
 
   return {
     'ImportDeclaration': function (node) {
-      var imports = getExports(node.source.value, context)
+      var imports = Exports.get(node.source.value, context)
       if (imports == null) return
 
       if (imports.errors.length > 0) {

--- a/src/rules/no-named-as-default.js
+++ b/src/rules/no-named-as-default.js
@@ -1,11 +1,11 @@
-import { get as getExports } from '../core/getExports'
+import Exports from '../core/getExports'
 import importDeclaration from '../importDeclaration'
 
-export default function (context) {
+module.exports = function (context) {
   function checkDefault(nameKey, defaultSpecifier) {
     var declaration = importDeclaration(context)
 
-    var imports = getExports(declaration.source.value, context)
+    var imports = Exports.get(declaration.source.value, context)
     if (imports == null) return
 
     if (imports.hasDefault &&

--- a/src/rules/no-require.js
+++ b/src/rules/no-require.js
@@ -1,6 +1,6 @@
-import { get as getExports } from '../core/getExports'
+import Exports from '../core/getExports'
 
-export default function (context) {
+module.exports = function (context) {
   return {
     'CallExpression': function (call) {
       if (call.callee.type !== 'Identifier') return
@@ -12,7 +12,7 @@ export default function (context) {
       if (module.type !== 'Literal') return
       if (typeof module.value !== 'string') return
 
-      var imports = getExports(module.value, context)
+      var imports = Exports.get(module.value, context)
       if (!imports || imports.hasDefault || imports.hasNamed) {
         context.report(call.callee,
           'CommonJS require of ES module \'' + module.value + '\'.')

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -4,7 +4,7 @@
  */
 import resolve from '../core/resolve'
 
-export default function (context) {
+module.exports = function (context) {
 
   function checkSource(node) {
     if (node.source == null) return

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -1,8 +1,7 @@
-'use strict'
+import { expect } from  'chai'
+import path from 'path'
 
-var expect = require('chai').expect
-  , path = require('path')
-var ExportMap = require('../../../lib/core/getExports')
+import ExportMap from '../../../lib/core/getExports'
 
 function getFilename(file) {
   return path.join(__dirname, '..', '..', 'files', file || 'foo.js')

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -58,4 +58,21 @@ describe('getExports', function () {
     expect(imports.named.has('Bar')).to.be.true
   })
 
+  it('finds exports for an ES7 module with proper parse options', function () {
+    var imports = ExportMap.parse(getFilename('jsx/FooES7.js'), {
+      'import/parse-options': {
+        plugins: [
+          'decorators',
+          'jsx',
+          'classProperties',
+          'objectRestSpread'
+        ]
+      }
+    })
+
+    expect(imports).to.exist
+    expect(imports).to.have.property('hasDefault', true)
+    expect(imports.named.has('Bar')).to.be.true
+  })
+
 })

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -38,7 +38,9 @@ ruleTester.run('default', rule, {
 
     // sanity check
   , test({ code: 'export {a} from "./named-exports"' })
-  , test({ code: 'import twofer from "./trampoline"' })
+  , test({ code: 'import twofer from "./trampoline"'
+         , settings: { 'import/parse-options': { plugins: ['exportExtensions']}}
+         })
 
     // #54: import of named export default
   , test({ code: 'import foo from "./named-default-export"' })

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -38,10 +38,7 @@ ruleTester.run('default', rule, {
 
     // sanity check
   , test({ code: 'export {a} from "./named-exports"' })
-
-  , test({ code: 'import twofer from "./trampoline"'
-         , settings: { 'import/parser': 'babel-eslint' }
-         })
+  , test({ code: 'import twofer from "./trampoline"' })
 
     // #54: import of named export default
   , test({ code: 'import foo from "./named-default-export"' })
@@ -79,7 +76,6 @@ ruleTester.run('default', rule, {
          })
     // exports default from a module with no default
   , test({ code: 'import twofer from "./broken-trampoline"'
-         , settings: { 'import/parser': 'babel-eslint' }
          , errors: 1
          })
   ]

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -1,6 +1,6 @@
 import { test } from '../utils'
 
-import { linter, RuleTester } from 'eslint'
+import { RuleTester } from 'eslint'
 
 var ruleTester = new RuleTester()
   , rule = require('../../../lib/rules/export')

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -66,7 +66,7 @@ ruleTester.run('named', rule, {
          , parser: 'babel-eslint'
          })
   , test({ code: 'import { foo, bar } from "./named-trampoline"'
-         , parser: 'babel-eslint'
+         , settings: { 'import/parse-options': { plugins: ['exportExtensions'] }}
          })
 
     // regression tests
@@ -126,6 +126,7 @@ ruleTester.run('named', rule, {
          , errors: 1
          })
   , test({ code: 'import { foo, bar, baz } from "./named-trampoline"'
+         , settings: { 'import/parse-options': { plugins: ['exportExtensions'] }}
          , parser: 'babel-eslint'
          , errors: 1
          })

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -67,7 +67,6 @@ ruleTester.run('named', rule, {
          })
   , test({ code: 'import { foo, bar } from "./named-trampoline"'
          , parser: 'babel-eslint'
-         , settings: { 'import/parser': 'babel-eslint' }
          })
 
     // regression tests
@@ -128,12 +127,10 @@ ruleTester.run('named', rule, {
          })
   , test({ code: 'import { foo, bar, baz } from "./named-trampoline"'
          , parser: 'babel-eslint'
-         , settings: { 'import/parser': 'babel-eslint' }
          , errors: 1
          })
   , test({ code: 'import { baz } from "./broken-trampoline"'
          , parser: 'babel-eslint'
-         , settings: { 'import/parser': 'babel-eslint' }
          , errors: 1
          })
   ]

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -23,7 +23,8 @@ ruleTester.run('namespace', rule, {
     test({ code: 'import * as names from "./re-export-names"; ' +
                  'console.log(names.foo);'
          }),
-    test({ code: "import * as elements from './jsx';"}),
+    test({ code: "import * as elements from './jsx';"
+         , settings: { 'import/parse-options': { plugins: ['jsx'] }}}),
     test({ code: "import * as foo from './common';"
          , settings: { 'import/ignore': ['common'] }
          })

--- a/tests/src/rules/no-errors.js
+++ b/tests/src/rules/no-errors.js
@@ -1,6 +1,5 @@
-var test = require("../utils").test
-
-var RuleTester = require('eslint').RuleTester
+import { test } from '../utils'
+import { RuleTester } from 'eslint'
 
 var ruleTester = new RuleTester()
   , rule = require('../../../lib/rules/no-errors')
@@ -13,7 +12,15 @@ ruleTester.run('no-errors', rule, {
     test({code: "import { a } from './test'"})
 
     // babel-core is default parser, now
-  , test({ code: "import Foo from './jsx/FooES7.js';" })
+  , test({ code: "import Foo from './jsx/FooES7.js';",
+           settings: { 'import/parse-options': { plugins: [ 'decorators'
+                                                          , 'jsx'
+                                                          , 'classProperties'
+                                                          , 'objectRestSpread'
+                                                          ]
+                                               }
+                     }
+         })
   ],
 
   invalid: [

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -1,9 +1,8 @@
 var path = require('path')
 
-var test = require('../utils').test
+import { test } from '../utils'
 
-var linter = require('eslint').linter,
-    RuleTester = require('eslint').RuleTester
+import { RuleTester } from 'eslint'
 
 var ruleTester = new RuleTester()
   , rule = require('../../../lib/rules/no-unresolved')


### PR DESCRIPTION
Updated to Babel 6 for compile + runtime, and switching to Babylon directly as default parser.

- [x] expose Babylon/parser via shared settings
- [x] NVM: plugins do it. too complicated, for now. ~~use `.babelrc` to divine default Babylon `plugins` settings (need to investigate how Babel does this)~~
- [x] create an 'es7-jsx' shared config with proper parser settings pre-filled (unless obviated by using `.babelrc`)

