### PR TITLE
Allow 'nested' aliases in resolve config

### DIFF
--- a/resolvers/webpack/resolve-alias.js
+++ b/resolvers/webpack/resolve-alias.js
@@ -18,13 +18,23 @@ var sep = '/'
 function matchAlias(source, alias, value) {
   var isExact = (alias[alias.length - 1] === '$')
     , isFile = (path.extname(value) !== '')
-    , segments = source.split(sep)
+    , sourceSegments = source.split(sep)
+    , ptr = 0
+    , aliasSegments
 
   if (isExact) alias = alias.slice(0, -1)
 
-  if (segments[0] === alias) {
+  aliasSegments = alias.split(sep)
+
+  // look for a common prefix
+  while(sourceSegments[ptr] == aliasSegments[ptr] && ptr < sourceSegments.length && ptr < aliasSegments.length) {
+    ptr++;
+  }
+
+  // the common prefix must be the entirety of the alias
+  if (ptr === aliasSegments.length) {
     // always return exact match
-    if (segments.length === 1) return value
+    if (sourceSegments.length === aliasSegments.length) return value
 
     // prefix match on exact match for file is an error
     if (isFile && (isExact || !/^[./]/.test(value))) {
@@ -32,7 +42,7 @@ function matchAlias(source, alias, value) {
     }
 
     // otherwise, prefix match is fine for non-file paths
-    if (!isExact && !isFile) return [value].concat(segments.slice(1)).join(sep)
+    if (!isExact && !isFile) return [value].concat(sourceSegments.slice(ptr)).join(sep)
   }
 
 }

--- a/resolvers/webpack/test/alias.js
+++ b/resolvers/webpack/test/alias.js
@@ -73,3 +73,60 @@ describe("webpack alias spec", function () {
   tableLine( { xyz$: "xyz/dir" }
            , 'xyz/dir', 'xyz/file' )
 })
+
+describe("nested module names", function () {
+  // from table: http://webpack.github.io/docs/configuration.html#resolve-alias
+  function nestedName(alias, xyz, xyzFile) {
+    describe(JSON.stringify(alias), function () {
+      it("top/xyz: " + xyz, function () {
+        expect(resolveAlias('top/xyz', alias)).to.equal(xyz)
+      })
+      it("top/xyz/file: " + (xyzFile.name || xyzFile), function () {
+        if (xyzFile === Error) {
+          expect(resolveAlias.bind(null, 'top/xyz/file', alias)).to.throw(xyzFile)
+        } else {
+          expect(resolveAlias('top/xyz/file', alias)).to.equal(xyzFile)
+        }
+      })
+    })
+  }
+
+  nestedName( { 'top/xyz': "/absolute/path/to/file.js" }
+      , '/absolute/path/to/file.js', 'top/xyz/file' )
+
+  nestedName( { 'top/xyz$': "/absolute/path/to/file.js" }
+      ,  "/absolute/path/to/file.js", Error )
+
+  nestedName( { 'top/xyz': "./dir/file.js" }
+      , './dir/file.js',  'top/xyz/file' )
+
+  nestedName( { 'top/xyz$': "./dir/file.js" }
+      , './dir/file.js', Error )
+
+  nestedName( { 'top/xyz': "/some/dir" }
+      , '/some/dir', '/some/dir/file' )
+
+  nestedName( { 'top/xyz$': "/some/dir" }
+      , '/some/dir', 'top/xyz/file' )
+
+  nestedName( { 'top/xyz': "./dir" }
+      , './dir', './dir/file' )
+
+  nestedName( { 'top/xyz': "modu" }
+      , 'modu', 'modu/file' )
+
+  nestedName( { 'top/xyz$': "modu" }
+      , 'modu', 'top/xyz/file' )
+
+  nestedName( { 'top/xyz': "modu/some/file.js" }
+      , 'modu/some/file.js', Error )
+
+  nestedName( { 'top/xyz': "modu/dir" }
+      , 'modu/dir', 'modu/dir/file' )
+
+  nestedName( { 'top/xyz': "top/xyz/dir" }
+      , 'top/xyz/dir',  'top/xyz/dir/file' )
+
+  nestedName( { 'top/xyz$': "top/xyz/dir" }
+      , 'top/xyz/dir', 'top/xyz/file' )
+})


### PR DESCRIPTION
In my project, I have nested my private aliases in a namespace-ish manner.

My `resolve.alias` looks somewhat like:
```javascript
resolve: {
  alias: {
    'ns/module1': path.resolve('...'),
    'ns/module2': path.resolve('...')
  }
}
```

This functions in webpack but wasn't functioning with the slightly simpler implementation of `matchAlias` in the webpack resolver.

This patch looks for a common prefix in the `source` and `alias` in `matchAlias` and fixes configs as above.
