### PR TITLE
Allow 'absolute' specification of webpack config.

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -27,12 +27,17 @@ exports.resolveImport = function resolveImport(source, file, settings) {
 
   var webpackConfig
   try {
-    var packageDir = findRoot(file)
-    if (!packageDir) throw new Error('package not found above ' + file)
+    // see if we've got an absolute path
+    webpackConfig = require(get(settings, 'config', null))
+  } catch(err) {
+    try {
+      var packageDir = findRoot(file)
+      if (!packageDir) throw new Error('package not found above ' + file)
 
-    webpackConfig = require(path.join(packageDir, get(settings, 'config', 'webpack.config.js')))
-  } catch (err) {
-    webpackConfig = {}
+      webpackConfig = require(path.join(packageDir, get(settings, 'config', 'webpack.config.js')))
+    } catch (err) {
+      webpackConfig = {}
+    }
   }
 
   // externals

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -1,0 +1,22 @@
+var chai =  require('chai')
+  , expect = chai.expect
+
+import { resolveImport as resolve } from '../index'
+
+import path from 'path'
+
+var file = path.join(__dirname, 'files', 'src', 'jsx', 'dummy.js')
+var absoluteSettings = {
+  config: path.join(__dirname, 'files/some/absolute.path.webpack.config.js')
+}
+
+describe("config", function () {
+  it("finds webpack.config.js in parent directories", function () {
+    expect(resolve('main-module', file)).to.exist
+        .and.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
+  })
+  it("finds absolute webpack.config.js files", function () {
+    expect(resolve('foo', file, absoluteSettings)).to.exist
+        .and.equal(path.join(__dirname, 'files', 'some', 'absolutely', 'goofy', 'path', 'foo.js'))
+  })
+})

--- a/resolvers/webpack/test/files/some/absolute.path.webpack.config.js
+++ b/resolvers/webpack/test/files/some/absolute.path.webpack.config.js
@@ -1,0 +1,16 @@
+var path = require('path')
+
+module.exports = {
+  resolve: {
+    alias: {
+      'foo': path.join(__dirname, 'absolutely', 'goofy', 'path', 'foo.js'),
+    },
+    modulesDirectories: ['node_modules', 'bower_components'],
+    root: path.join(__dirname, 'src'),
+  },
+
+  externals: [
+    { 'jquery': 'jQuery' },
+    'bootstrap',
+  ],
+}


### PR DESCRIPTION
As the title, I have a project structure akin to:

```
node/webpack.config.js
node/package.json
src/module1/submodule/...
src/module2/submodule/...
```
And I alias each src/moduleX folder to something more succinct. Names have been changed to keep identity of real code secret etc ;)

Hence, it would be handy for me to be able to just specify an absolute webpack location. This change makes that possible and tests it.

Thanks for the great plugin!
