### PR TITLE
deep namespaces: correct caching

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,13 +87,16 @@ gulp.task('tests', function () {
 // used externally by Istanbul, too
 gulp.task('pretest', ['src', 'tests', 'wipe-extras'])
 
+var reporter = 'spec'
+
 gulp.task('test', ['pretest'], function () {
   return gulp.src('tests/lib/**/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec', grep: process.env.TEST_GREP }))
+    .pipe(mocha({ reporter: reporter, grep: process.env.TEST_GREP }))
   // NODE_PATH=./lib mocha --recursive --reporter dot tests/lib/
 })
 
 gulp.task('watch-test', function () {
+  reporter = 'progress'
   gulp.watch(SRC, ['test'])
   gulp.watch('tests/' + SRC, ['test'])
 })

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -13,6 +13,7 @@ const exportCaches = new Map()
 export default class ExportMap {
   constructor() {
     this.namespace = new Map()
+    // todo: restructure to key on path, value is resolver + map of names
     this.reexports = new Map()
     this.dependencies = new Map()
     this.errors = []
@@ -243,6 +244,19 @@ export default class ExportMap {
 
     return undefined
   }
+
+  forEach(callback, thisArg) {
+    this.namespace.forEach((v, n) =>
+      callback.call(thisArg, v, n, this))
+
+    this.reexports.forEach(({ getImport, local }, name) =>
+      callback.call(thisArg, getImport().get(local), name, this))
+
+    this.dependencies.forEach(dep => dep().forEach((v, n) =>
+      callback.call(thisArg, v, n, this)))
+  }
+
+  // todo: keys, values, entries?
 
   reportErrors(context, declaration) {
     context.report({

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -11,14 +11,11 @@ import isIgnored from './ignore'
 const exportCaches = new Map()
 
 export default class ExportMap {
-  constructor(context) {
-    this.context = context
+  constructor() {
     this.named = new Map()
-
     this.errors = []
   }
 
-  get settings() { return this.context && this.context.settings }
 
   get hasDefault() { return this.named.has('default') }
   get hasNamed() { return this.named.size > (this.hasDefault ? 1 : 0) }
@@ -100,7 +97,7 @@ export default class ExportMap {
     function getNamespace(identifier) {
       if (!namespaces.has(identifier.name)) return
 
-      let namespace = m.resolveReExport(namespaces.get(identifier.name), path)
+      let namespace = m.resolveReExport(context, namespaces.get(identifier.name), path)
       if (namespace) return { namespace: namespace.named }
     }
 
@@ -116,7 +113,7 @@ export default class ExportMap {
       }
 
       if (n.type === 'ExportAllDeclaration') {
-        let remoteMap = m.resolveReExport(n, path)
+        let remoteMap = m.resolveReExport(context, n, path)
         if (remoteMap == null) return
         remoteMap.named.forEach((value, name) => { m.named.set(name, value) })
         return
@@ -149,7 +146,7 @@ export default class ExportMap {
 
         // capture specifiers
         let remoteMap
-        if (n.source) remoteMap = m.resolveReExport(n, path)
+        if (n.source) remoteMap = m.resolveReExport(context, n, path)
 
         n.specifiers.forEach((s) => {
           const exportMeta = {}
@@ -172,11 +169,11 @@ export default class ExportMap {
     return m
   }
 
-  resolveReExport(node, base) {
-    var remotePath = resolve.relative(node.source.value, base, this.settings)
+  resolveReExport(context, node, base) {
+    var remotePath = resolve.relative(node.source.value, base, context.settings)
     if (remotePath == null) return null
 
-    return ExportMap.for(remotePath, this.context)
+    return ExportMap.for(remotePath, context)
   }
 
   reportErrors(context, declaration) {

--- a/src/rules/default.js
+++ b/src/rules/default.js
@@ -19,7 +19,7 @@ module.exports = function (context) {
 
     if (imports.errors.length) {
       imports.reportErrors(context, node)
-    } else if (!imports.hasDefault) {
+    } else if (!imports.get('default')) {
       context.report(defaultSpecifier, 'No default export found in module.')
     }
   }

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -17,12 +17,10 @@ module.exports = function (context) {
       return
     }
 
-    var names = imports.named
-
     node.specifiers.forEach(function (im) {
       if (im.type !== type) return
 
-      if (!names.has(im[key].name)) {
+      if (!imports.get(im[key].name)) {
         context.report(im[key],
           im[key].name + ' not found in \'' + node.source.value + '\'')
       }

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -32,15 +32,15 @@ module.exports = function (context) {
         for (let specifier of declaration.specifiers) {
           switch (specifier.type) {
             case 'ImportNamespaceSpecifier':
-              if (!imports.hasNamed) {
+              if (!imports.size) {
                 context.report(specifier,
                   `No exported names found in module '${declaration.source.value}'.`)
               }
-              namespaces.set(specifier.local.name, imports.named)
+              namespaces.set(specifier.local.name, imports)
               break
             case 'ImportDefaultSpecifier':
             case 'ImportSpecifier': {
-              const meta = imports.named.get(
+              const meta = imports.get(
                 // default to 'default' for default http://i.imgur.com/nj6qAWy.jpg
                 specifier.imported ? specifier.imported.name : 'default')
               if (!meta || !meta.namespace) break
@@ -65,7 +65,7 @@ module.exports = function (context) {
         return
       }
 
-      if (!imports.hasNamed) {
+      if (!imports.size) {
         context.report(namespace,
           `No exported names found in module '${declaration.source.value}'.`)
       }
@@ -87,7 +87,7 @@ module.exports = function (context) {
       var namespace = namespaces.get(dereference.object.name)
       var namepath = [dereference.object.name]
       // while property is namespace and parent is member expression, keep validating
-      while (namespace instanceof Map &&
+      while (namespace instanceof Exports &&
              dereference.type === 'MemberExpression') {
 
         if (dereference.computed) {
@@ -122,7 +122,7 @@ module.exports = function (context) {
 
       // DFS traverse child namespaces
       function testKey(pattern, namespace, path = [init.name]) {
-        if (!(namespace instanceof Map)) return
+        if (!(namespace instanceof Exports)) return
 
         if (pattern.type !== 'ObjectPattern') return
 

--- a/src/rules/no-deprecated.js
+++ b/src/rules/no-deprecated.js
@@ -29,8 +29,8 @@ module.exports = function (context) {
 
 
         case 'ImportNamespaceSpecifier':{
-          if (!imports.named.size) return
-          namespaces.set(im.local.name, imports.named)
+          if (!imports.size) return
+          namespaces.set(im.local.name, imports)
           return
         }
 
@@ -48,13 +48,13 @@ module.exports = function (context) {
       }
 
       // unknown thing can't be deprecated
-      if (!imports.named.has(imported)) return
+      if (!imports.has(imported)) return
 
-      // capture named import of deep namespace
-      const { namespace } = imports.named.get(imported)
+      // capture import of deep namespace
+      const { namespace } = imports.get(imported)
       if (namespace) namespaces.set(local, namespace)
 
-      const deprecation = getDeprecation(imports.named.get(imported))
+      const deprecation = getDeprecation(imports.get(imported))
       if (!deprecation) return
 
       context.report({ node: im, message: message(deprecation) })
@@ -94,7 +94,7 @@ module.exports = function (context) {
       var namespace = namespaces.get(dereference.object.name)
       var namepath = [dereference.object.name]
       // while property is namespace and parent is member expression, keep validating
-      while (namespace instanceof Map &&
+      while (namespace instanceof Exports &&
              dereference.type === 'MemberExpression') {
 
         // ignore computed parts for now

--- a/src/rules/no-named-as-default.js
+++ b/src/rules/no-named-as-default.js
@@ -13,8 +13,8 @@ module.exports = function (context) {
       return
     }
 
-    if (imports.hasDefault &&
-        imports.named.has(defaultSpecifier[nameKey].name)) {
+    if (imports.has('default') &&
+        imports.has(defaultSpecifier[nameKey].name)) {
 
       context.report(defaultSpecifier,
         'Using exported name \'' + defaultSpecifier[nameKey].name +

--- a/tests/files/deep/cache-1.js
+++ b/tests/files/deep/cache-1.js
@@ -1,0 +1,2 @@
+import * as b from './cache-2'
+export { b }

--- a/tests/files/deep/cache-2a.js
+++ b/tests/files/deep/cache-2a.js
@@ -1,0 +1,2 @@
+import * as c from './c'
+export { c }

--- a/tests/files/deep/cache-2b.js
+++ b/tests/files/deep/cache-2b.js
@@ -1,0 +1,2 @@
+import * as c from './c'
+// export { c }

--- a/tests/files/issue210.config.js
+++ b/tests/files/issue210.config.js
@@ -1,0 +1,3 @@
+exports.parserOptions = {
+  sourceType: 'module',
+}

--- a/tests/files/issue210.js
+++ b/tests/files/issue210.js
@@ -1,0 +1,1 @@
+export { test } from './issue210.js'

--- a/tests/files/narcissist.js
+++ b/tests/files/narcissist.js
@@ -1,0 +1,2 @@
+export const me = 'awesome'
+export { me as soGreat } from './narcissist'

--- a/tests/src/cli.js
+++ b/tests/src/cli.js
@@ -1,0 +1,25 @@
+/**
+ * tests that require fully booting up ESLint
+ */
+import { expect } from 'chai'
+import { CLIEngine } from 'eslint'
+
+describe('CLI regression tests', function () {
+  describe('issue #210', function () {
+    this.timeout(10000)
+    let cli
+    before(function () {
+      cli = new CLIEngine({
+        useEslintrc: false,
+        configFile: './tests/files/issue210.config.js',
+        rulePaths: ['./lib/rules'],
+        rules: {
+          'named': 2,
+        },
+      })
+    })
+    it("doesn't throw an error on gratuitous, erroneous self-reference", function () {
+      expect(() => cli.executeOnFiles(['./tests/files/issue210.js'])).not.to.throw(Error)
+    })
+  })
+})

--- a/tests/src/cli.js
+++ b/tests/src/cli.js
@@ -6,7 +6,6 @@ import { CLIEngine } from 'eslint'
 
 describe('CLI regression tests', function () {
   describe('issue #210', function () {
-    this.timeout(10000)
     let cli
     before(function () {
       cli = new CLIEngine({

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -19,7 +19,7 @@ describe('getExports', function () {
     }).not.to.throw(Error)
 
     expect(imports).to.exist
-    expect(imports.named.has('foo')).to.be.true
+    expect(imports.has('foo')).to.be.true
 
   })
 
@@ -72,7 +72,7 @@ describe('getExports', function () {
     }).not.to.throw(Error)
 
     expect(imports).to.exist
-    expect(imports.named.has('bar')).to.be.true
+    expect(imports.has('bar')).to.be.true
 
   })
 
@@ -83,8 +83,8 @@ describe('getExports', function () {
     )
 
     expect(imports).to.exist
-    expect(imports).to.have.property('hasDefault', true)
-    expect(imports.named.has('Bar')).to.be.true
+    expect(imports.get('default')).to.exist
+    expect(imports.has('Bar')).to.be.true
   })
 
   context('deprecation metadata', function () {
@@ -101,25 +101,25 @@ describe('getExports', function () {
         })
 
         it('works with named imports.', function () {
-          expect(imports.named.has('fn')).to.be.true
+          expect(imports.has('fn')).to.be.true
 
-          expect(imports.named.get('fn'))
+          expect(imports.get('fn'))
             .to.have.deep.property('doc.tags[0].title', 'deprecated')
-          expect(imports.named.get('fn'))
+          expect(imports.get('fn'))
             .to.have.deep.property('doc.tags[0].description', "please use 'x' instead.")
         })
 
         it('works with default imports.', function () {
-          expect(imports.named.has('default')).to.be.true
-          const importMeta = imports.named.get('default')
+          expect(imports.has('default')).to.be.true
+          const importMeta = imports.get('default')
 
           expect(importMeta).to.have.deep.property('doc.tags[0].title', 'deprecated')
           expect(importMeta).to.have.deep.property('doc.tags[0].description', 'this is awful, use NotAsBadClass.')
         })
 
         it('works with variables.', function () {
-          expect(imports.named.has('MY_TERRIBLE_ACTION')).to.be.true
-          const importMeta = imports.named.get('MY_TERRIBLE_ACTION')
+          expect(imports.has('MY_TERRIBLE_ACTION')).to.be.true
+          const importMeta = imports.get('MY_TERRIBLE_ACTION')
 
           expect(importMeta).to.have.deep.property(
             'doc.tags[0].title', 'deprecated')
@@ -129,8 +129,8 @@ describe('getExports', function () {
 
         context('multi-line variables', function () {
           it('works for the first one', function () {
-            expect(imports.named.has('CHAIN_A')).to.be.true
-            const importMeta = imports.named.get('CHAIN_A')
+            expect(imports.has('CHAIN_A')).to.be.true
+            const importMeta = imports.get('CHAIN_A')
 
             expect(importMeta).to.have.deep.property(
               'doc.tags[0].title', 'deprecated')
@@ -138,8 +138,8 @@ describe('getExports', function () {
               'doc.tags[0].description', 'this chain is awful')
           })
           it('works for the second one', function () {
-            expect(imports.named.has('CHAIN_B')).to.be.true
-            const importMeta = imports.named.get('CHAIN_B')
+            expect(imports.has('CHAIN_B')).to.be.true
+            const importMeta = imports.get('CHAIN_B')
 
             expect(importMeta).to.have.deep.property(
               'doc.tags[0].title', 'deprecated')
@@ -147,8 +147,8 @@ describe('getExports', function () {
               'doc.tags[0].description', 'so awful')
           })
           it('works for the third one, etc.', function () {
-            expect(imports.named.has('CHAIN_C')).to.be.true
-            const importMeta = imports.named.get('CHAIN_C')
+            expect(imports.has('CHAIN_C')).to.be.true
+            const importMeta = imports.get('CHAIN_C')
 
             expect(importMeta).to.have.deep.property(
               'doc.tags[0].title', 'deprecated')
@@ -202,22 +202,22 @@ describe('getExports', function () {
     it('works with espree & traditional namespace exports', function () {
       const a = ExportMap.parse(getFilename('deep/a.js'), espreeContext)
       expect(a.errors).to.be.empty
-      expect(a.named.get('b').namespace).to.exist
-      expect(a.named.get('b').namespace.has('c')).to.be.true
+      expect(a.get('b').namespace).to.exist
+      expect(a.get('b').namespace.has('c')).to.be.true
     })
 
     it('captures namespace exported as default', function () {
       const def = ExportMap.parse(getFilename('deep/default.js'), espreeContext)
       expect(def.errors).to.be.empty
-      expect(def.named.get('default').namespace).to.exist
-      expect(def.named.get('default').namespace.has('c')).to.be.true
+      expect(def.get('default').namespace).to.exist
+      expect(def.get('default').namespace.has('c')).to.be.true
     })
 
     it('works with babel-eslint & ES7 namespace exports', function () {
       const a = ExportMap.parse(getFilename('deep-es7/a.js'), babelContext)
       expect(a.errors).to.be.empty
-      expect(a.named.get('b').namespace).to.exist
-      expect(a.named.get('b').namespace.has('c')).to.be.true
+      expect(a.get('b').namespace).to.exist
+      expect(a.get('b').namespace.has('c')).to.be.true
     })
   })
 
@@ -250,6 +250,18 @@ describe('getExports', function () {
     })
 
     after('remove test file', (done) => fs.unlink(getFilename('deep/cache-2.js'), done))
+  })
+
+  context('Map API', function () {
+    context('#size', function () {
+
+      it('counts the names', () => expect(ExportMap.get('./named-exports', fakeContext))
+        .to.have.property('size', 8))
+
+      it('includes exported namespace size', () => expect(ExportMap.get('./export-all', fakeContext))
+        .to.have.property('size', 1))
+
+    })
   })
 
 })

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -264,4 +264,18 @@ describe('getExports', function () {
     })
   })
 
+  context('issue #210: self-reference', function () {
+    it("doesn't crash", function () {
+      expect(() => ExportMap.get('./narcissist', fakeContext)).not.to.throw(Error)
+    })
+    it("'has' circular reference", function () {
+      expect(ExportMap.get('./narcissist', fakeContext))
+        .to.exist.and.satisfy(m => m.has('soGreat'))
+    })
+    it("can 'get' circular reference", function () {
+      expect(ExportMap.get('./narcissist', fakeContext))
+        .to.exist.and.satisfy(m => m.get('soGreat') != null)
+    })
+  })
+
 })

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -30,10 +30,15 @@ ruleTester.run('export', rule, {
       errors: ['Multiple default exports.', 'Multiple default exports.'],
     }),
     test({
+      code: 'export default foo; export * from "./default-export"',
+      errors: ['Multiple default exports.', 'Multiple default exports.'],
+    }),
+    test({
       code: 'export default function foo() {}; ' +
                  'export default function bar() {}',
       errors: ['Multiple default exports.', 'Multiple default exports.'],
     }),
+
     test({
       code: 'export function foo() {}; ' +
                  'export { bar as foo }',
@@ -60,10 +65,10 @@ ruleTester.run('export', rule, {
       errors: ['Multiple exports of name \'foo\'.',
                'Multiple exports of name \'foo\'.'],
     }),
-    test({ code: 'export * from "./default-export"'
-         , errors: [{ message: 'No named exports found in module ' +
-                               '\'./default-export\'.'
-                    , type: 'Literal' }] }),
+    // test({ code: 'export * from "./default-export"'
+    //      , errors: [{ message: 'No named exports found in module ' +
+    //                            '\'./default-export\'.'
+    //                 , type: 'Literal' }] }),
 
     test({
       code: 'export * from "./malformed.js"',

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -86,6 +86,9 @@ ruleTester.run('named', rule, {
     // ignore is ignored if exports are found
     test({ code: 'import { foo } from "es6-module"' }),
 
+    // issue #210: shameless self-reference
+    test({ code: 'import { me, soGreat } from "./narcissist"' }),
+
   ],
 
   invalid: [

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -29,8 +29,7 @@ ruleTester.run('named', rule, {
     test({code: 'import {a, b, d} from "./common"; ' +
                 '// eslint-disable-line named' }),
 
-    test({ code: 'import {foo, bar} from "./re-export-names"'
-         , args: [2, 'es6-only']}),
+    test({ code: 'import { foo, bar } from "./re-export-names"' }),
 
     test({ code: 'import { foo, bar } from "./common"'
          , settings: { 'import/ignore': ['common'] } }),

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -75,13 +75,22 @@ const valid = [
       'import * as names from "./named-exports"; ',
   }),
 
+  // names.default is valid export
+  test({ code: "import * as names from './default-export';" }),
+  test({
+   code: 'export * as names from "./default-export"',
+   parser: 'babel-eslint',
+  }),
+  test({
+    code: 'export defport, * as names from "./default-export"',
+    parser: 'babel-eslint',
+  }),
+
 ]
 
 const invalid = [
   test({code: "import * as foo from './common';",
         errors: ["No exported names found in module './common'."]}),
-  test({code: "import * as names from './default-export';",
-        errors: ["No exported names found in module './default-export'."]}),
 
   test({ code: "import * as names from './named-exports'; " +
                ' console.log(names.c);'
@@ -119,12 +128,6 @@ const invalid = [
   /////////
   // es7 //
   /////////
-  test({ code: 'export * as names from "./default-export"'
-       , parser: 'babel-eslint'
-       , errors: ["No exported names found in module './default-export'."] }),
-  test({ code: 'export defport, * as names from "./default-export"'
-       , parser: 'babel-eslint'
-       , errors: ["No exported names found in module './default-export'."] }),
 
   test({
     code: 'import * as Endpoints from "./issue-195/Endpoints"; console.log(Endpoints.Foo)',


### PR DESCRIPTION
Use full `ExportMap` as deep namespace name maps. Stats on every access for cache correctness under `eslint_d`/`eslint-loader`. (fixes #200)

Explicitly detect and exit 0-deep self-exports. (fixes #210)