### PR TITLE
separate rule docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 
 ## Rules
 
-* Ensure imports point to a file/module that can be resolved. ([`no-unresolved`](./docs/rules/no-unresolved.md))
-* Ensure named imports correspond to a named export in the remote file. ([`named`](#named))
+* Ensure imports point to a file/module that can be resolved. ([`no-unresolved`])
+* Ensure named imports correspond to a named export in the remote file. ([`named`])
 * Ensure a default export is present, given a default import. ([`default`](#default))
 * Ensure imported namespaces contain dereferenced properties as they are dereferenced. ([`namespace`](#namespace))
 * Report any invalid exports, i.e. re-export of the same name ([`export`](#export))
+
+[`no-unresolved`]: ./docs/rules/no-unresolved.md
+[`named`]: ./docs/rules/named.md
 
 Helpful warnings:
 
@@ -66,13 +69,6 @@ rules:
 
 # Rule Details
 
-
-
-### `named`
-
-Verifies that all named imports are part of the set of named exports in the referenced module.
-
-For `export`, verifies that all named exports exist in the referenced module.
 
 ### `default`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 
 ## Rules
 
-* Ensure imports point to a file/module that can be resolved. ([`no-unresolved`](#no-unresolved))
+* Ensure imports point to a file/module that can be resolved. ([`no-unresolved`](./docs/rules/no-unresolved.md))
 * Ensure named imports correspond to a named export in the remote file. ([`named`](#named))
 * Ensure a default export is present, given a default import. ([`default`](#default))
 * Ensure imported namespaces contain dereferenced properties as they are dereferenced. ([`namespace`](#namespace))
@@ -66,20 +66,7 @@ rules:
 
 # Rule Details
 
-### `no-unresolved`
 
-Ensures an imported module can be resolved to a module on the local filesystem,
-as defined by standard Node `require.resolve` behavior.
-
-See [settings](#settings) for customization options for the resolution (i.e.
-additional filetypes, `NODE_PATH`, etc.)
-
-This rule can also optionally report on unresolved modules in CommonJS `require('./foo')` calls and AMD `require(['./foo'], function (foo){...})` and `define(['./foo'], function (foo){...})`.
-
-To enable this, send `{ commonjs: true/false, amd: true/false }` as a rule option.
-Both are disabled by default.
-
-If you are using Webpack, see the section on [resolver plugins](#resolver-plugins).
 
 ### `named`
 

--- a/README.md
+++ b/README.md
@@ -69,15 +69,6 @@ rules:
 
 # Rule Details
 
-
-### `default`
-
-If a default import is requested, this rule will report if there is no default
-export in the imported module.
-
-For [ES7], reports if a default is named and exported but is not found in the
-referenced module.
-
 ### `namespace`
 
 Enforces names exist at the time they are dereferenced, when imported as a full namespace (i.e. `import * as foo from './foo'; foo.bar();` will report if `bar` is not exported by `./foo`.).

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 * Ensure named imports correspond to a named export in the remote file. ([`named`])
 * Ensure a default export is present, given a default import. ([`default`])
 * Ensure imported namespaces contain dereferenced properties as they are dereferenced. ([`namespace`])
-* Report any invalid exports, i.e. re-export of the same name ([`export`](#export))
+* Report any invalid exports, i.e. re-export of the same name ([`export`])
 
 [`no-unresolved`]: ./docs/rules/no-unresolved.md
 [`named`]: ./docs/rules/named.md
 [`default`]: ./docs/rules/default.md
 [`namespace`]: ./docs/rules/namespace.md
+[`export`]: ./docs/rules/export.md
 
 Helpful warnings:
 
@@ -75,33 +76,6 @@ rules:
 
 # Rule Details
 
-### `export`
-
-Reports funny business with exports, such as
-
-```js
-export default class MyClass { /*...*/ } // Multiple default exports.
-
-function makeClass() { return new MyClass(...arguments) }
-
-export default makeClass // Multiple default exports.
-```
-
-or
-```js
-export const foo = function () { /*...*/ } // Multiple exports of name 'foo'.
-
-function bar() { /*...*/ }
-export { bar as foo } // Multiple exports of name 'foo'.
-```
-
-In the case of named/default re-export, all `n` re-exports will be reported,
-as at least `n-1` of them are clearly mistakes, but it is not clear which one
-(if any) is intended. Could be the result of copy/paste, code duplication with
-intent to rename, etc.
-
-
-[ES7]: https://github.com/leebyron/ecmascript-more-export-from
 
 
 ### `no-duplicates`

--- a/README.md
+++ b/README.md
@@ -13,22 +13,26 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 
 * Ensure imports point to a file/module that can be resolved. ([`no-unresolved`])
 * Ensure named imports correspond to a named export in the remote file. ([`named`])
-* Ensure a default export is present, given a default import. ([`default`](#default))
-* Ensure imported namespaces contain dereferenced properties as they are dereferenced. ([`namespace`](#namespace))
+* Ensure a default export is present, given a default import. ([`default`])
+* Ensure imported namespaces contain dereferenced properties as they are dereferenced. ([`namespace`])
 * Report any invalid exports, i.e. re-export of the same name ([`export`](#export))
 
 [`no-unresolved`]: ./docs/rules/no-unresolved.md
 [`named`]: ./docs/rules/named.md
+[`default`]: ./docs/rules/default.md
+[`namespace`]: ./docs/rules/namespace.md
 
 Helpful warnings:
 
-* Report CommonJS `require` calls. ([`no-require`](#no-require))
 * Report use of exported name as identifier of default export ([`no-named-as-default`](#no-named-as-default))
-* Report repeated import of the same module in multiple places ([`no-duplicates`](#no-duplicates), warning by default)
 
-Style rules:
+Style guide:
 
+* Report CommonJS `require` calls. ([`no-require`])
 * Ensure all imports appear before other statements ([`imports-first`](#imports-first))
+* Report repeated import of the same module in multiple places ([`no-duplicates`](#no-duplicates))
+
+[`no-require`]: ./docs/rules/no-require.md
 
 ## Installation
 
@@ -69,47 +73,7 @@ rules:
 
 # Rule Details
 
-### `namespace`
 
-Enforces names exist at the time they are dereferenced, when imported as a full namespace (i.e. `import * as foo from './foo'; foo.bar();` will report if `bar` is not exported by `./foo`.).
-
-Will report at the import declaration if there are _no_ exported names found.
-
-Also, will report for computed references (i.e. `foo["bar"]()`).
-
-Reports on assignment to a member of an imported namespace.
-
-**Implementation note**: currently, this rule does not check for possible
-redefinition of the namespace in an intermediate scope. Adherence to the ESLint
-`no-shadow` rule for namespaces will prevent this from being a problem.
-
-For [ES7], reports if an exported namespace would be empty (no names exported from the referenced module.)
-
-### `no-require`
-
-Reports `require([string])` function calls. Will not report if >1 argument,
-or single argument is not a literal string.
-
-Intended for temporary use when migrating to pure ES6 modules.
-
-Given:
-```js
-// ./mod.js
-export const foo = 'bar'
-export function bar() { return foo }
-
-// ./common.js
-exports.something = 'whatever'
-```
-
-This would be reported:
-
-```js
-var mod = require('./mod')
-  , common = require('./common')
-  , fs = require('fs')
-  , whateverModule = require('./not-found')
-```
 
 ### `no-named-as-default`
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ Helpful warnings:
 Style guide:
 
 * Report CommonJS `require` calls. ([`no-require`])
-* Ensure all imports appear before other statements ([`imports-first`](#imports-first))
+* Ensure all imports appear before other statements ([`imports-first`])
 * Report repeated import of the same module in multiple places ([`no-duplicates`])
 
 [`no-require`]: ./docs/rules/no-require.md
+[`imports-first`]: ./docs/rules/imports-first.md
 [`no-duplicates`]: ./docs/rules/no-duplicates.md
 
 ## Installation
@@ -73,35 +74,6 @@ rules:
   import/export: 2
   # etc...
 ```
-
-
-# Rule Details
-
-### `imports-first`
-
-By popular demand, this rule reports any imports that come after non-import
-statments:
-
-```js
-import foo from './foo'
-
-// some module-level initializer
-initWith(foo)
-
-import bar from './bar' // <- reported
-```
-
-Providing `absolute-first` as an option will report any absolute imports (i.e.
-packages) that come after any relative imports:
-
-```js
-import foo from 'foo'
-import bar from './bar'
-
-import * as _ from 'lodash' // <- reported
-```
-
-This rule is disabled by default.
 
 # Resolver plugins
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Style guide:
 
 * Report CommonJS `require` calls. ([`no-require`])
 * Ensure all imports appear before other statements ([`imports-first`](#imports-first))
-* Report repeated import of the same module in multiple places ([`no-duplicates`](#no-duplicates))
+* Report repeated import of the same module in multiple places ([`no-duplicates`])
 
 [`no-require`]: ./docs/rules/no-require.md
+[`no-duplicates`]: ./docs/rules/no-duplicates.md
 
 ## Installation
 
@@ -75,35 +76,6 @@ rules:
 
 
 # Rule Details
-
-
-
-### `no-duplicates`
-
-Reports if a resolved path is imported more than once.
-
-Valid:
-```js
-import SomeDefaultClass, * as names from './mod'
-```
-
-...whereas here, both `./mod` imports will be reported:
-
-```js
-import SomeDefaultClass from './mod'
-
-// oops, some other import separated these lines
-import foo from './some-other-mod'
-
-import * as names from './mod'
-```
-
-The motivation is that this is likely a result of two developers importing different
-names from the same module at different times (and potentially largely different
-locations in the file.) This rule brings both (or n-many) to attention.
-
-This rule is only set to a warning, by default.
-
 
 ### `imports-first`
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 
 Helpful warnings:
 
-* Report use of exported name as identifier of default export ([`no-named-as-default`](#no-named-as-default))
+* Report use of exported name as identifier of default export ([`no-named-as-default`])
+
+[`no-named-as-default`]: ./docs/rules/no-named-as-default.md
 
 Style guide:
 
@@ -72,45 +74,6 @@ rules:
 
 
 # Rule Details
-
-
-
-### `no-named-as-default`
-
-Reports use of an exported name as the locally imported name of a default export.
-
-Given:
-```js
-// foo.js
-export default 'foo';
-export const bar = 'baz';
-```
-
-...this would be valid:
-```js
-import foo from './foo.js';
-```
-
-...and this would be reported:
-```js
-// message: Using exported name 'bar' as identifier for default export.
-import bar from './foo.js';
-```
-
-Rationale: using an exported name as the name of the default export is likely...
-
-- *misleading*: others familiar with `foo.js` probably expect the name to be `foo`
-- *a mistake*: only needed to import `bar` and forgot the brackets (the case that is prompting this)
-
-For [ES7], this also prevents exporting the default from a referenced module as a name within than module, for the same reasons:
-
-```js
-// valid:
-export foo from './foo.js'
-
-// message: Using exported name 'bar' as identifier for default export.
-export bar from './foo.js';
-```
 
 ### `export`
 

--- a/docs/rules/default.md
+++ b/docs/rules/default.md
@@ -1,0 +1,69 @@
+# default
+
+If a default import is requested, this rule will report if there is no default
+export in the imported module.
+
+For [ES7], reports if a default is named and exported but is not found in the
+referenced module.
+
+Note: for modules, the plugin will find exported names (including defaults)
+from [`jsnext:main`], if present in `package.json`.
+Redux's npm module includes this key, and thereby is lintable, for example. Otherwise,
+the whole `node_modules` folder is ignored by default ([`import/ignore`]) as most published modules are
+formatted in CommonJS, which [at time of this writing](https://github.com/benmosher/eslint-plugin-import/issues/13)
+is not able to be analyzed for exports.
+
+
+## Rule Details
+
+Given:
+
+```js
+// ./foo.js
+export default function () { return 42 }
+
+// ./bar.js
+export function bar() { return null }
+
+// ./baz.js
+module.exports = function () { /* ... */ }
+
+// node_modules/some-module/index.js
+exports.sharedFunction = function shared() { /* ... */ }
+```
+
+The following is considered valid:
+
+```js
+import foo from './foo'
+
+// assuming 'node_modules' are ignored (true by default)
+import someModule from 'some-module'
+```
+
+...and the following cases are reported:
+
+```js
+import bar from './bar' // no default export found in ./bar
+import baz from './baz' // no default export found in ./baz
+```
+
+
+## When Not To Use It
+
+If you are using CommonJS and/or modifying the exported namespace of any module at
+runtime, you will likely see false positives with this rule.
+
+This rule currently does not interpret `module.exports = ...` as a `default` export,
+either, so such a situation will be reported in the importing module.
+
+## Further Reading
+
+- Lee Byron's [ES7] export proposal
+- [`import/ignore`] setting
+- [`jsnext:main`] (Rollup)
+
+
+[ES7]: https://github.com/leebyron/ecmascript-more-export-from
+[`import/ignore`]: ../../README.md#importignore
+[`jsnext:main`]: https://github.com/rollup/rollup/wiki/jsnext:main

--- a/docs/rules/export.md
+++ b/docs/rules/export.md
@@ -1,4 +1,4 @@
-# `export`
+# export
 
 Reports funny business with exports, like repeated exports of names or defaults.
 

--- a/docs/rules/export.md
+++ b/docs/rules/export.md
@@ -1,0 +1,32 @@
+# `export`
+
+Reports funny business with exports, like repeated exports of names or defaults.
+
+## Rule Details
+
+```js
+export default class MyClass { /*...*/ } // Multiple default exports.
+
+function makeClass() { return new MyClass(...arguments) }
+
+export default makeClass // Multiple default exports.
+```
+
+or
+```js
+export const foo = function () { /*...*/ } // Multiple exports of name 'foo'.
+
+function bar() { /*...*/ }
+export { bar as foo } // Multiple exports of name 'foo'.
+```
+
+In the case of named/default re-export, all `n` re-exports will be reported,
+as at least `n-1` of them are clearly mistakes, but it is not clear which one
+(if any) is intended. Could be the result of copy/paste, code duplication with
+intent to rename, etc.
+
+## Further Reading
+
+- Lee Byron's [ES7] export proposal
+
+[ES7]: https://github.com/leebyron/ecmascript-more-export-from

--- a/docs/rules/imports-first.md
+++ b/docs/rules/imports-first.md
@@ -1,0 +1,32 @@
+# imports-first
+
+By popular demand, this rule reports any imports that come after non-import
+statments.
+
+## Rule Details
+
+```js
+import foo from './foo'
+
+// some module-level initializer
+initWith(foo)
+
+import bar from './bar' // <- reported
+```
+
+Providing `absolute-first` as an option will report any absolute imports (i.e.
+packages) that come after any relative imports:
+
+```js
+import foo from 'foo'
+import bar from './bar'
+
+import * as _ from 'lodash' // <- reported
+```
+
+TODO: add explanation of imported name hoisting
+
+## When Not To Use It
+
+If you don't mind imports being sprinkled throughout, you may not want to
+enable this rule.

--- a/docs/rules/named.md
+++ b/docs/rules/named.md
@@ -1,0 +1,94 @@
+# named
+
+Verifies that all named imports are part of the set of named exports in the referenced module.
+
+For `export`, verifies that all named exports exist in the referenced module.
+
+Note: for modules, the plugin will find exported names from [`jsnext:main`], if present in `package.json`.
+Redux's npm module includes this key, and thereby is lintable, for example. Otherwise,
+the whole `node_modules` folder is ignored by default ([`import/ignore`]) as most published modules are
+formatted in CommonJS, which [at time of this writing](https://github.com/benmosher/eslint-plugin-import/issues/13)
+is not able to be analyzed for exports.
+
+
+## Rule Details
+
+Given:
+
+```js
+// ./foo.js
+export const foo = "I'm so foo"
+```
+
+The following is considered valid:
+
+```js
+// ./bar.js
+import { foo } from './foo'
+
+// ES7 proposal
+export { foo as bar } from './foo'
+
+// node_modules without jsnext:main are not analyzed by default
+// (import/ignore setting)
+import { SomeNonsenseThatDoesntExist } from 'react'
+```
+
+...and the following are reported:
+
+```js
+// ./baz.js
+import { notFoo } from './foo'
+
+// ES7 proposal
+export { notFoo as defNotBar } from './foo'
+
+// will follow 'jsnext:main', if available
+import { dontCreateStore } from 'redux'
+```
+
+### Settings
+
+[`import/ignore`] can be provided as a setting to ignore certain modules (node_modules,
+CoffeeScript, CSS if using Webpack, etc.).
+
+Given:
+
+```yaml
+# .eslintrc (YAML)
+---
+settings:
+  import/ignore:
+    - node_modules  # included by default, but replaced if explicitly configured
+    - *.coffee$     # can't parse CoffeeScript (unless a custom polyglot parser was configured)
+```
+
+and
+
+```coffeescript
+# ./whatever.coffee
+exports.whatever = (foo) -> console.log foo
+```
+
+then the following is not reported:
+
+```js
+// ./foo.js
+
+// can't be analyzed, and ignored, so not reported
+import { notWhatever } from './whatever'
+```
+
+## When Not To Use It
+
+If you are using CommonJS and/or modifying the exported namespace of any module at
+runtime, you will likely see false positives with this rule.
+
+## Further Reading
+
+- [`import/ignore`] setting
+- [`jsnext:main`] (Rollup)
+
+
+[`jsnext:main`]: https://github.com/rollup/rollup/wiki/jsnext:main
+[`import/ignore`]: ../../README.md#importignore

--- a/docs/rules/namespace.md
+++ b/docs/rules/namespace.md
@@ -1,0 +1,35 @@
+# `namespace`
+
+Enforces names exist at the time they are dereferenced, when imported as a full namespace (i.e. `import * as foo from './foo'; foo.bar();` will report if `bar` is not exported by `./foo`.).
+
+Will report at the import declaration if there are _no_ exported names found.
+
+Also, will report for computed references (i.e. `foo["bar"]()`).
+
+Reports on assignment to a member of an imported namespace.
+
+Note: for modules, the plugin will find exported names from [`jsnext:main`], if present in `package.json`.
+Redux's npm module includes this key, and thereby is lintable, for example. Otherwise,
+the whole `node_modules` folder is ignored by default ([`import/ignore`]) as most published modules are
+formatted in CommonJS, which [at time of this writing](https://github.com/benmosher/eslint-plugin-import/issues/13)
+is not able to be analyzed for exports.
+
+## Rule Details
+
+Currently, this rule does not check for possible
+redefinition of the namespace in an intermediate scope. Adherence to the ESLint
+`no-shadow` rule for namespaces will prevent this from being a problem.
+
+For [ES7], reports if an exported namespace would be empty (no names exported from the referenced module.)
+
+TODO: examples.
+
+## Further Reading
+
+- Lee Byron's [ES7] export proposal
+- [`import/ignore`] setting
+- [`jsnext:main`] (Rollup)
+
+[ES7]: https://github.com/leebyron/ecmascript-more-export-from
+[`import/ignore`]: ../../README.md#importignore
+[`jsnext:main`]: https://github.com/rollup/rollup/wiki/jsnext:main

--- a/docs/rules/namespace.md
+++ b/docs/rules/namespace.md
@@ -1,4 +1,4 @@
-# `namespace`
+# namespace
 
 Enforces names exist at the time they are dereferenced, when imported as a full namespace (i.e. `import * as foo from './foo'; foo.bar();` will report if `bar` is not exported by `./foo`.).
 

--- a/docs/rules/no-duplicates.md
+++ b/docs/rules/no-duplicates.md
@@ -1,0 +1,30 @@
+# no-duplicates
+
+Reports if a resolved path is imported more than once.
+
+## Rule Details
+
+Valid:
+```js
+import SomeDefaultClass, * as names from './mod'
+```
+
+...whereas here, both `./mod` imports will be reported:
+
+```js
+import SomeDefaultClass from './mod'
+
+// oops, some other import separated these lines
+import foo from './some-other-mod'
+
+import * as names from './mod'
+```
+
+The motivation is that this is likely a result of two developers importing different
+names from the same module at different times (and potentially largely different
+locations in the file.) This rule brings both (or n-many) to attention.
+
+## When Not To Use It
+
+If you like to split up imports across lines or may need to import a default and a namespace,
+you may want to disable this rule.

--- a/docs/rules/no-named-as-default.md
+++ b/docs/rules/no-named-as-default.md
@@ -1,0 +1,44 @@
+# `no-named-as-default`
+
+Reports use of an exported name as the locally imported name of a default export.
+
+Rationale: using an exported name as the name of the default export is likely...
+
+- *misleading*: others familiar with `foo.js` probably expect the name to be `foo`
+- *a mistake*: only needed to import `bar` and forgot the brackets (the case that is prompting this)
+
+## Rule Details
+
+Given:
+```js
+// foo.js
+export default 'foo';
+export const bar = 'baz';
+```
+
+...this would be valid:
+```js
+import foo from './foo.js';
+```
+
+...and this would be reported:
+```js
+// message: Using exported name 'bar' as identifier for default export.
+import bar from './foo.js';
+```
+
+For [ES7], this also prevents exporting the default from a referenced module as a name within than module, for the same reasons:
+
+```js
+// valid:
+export foo from './foo.js'
+
+// message: Using exported name 'bar' as identifier for default export.
+export bar from './foo.js';
+```
+
+## Further Reading
+
+- Lee Byron's [ES7] export proposal
+
+[ES7]: https://github.com/leebyron/ecmascript-more-export-from

--- a/docs/rules/no-named-as-default.md
+++ b/docs/rules/no-named-as-default.md
@@ -1,4 +1,4 @@
-# `no-named-as-default`
+# no-named-as-default
 
 Reports use of an exported name as the locally imported name of a default export.
 

--- a/docs/rules/no-require.md
+++ b/docs/rules/no-require.md
@@ -1,0 +1,35 @@
+# `no-require`
+
+Reports `require([string])` function calls. Will not report if >1 argument,
+or single argument is not a literal string.
+
+Intended for temporary use when migrating to pure ES6 modules.
+
+## Rule Details
+
+Given:
+```js
+// ./mod.js
+export const foo = 'bar'
+export function bar() { return foo }
+
+// ./common.js
+exports.something = 'whatever'
+```
+
+This would be reported:
+
+```js
+var mod = require('./mod')
+  , common = require('./common')
+  , fs = require('fs')
+  , whateverModule = require('./not-found')
+```
+
+## When Not To Use It
+
+If you don't mind mixing module systems (sometimes this is useful), you probably
+don't want this rule.
+
+It is also fairly noisy if you have a larger codebase that is being transitioned
+from CommonJS to ES6 modules.

--- a/docs/rules/no-require.md
+++ b/docs/rules/no-require.md
@@ -1,4 +1,4 @@
-# `no-require`
+# no-require
 
 Reports `require([string])` function calls. Will not report if >1 argument,
 or single argument is not a literal string.

--- a/docs/rules/no-unresolved.md
+++ b/docs/rules/no-unresolved.md
@@ -1,0 +1,65 @@
+# no-unresolved
+
+Ensures an imported module can be resolved to a module on the local filesystem,
+as defined by standard Node `require.resolve` behavior.
+
+See [settings](../../README.md#settings) for customization options for the resolution (i.e.
+additional filetypes, `NODE_PATH`, etc.)
+
+This rule can also optionally report on unresolved modules in CommonJS `require('./foo')` calls and AMD `require(['./foo'], function (foo){...})` and `define(['./foo'], function (foo){...})`.
+
+To enable this, send `{ commonjs: true/false, amd: true/false }` as a rule option.
+Both are disabled by default.
+
+If you are using Webpack, see the section on [resolver plugins](../../README.md#resolver-plugins).
+
+## Rule Details
+
+### Options
+
+By default, only ES6 imports will be resolved:
+
+```js
+/*eslint import/no-unresolved: 2*/
+import x from './foo' // reports if './foo' cannot be resolved on the filesystem
+```
+
+If `{commonjs: true}` is provided, single-argument `require` calls will be resolved:
+
+```js
+/*eslint import/no-unresolved: [2, { commonjs: true }]*/
+const { default: x } = require('./foo') // reported if './foo' is not found
+
+require(0) // ignored
+require(['x', 'y'], function (x, y) { /*...*/ }) // ignored
+```
+
+Similarly, if `{ amd: true }` is provided, dependency paths for `define` and `require`
+calls will be resolved:
+
+```js
+/*eslint import/no-unresolved: [2, { amd: true }]*/
+define(['./foo'], function (foo) { /*...*/ }) // reported if './foo' is not found
+require(['./foo'], function (foo) { /*...*/ }) // reported if './foo' is not found
+
+const { default: x } = require('./foo') // ignored
+```
+
+Both may be provided, too:
+```js
+/*eslint import/no-unresolved: [2, { commonjs: true, amd: true }]*/
+const { default: x } = require('./foo') // reported if './foo' is not found
+define(['./foo'], function (foo) { /*...*/ }) // reported if './foo' is not found
+require(['./foo'], function (foo) { /*...*/ }) // reported if './foo' is not found
+```
+
+## When Not To Use It
+
+If you're using a module bundler other than Node or Webpack, you may end up with
+a lot of false positive reports of missing dependencies.
+
+## Further Reading
+
+- [Resolver plugins](../../README.md#resolver-plugins)
+- [Node resolver](https://npmjs.com/package/eslint-import-resolver-node) (default)
+- [Webpack resolver](https://npmjs.com/package/eslint-import-resolver-webpack)


### PR DESCRIPTION
in traditional ESLint `docs/rules/[rule name].md` fashion.

closes #128 

- [x] no-unresolved
- [x] named
- [x] default
- [x] namespace
- [x] no-named-as-default
- [x] export

Style guide:
- [x] no-require
- [x] no-duplicates
- [x] imports-first  (todo: add a note about import hoisting? also: need to understand import hoisting)