### PR TITLE
Optionally resolve single-argument `require` calls.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,3 +8,4 @@ rules:
   quotes: [2, "single"]
   curly: [2, "multi-line"]
   comma-dangle: [2, always-multiline]
+  eqeqeq: [2, "allow-null"]

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@ extends: eslint:recommended
 env:
   node: true
 rules:
-  max-len: [1, 80, 2]
+  max-len: [1, 99, 2]
   semi: [2, "never"]
   quotes: [2, "single"]
   curly: [2, "multi-line"]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ plugins:
   - import
 
 rules:
-  import/no-unresolved: 2
+  import/no-unresolved: [2, {commonjs: true, amd: true}]
   import/named: 2
   import/namespace: 2
   import/default: 2
@@ -73,6 +73,10 @@ as defined by standard Node `require.resolve` behavior.
 See [settings](#settings) for customization options for the resolution (i.e.
 additional filetypes, `NODE_PATH`, etc.)
 
+This rule can also optionally report on unresolved modules in CommonJS `require('./foo')` calls and AMD `require(['./foo'], function (foo){...})` and `define(['./foo'], function (foo){...})`.
+
+To enable this, send `{ commonjs: true/false, amd: true/false }` as a rule option.
+Both are disabled by default.
 
 ### `named`
 

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,7 +1,11 @@
 ---
-extends: eslint:recommended
+extends: '../.eslintrc'
+
 env:
   es6: true
+
 ecmaFeatures:
   modules: true
 
+rules:
+  comma-dangle: [1, "always-multiline"]

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -2,12 +2,12 @@ import fs from 'fs'
 
 const defaultParseOptions = { ecmaVersion: 6  // for espree, esprima. not needed
                                               // for babylon
-                            , sourceType: "module"
+                            , sourceType: 'module'
                             }
 
 export default function parse(path, context) {
   const { settings } = context
-      , parser = settings['import/parser'] || "babylon"
+      , parser = settings['import/parser'] || 'babylon'
 
   const { parse } = require(parser)
       , options = Object.assign( {}
@@ -15,7 +15,7 @@ export default function parse(path, context) {
                                , settings['import/parse-options'])
 
   // detect and handle "jsx" ecmaFeature
-  if (context.ecmaFeatures && parser === "babylon") {
+  if (context.ecmaFeatures && parser === 'babylon') {
     const { jsx } = context.ecmaFeatures
     if (jsx && (!options.plugins || options.plugins.indexOf('jsx') < 0)) {
       if (!options.plugins) options.plugins = ['jsx']

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 
 const defaultParseOptions = { ecmaVersion: 6  // for espree, esprima. not needed
                                               // for babylon
-                            , sourceType: 'module'
+                            , sourceType: 'module',
                             }
 
 export default function parse(path, context) {

--- a/src/rules/default.js
+++ b/src/rules/default.js
@@ -24,6 +24,6 @@ module.exports = function (context) {
 
   return {
     'ImportDeclaration': checkDefault.bind(null, 'ImportDefaultSpecifier'),
-    'ExportNamedDeclaration': checkDefault.bind(null, 'ExportDefaultSpecifier')
+    'ExportNamedDeclaration': checkDefault.bind(null, 'ExportDefaultSpecifier'),
   }
 }

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -69,6 +69,6 @@ module.exports = function (context) {
           context.report(node, `Multiple exports of name '${name}'.`)
         }
       }
-    }
+    },
   }
 }

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -11,14 +11,20 @@ module.exports = function (context) {
             if (/^\./.test(node.source.value)) {
               anyRelative = true
             } else if (anyRelative) {
-              context.report(node.source, 'Absolute imports should come before relative imports.')
+              context.report({
+                node: node.source,
+                message: 'Absolute imports should come before relative imports.',
+              })
             }
           }
           if (i !== ++last) {
-            context.report(node, 'Import in body of module; reorder to top.')
+            context.report({
+              node,
+              message: 'Import in body of module; reorder to top.',
+            })
           }
         }
       })
-    }
+    },
   }
 }

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -1,12 +1,12 @@
 module.exports = function (context) {
   return {
-    "Program": function (n) {
+    'Program': function (n) {
       const body = n.body
           , absoluteFirst = context.options[0] === 'absolute-first'
       let last = -1
         , anyRelative = false
       body.forEach(function (node, i){
-        if (node.type === "ImportDeclaration") {
+        if (node.type === 'ImportDeclaration') {
           if (absoluteFirst) {
             if (/^\./.test(node.source.value)) {
               anyRelative = true

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -33,7 +33,7 @@ module.exports = function (context) {
     'ExportNamedDeclaration': checkSpecifiers.bind( null
                                                   , 'local'
                                                   , 'ExportSpecifier'
-                                                  )
+                                                  ),
   }
 
 }

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -90,7 +90,7 @@ module.exports = function (context) {
       for (let property of id.properties) {
         if (property.key.type !== 'Identifier') {
           context.report( property
-                        , "Only destructure top-level names.")
+                        , 'Only destructure top-level names.')
         } else if (!namespace.has(property.key.name)) {
           context.report( property
                         , message(property.key, init)

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -97,6 +97,6 @@ module.exports = function (context) {
                         )
         }
       }
-    }
+    },
   }
 }

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -3,7 +3,7 @@ import resolve from '../core/resolve'
 module.exports = function (context) {
   const imported = new Map()
   return {
-    "ImportDeclaration": function (n) {
+    'ImportDeclaration': function (n) {
       // resolved path will cover aliased duplicates
       let resolvedPath = resolve(n.source.value, context) || n.source.value
 
@@ -14,7 +14,7 @@ module.exports = function (context) {
       }
     },
 
-    "Program:exit": function () {
+    'Program:exit': function () {
       for (let [module, nodes] of imported.entries()) {
         if (nodes.size > 1) {
           for (let node of nodes) {

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -22,6 +22,6 @@ module.exports = function (context) {
           }
         }
       }
-    }
+    },
   }
 }

--- a/src/rules/no-errors.js
+++ b/src/rules/no-errors.js
@@ -23,6 +23,6 @@ module.exports = function (context) {
       if (imports.errors.length > 0) {
         context.report(node.source, message(node, imports.errors))
       }
-    }
+    },
   }
 }

--- a/src/rules/no-named-as-default.js
+++ b/src/rules/no-named-as-default.js
@@ -19,6 +19,6 @@ module.exports = function (context) {
   }
   return {
     'ImportDefaultSpecifier': checkDefault.bind(null, 'local'),
-    'ExportDefaultSpecifier': checkDefault.bind(null, 'exported')
+    'ExportDefaultSpecifier': checkDefault.bind(null, 'exported'),
   }
 }

--- a/src/rules/no-require.js
+++ b/src/rules/no-require.js
@@ -13,8 +13,8 @@ module.exports = function (context) {
       // keeping it simple: all 1-string-arg `require` calls are reported
       context.report({
         node: call.callee,
-        message: `CommonJS require of module '${module.value}'.`
+        message: `CommonJS require of module '${module.value}'.`,
       })
-    }
+    },
   }
 }

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -6,13 +6,17 @@ import resolve from '../core/resolve'
 
 module.exports = function (context) {
 
-  function checkSource(node) {
-    if (node.source == null) return
+  function checkSourceValue(source) {
+    if (source == null) return
 
-    if (resolve(node.source.value, context) == null) {
-      context.report(node.source,
-        'Unable to resolve path to module \'' + node.source.value + '\'.')
+    if (resolve(source.value, context) == null) {
+      context.report(source,
+        'Unable to resolve path to module \'' + source.value + '\'.')
     }
+  }
+
+  function checkSource(node) {
+    checkSourceValue(node.source)
   }
 
   return {
@@ -21,3 +25,15 @@ module.exports = function (context) {
     'ExportAllDeclaration': checkSource
   }
 }
+
+module.exports.schema = [
+  {
+    "type": "object",
+    "properties": {
+      "commonjs": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  }
+]

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -15,15 +15,39 @@ module.exports = function (context) {
     }
   }
 
+  // for import-y declarations
   function checkSource(node) {
     checkSourceValue(node.source)
   }
 
-  return {
+  // for CommonJS `require` calls
+  // adapted from https://github.com/mctep/eslint-plugin-import/commit/acd4b4508d551f7f800fdd06e5c64ec01f3d1113
+  function checkCommon(call) {
+    if (call.callee.type !== 'Identifier') return
+    if (call.callee.name !== 'require') return
+    if (call.arguments.length !== 1) return
+
+    const modulePath = call.arguments[0]
+    if (modulePath.type !== 'Literal') return
+    if (typeof modulePath.value !== 'string') return
+
+    checkSourceValue(modulePath)
+  }
+
+  const visitors = {
     'ImportDeclaration': checkSource,
     'ExportNamedDeclaration': checkSource,
     'ExportAllDeclaration': checkSource
   }
+
+  if (context.options[0] != null) {
+    const { commonjs } = context.options[0]
+    if (commonjs) {
+      visitors['CallExpression'] = checkCommon
+    }
+  }
+
+  return visitors
 }
 
 module.exports.schema = [

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -47,39 +47,43 @@ ruleTester.run('no-unresolved', rule, {
          , parser: 'babel-eslint' }),
     test({ code: 'export bar from "./bar"'
          , parser: 'babel-eslint' }),
-    test({ code: 'import foo from "./jsx/MyUnCoolComponent.jsx"'
-         , options: ['case-sensitive'] }),
+    test({ code: 'import foo from "./jsx/MyUnCoolComponent.jsx"' }),
+
+    // commonjs setting
+    test({ code: 'var foo = require("./bar")'
+         , options: [{ commonjs: true }]}),
   ],
 
   invalid: [
     // should fail for jsx by default
-    test({ code: 'import * as foo from "jsx-module/foo"'
-         , errors: [ {message: 'Unable to resolve path to ' +
-                               'module \'jsx-module/foo\'.'} ]
-         }),
+    test({
+      code: 'import * as foo from "jsx-module/foo"',
+      errors: [ {message: 'Unable to resolve path to ' +
+                          'module \'jsx-module/foo\'.'} ],
+    }),
 
 
-    test({ code: 'import reallyfake from "./reallyfake/module"'
-         , settings: { 'import/ignore': ['^\\./fake/'] }
-         , errors: [{ message: 'Unable to resolve path to module ' +
-                               '\'./reallyfake/module\'.' }]
-         }),
+    test({
+      code: 'import reallyfake from "./reallyfake/module"',
+      settings: { 'import/ignore': ['^\\./fake/'] },
+      errors: [{ message: 'Unable to resolve path to module ' +
+                          '\'./reallyfake/module\'.' }],
+    }),
 
 
     test({
       code: "import bar from './baz';",
       errors: [{ message: "Unable to resolve path to module './baz'."
-               , type: 'Literal'
-               }]}),
+               , type: 'Literal' }],
+    }),
     test({ code: "import bar from './baz';"
          , errors: [{ message: "Unable to resolve path to module './baz'."
-                    , type: 'Literal'
-                    }]
-         }),
+                    , type: 'Literal',
+                    }] }),
     test({
       code: "import bar from './empty-folder';",
       errors: [{ message: "Unable to resolve path to module './empty-folder'."
-               , type: 'Literal'
+               , type: 'Literal',
                }]}),
 
     // sanity check that this module is _not_ found without proper settings
@@ -87,29 +91,27 @@ ruleTester.run('no-unresolved', rule, {
       code: "import { DEEP } from 'in-alternate-root';",
       errors: [{ message: 'Unable to resolve path to ' +
                           "module 'in-alternate-root'."
-               , type: 'Literal'
-               }]})
+               , type: 'Literal',
+               }]}),
 
-  , test({ code: 'export { foo } from "./does-not-exist"'
-         , errors: 1
-         })
-  , test({ code: 'export * from "./does-not-exist"'
-         , errors: 1
-         })
+    test({ code: 'export { foo } from "./does-not-exist"'
+         , errors: 1 }),
+    test({
+      code: 'export * from "./does-not-exist"',
+      errors: 1,
+    }),
 
     // export symmetry proposal
-  , test({ code: 'export * as bar from "./does-not-exist"'
+    test({ code: 'export * as bar from "./does-not-exist"'
          , parser: 'babel-eslint'
-         , errors: 1
-         })
-  , test({ code: 'export bar from "./does-not-exist"'
+         , errors: 1,
+         }),
+    test({ code: 'export bar from "./does-not-exist"'
          , parser: 'babel-eslint'
-         , errors: 1
-         })
+         , errors: 1,
+         }),
 
-  , test({ code: 'import foo from "./jsx/MyUncoolComponent.jsx"'
-         , options: ['case-sensitive']
-         , errors: 1
-         })
-  ]
+    test({ code: 'import foo from "./jsx/MyUncoolComponent.jsx"'
+         , errors: 1 }),
+  ],
 })

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -54,11 +54,21 @@ ruleTester.run('no-unresolved', rule, {
          , options: [{ commonjs: true }]}),
     test({ code: 'require("./bar")'
          , options: [{ commonjs: true }]}),
-
-    // validate it doesn't check if turned off (default)
     test({ code: 'require("./does-not-exist")'
          , options: [{ commonjs: false }]}),
     test({ code: 'require("./does-not-exist")' }),
+
+    // amd setting
+    test({ code: 'require(["./bar"], function (bar) {})'
+         , options: [{ amd: true }]}),
+    test({ code: 'define(["./bar"], function (bar) {})'
+         , options: [{ amd: true }]}),
+    test({ code: 'require(["./does-not-exist"], function (bar) {})'
+         , options: [{ amd: false }]}),
+    // don't validate without callback param
+    test({ code: 'require(["./does-not-exist"])'
+         , options: [{ amd: true }]}),
+    test({ code: 'define(["./does-not-exist"], function (bar) {})' }),
   ],
 
   invalid: [
@@ -136,6 +146,35 @@ ruleTester.run('no-unresolved', rule, {
       options: [{ commonjs: true }],
       errors: [{
         message: "Unable to resolve path to module './baz'.",
+        type: 'Literal',
+      }],
+    }),
+
+    // amd
+    test({
+      code: 'require(["./baz"], function (bar) {})',
+      options: [{ amd: true }],
+      errors: [{
+        message: "Unable to resolve path to module './baz'.",
+        type: 'Literal',
+      }],
+    }),
+    test({
+      code: 'define(["./baz"], function (bar) {})',
+      options: [{ amd: true }],
+      errors: [{
+        message: "Unable to resolve path to module './baz'.",
+        type: 'Literal',
+      }],
+    }),
+    test({
+      code: 'define(["./baz", "./bar", "./does-not-exist"], function (bar) {})',
+      options: [{ amd: true }],
+      errors: [{
+        message: "Unable to resolve path to module './baz'.",
+        type: 'Literal',
+      },{
+        message: "Unable to resolve path to module './does-not-exist'.",
         type: 'Literal',
       }],
     }),

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -19,38 +19,36 @@ ruleTester.run('no-unresolved', rule, {
       settings: {
         'import/resolve': {
           'paths': [path.join( process.cwd()
-                             , 'tests', 'files', 'alternate-root')]
-        }
-      }
+                             , 'tests', 'files', 'alternate-root')],
+        },
+      },
     }),
     test({
       code: "import { DEEP } from 'in-alternate-root'; " +
             "import { bar } from 'src-bar';",
       settings: {'import/resolve': { 'paths': [
         path.join('tests', 'files', 'src-root'),
-        path.join('tests', 'files', 'alternate-root')
+        path.join('tests', 'files', 'alternate-root'),
       ]}}}),
 
     test({ code: 'import * as foo from "a"' }),
 
-    test({ code: 'import * as foo from "jsx-module/foo"'
-         , settings: { 'import/resolve': { 'extensions': ['.jsx'] } }
-         })
+    test({
+      code: 'import * as foo from "jsx-module/foo"',
+      settings: { 'import/resolve': { 'extensions': ['.jsx'] } },
+    }),
 
-  , test({ code: 'export { foo } from "./bar"' })
-  , test({ code: 'export * from "./bar"' })
-  , test({ code: 'export { foo }' })
+    test({ code: 'export { foo } from "./bar"' }),
+    test({ code: 'export * from "./bar"' }),
+    test({ code: 'export { foo }' }),
 
-    // stage 1 proposal for export symmetry
-  , test({ code: 'export * as bar from "./bar"'
-         , parser: 'babel-eslint'
-         })
-  , test({ code: 'export bar from "./bar"'
-         , parser: 'babel-eslint'
-         })
-  , test({ code: 'import foo from "./jsx/MyUnCoolComponent.jsx"'
-         , options: ['case-sensitive']
-         })
+    // stage 1 proposal for export symmetry,
+    test({ code: 'export * as bar from "./bar"'
+         , parser: 'babel-eslint' }),
+    test({ code: 'export bar from "./bar"'
+         , parser: 'babel-eslint' }),
+    test({ code: 'import foo from "./jsx/MyUnCoolComponent.jsx"'
+         , options: ['case-sensitive'] }),
   ],
 
   invalid: [

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -52,6 +52,13 @@ ruleTester.run('no-unresolved', rule, {
     // commonjs setting
     test({ code: 'var foo = require("./bar")'
          , options: [{ commonjs: true }]}),
+    test({ code: 'require("./bar")'
+         , options: [{ commonjs: true }]}),
+
+    // validate it doesn't check if turned off (default)
+    test({ code: 'require("./does-not-exist")'
+         , options: [{ commonjs: false }]}),
+    test({ code: 'require("./does-not-exist")' }),
   ],
 
   invalid: [
@@ -113,5 +120,24 @@ ruleTester.run('no-unresolved', rule, {
 
     test({ code: 'import foo from "./jsx/MyUncoolComponent.jsx"'
          , errors: 1 }),
+
+
+    // commonjs setting
+    test({
+      code: 'var bar = require("./baz")',
+      options: [{ commonjs: true }],
+      errors: [{
+        message: "Unable to resolve path to module './baz'.",
+        type: 'Literal',
+      }],
+    }),
+    test({
+      code: 'require("./baz")',
+      options: [{ commonjs: true }],
+      errors: [{
+        message: "Unable to resolve path to module './baz'.",
+        type: 'Literal',
+      }],
+    }),
   ],
 })


### PR DESCRIPTION
Fixes #90 by adding a `commonjs` boolean option to `no-unresolved`.