### PR TITLE
Support for Flowtype import/exports

### DIFF
--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -122,6 +122,7 @@ export default class ExportMap {
       switch (n.declaration.type) {
         case 'FunctionDeclaration':
         case 'ClassDeclaration':
+        case 'TypeAlias': // flowtype with babel-eslint parser
           this.named.add(n.declaration.id.name)
           break
         case 'VariableDeclaration':

--- a/tests/files/flowtypes.js
+++ b/tests/files/flowtypes.js
@@ -1,0 +1,8 @@
+// @flow
+// requires babel-eslint parser or flow plugin
+// http://flowtype.org/blog/2015/02/18/Import-Types.html
+export type MyType = {
+  id: number,
+  firstName: string,
+  lastName: string
+};

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -68,6 +68,10 @@ ruleTester.run('named', rule, {
     test({ code: 'import { arrayKeyProp } from "./named-exports"' }),
     test({ code: 'import { deepProp } from "./named-exports"' }),
     test({ code: 'import { deepSparseElement } from "./named-exports"' }),
+
+    // flow types
+    test({ code: 'import type { MyType } from "./flowtypes"'
+         , settings: { 'import/parser': 'babel-eslint' }}),
   ],
 
   invalid: [
@@ -133,5 +137,13 @@ ruleTester.run('named', rule, {
         type: 'Literal',
       }],
     }),
+
+    // flow types
+    test({ code: 'import type { MissingType } from "./flowtypes"'
+         , settings: { 'import/parser': 'babel-eslint' }
+         , errors: [{
+           message: "MissingType not found in './flowtypes'",
+           type: 'Identifier',
+         }]}),
   ],
 })


### PR DESCRIPTION
Add support for Flowtype import/exports (http://flowtype.org/blog/2015/02/18/Import-Types.html) when using babel-eslint parser.

Currently any `import type SomeType from './types'` is marked as import, but its counterpart `export type SomeType` is ignored. Therefore, all those imports were marked as issue by rule `import/named`. This pull request adds the type exports to the list of named exports fixing this issue.

Alternatively, if this behavior is not desired, `ImportDeclaration`s with `n.importType === 'type'` should be ignored in order to be symmetric. If you prefer this solution give me a hint and I'll create another pull request.

Nice plugin, btw ;-)