### PR TITLE
Adds compiler loading for to-js languages in a similar fashion to Webpack itself

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -3,6 +3,7 @@ var findRoot = require('find-root')
   , resolve = require('resolve')
   , get = require('lodash.get')
   , find = require('array-find')
+  , interpret = require('interpret')
   // not available on 0.10.x
   , isAbsolute = path.isAbsolute || require('is-absolute')
 
@@ -38,6 +39,23 @@ exports.resolveImport = function resolveImport(source, file, settings) {
       if (!packageDir) throw new Error('package not found above ' + file)
 
       configPath = path.join(packageDir, configPath)
+    }
+
+    var ext = Object.keys(interpret.extensions).reduce(function (chosen, extension) {
+      var extlen = extension.length
+      return ( (configPath.substr(-extlen) === extension) && (extlen > chosen.length)) ?
+        extension : chosen
+    }, '')
+
+    var moduleName = interpret.extensions[ext]
+
+    if (moduleName) {
+      var compiler = require(moduleName)
+      var register = interpret.register[moduleName]
+      var config = interpret.configurations[moduleName]
+      if (register) {
+        register(compiler, config)
+      }
     }
 
     webpackConfig = require(configPath)

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -47,16 +47,7 @@ exports.resolveImport = function resolveImport(source, file, settings) {
         extension : chosen
     }, '')
 
-    var moduleName = interpret.extensions[ext]
-
-    if (moduleName) {
-      var compiler = require(moduleName)
-      var register = interpret.register[moduleName]
-      var config = interpret.configurations[moduleName]
-      if (register) {
-        register(compiler, config)
-      }
-    }
+    registerCompiler(interpret.extensions[ext])
 
     webpackConfig = require(configPath)
   } catch (err) {
@@ -149,4 +140,23 @@ function packageFilter(config, pkg) {
 
 
   return pkg
+}
+
+function registerCompiler(moduleDescriptor) {
+  if(moduleDescriptor) {
+    if(typeof moduleDescriptor === 'string') {
+      require(moduleDescriptor)
+    } else if(!Array.isArray(moduleDescriptor)) {
+      moduleDescriptor.register(require(moduleDescriptor.module))
+    } else {
+      for(var i = 0; i < moduleDescriptor.length; i++) {
+        try {
+          registerCompiler(moduleDescriptor[i])
+          break
+        } catch(e) {
+          // do nothing
+        }
+      }
+    }
+  }
 }

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "array-find": "^1.0.0",
     "find-root": "^0.1.1",
+    "interpret": "^1.0.0",
     "is-absolute": "^0.2.3",
     "lodash.get": "^3.7.0",
     "resolve": "^1.1.6"


### PR DESCRIPTION
As mentioned in https://github.com/benmosher/eslint-plugin-import/issues/102, this brings eslint-plugin-import in line with Webpack's own config loader.