### PR TITLE
Cache fileExists in core/resolve

### DIFF
--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -14,13 +14,22 @@ function fileExistsWithCaseSync(filepath) {
   return fileExistsWithCaseSync(dir)
 }
 
+const fileExistsCache = new Map()
+
 function fileExists(filepath) {
+  if (fileExistsCache.has(filepath)) {
+    return fileExistsCache.get(filepath)
+  }
+
+  let result
   if (CASE_INSENSITIVE) {
     // short-circuit if path doesn't exist, ignoring case
-    return !(!fs.existsSync(filepath) || !fileExistsWithCaseSync(filepath))
+    result = !(!fs.existsSync(filepath) || !fileExistsWithCaseSync(filepath))
   } else {
-    return fs.existsSync(filepath)
+    result = fs.existsSync(filepath)
   }
+  fileExistsCache.set(filepath, result)
+  return result
 }
 
 export function relative(modulePath, sourceFile, settings) {


### PR DESCRIPTION
In a project where I have import/no-unresolved enabled, I get the
following results with ESLint's TIMING=1 environment variable enabled:

```
Rule                          | Time (ms) | Relative
:-----------------------------|----------:|--------:
import/no-unresolved          | 18563.065 |    40.6%
react/sort-comp               |  1621.646 |     3.5%
no-irregular-whitespace       |  1386.958 |     3.0%
react/prop-types              |  1197.552 |     2.6%
no-implied-eval               |   829.967 |     1.8%
react/jsx-uses-vars           |   765.702 |     1.7%
keyword-spacing               |   765.665 |     1.7%
no-eval                       |   578.730 |     1.3%
semi-spacing                  |   549.684 |     1.2%
no-whitespace-before-property |   477.285 |     1.0%
```

To speed up this outlier, I decided to cache the results of file
existence checks in a Map. Adding this cache brings this time down
from ~18s to ~13s:

```
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
import/no-unresolved    | 13199.978 |    32.5%
react/sort-comp         |  1793.781 |     4.4%
react/prop-types        |  1400.975 |     3.4%
no-irregular-whitespace |  1315.485 |     3.2%
react/jsx-uses-vars     |   794.097 |     2.0%
no-implied-eval         |   765.593 |     1.9%
keyword-spacing         |   752.945 |     1.9%
no-eval                 |   592.048 |     1.5%
semi-spacing            |   532.061 |     1.3%
no-control-regex        |   479.856 |     1.2%
```

Addresses #187