### PR TITLE
Cache correctness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - iojs
   - stable
 env:
- - NODE_ENV=testing NODE_PATH=./lib
+ - NODE_PATH=./lib
 
 script: "npm run-script ci-test"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 # Test against this version of Node.js
 environment:
-  NODE_ENV: testing
   NODE_PATH: ./lib
   # NODE_PATH: ./lib
   matrix:

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "scripts": {
     "watch": "babel -d lib/ src/ --watch & mocha --recursive --reporter dot --compilers js:babel/register --watch tests/src/",
-    "cover": "npm run pretest && NODE_ENV=testing NODE_PATH=./lib istanbul cover --dir reports/coverage _mocha tests/lib/ -- --recursive --reporter dot && remap-istanbul -i reports/coverage/coverage.json -o reports/coverage/lcov-report --type html",
-    "test": "NODE_ENV=testing NODE_PATH=./lib mocha --recursive --reporter dot tests/lib/",
+    "cover": "npm run pretest && NODE_PATH=./lib istanbul cover --dir reports/coverage _mocha tests/lib/ -- --recursive --reporter dot; remap-istanbul -i reports/coverage/coverage.json -o reports/coverage/lcov-report --type html",
+    "test": "NODE_PATH=./lib mocha --recursive --reporter dot tests/lib/",
     "ci-test": "npm run-script pretest && mocha --recursive --reporter dot tests/lib/",
     "debug": "mocha debug --recursive --reporter dot tests/lib/",
     "compile": "rm -rf lib/ && babel -d lib/ src/",
     "prepublish": "npm run compile",
     "pretest": "eslint ./src && npm run compile && babel -d tests/lib/ tests/src/",
-    "coveralls": "istanbul cover --report lcovonly --dir reports/coverage _mocha tests/lib/ -- --recursive --reporter dot && remap-istanbul -i reports/coverage/coverage.json -o reports/coverage/lcov.info --type lcovonly && cat ./reports/coverage/lcov.info | coveralls"
+    "coveralls": "istanbul cover --report lcovonly --dir reports/coverage _mocha tests/lib/ -- --recursive --reporter dot; remap-istanbul -i reports/coverage/coverage.json -o reports/coverage/lcov.info --type lcovonly && cat ./reports/coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -21,7 +21,7 @@ module.exports = function (context) {
   }
 
   // for CommonJS `require` calls
-  // adapted from https://github.com/mctep/eslint-plugin-import/commit/acd4b4508d551f7f800fdd06e5c64ec01f3d1113
+  // adapted from @mctep: http://git.io/v4rAu
   function checkCommon(call) {
     if (call.callee.type !== 'Identifier') return
     if (call.callee.name !== 'require') return

--- a/tests/files/mutator.js
+++ b/tests/files/mutator.js
@@ -1,1 +1,1 @@
-export const mutant = "logan"
+export const mutant = 'logan'

--- a/tests/files/mutator.js
+++ b/tests/files/mutator.js
@@ -1,0 +1,1 @@
+export const mutant = "logan"

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -30,7 +30,8 @@ describe('getExports', function () {
     expect(firstAccess).to.exist
 
     // mutate (update modified time)
-    fs.utimes(getFilename('mutator.js'), Date.now(), Date.now(), (error) => {
+    const newDate = new Date()
+    fs.utimes(getFilename('mutator.js'), newDate, newDate, (error) => {
       expect(error).not.to.exist
       expect(ExportMap.get('./mutator', fakeContext)).not.to.equal(firstAccess)
       done()
@@ -88,9 +89,9 @@ describe('getExports', function () {
           'decorators',
           'jsx',
           'classProperties',
-          'objectRestSpread'
-        ]
-      }
+          'objectRestSpread',
+        ],
+      },
     }})
 
     expect(imports).to.exist


### PR DESCRIPTION
two-stage caching: level one on hash of settings object, level 2 on path.
- also: using mtime to invalidate cache entries for long processes (fixes #117)

Need to investigate using a short blackout to avoid the overhead of calling `fs.statSync` on every import. Even <1s would be useful, likely.