### PR TITLE
No native reassign

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  # - 0.10
   - 0.12
   - 4
   - stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [Unreleased]
+### Removed
+- support for Node 0.10, via `es6-*` ponyfills. Using native Map/Set/Symbol.
+
 ## [1.4.0] - 2016-03-25
 ### Added
 - Resolver plugin interface v2: more explicit response format that more clearly covers the found-but-core-module case, where there is no path.

--- a/package.json
+++ b/package.json
@@ -66,9 +66,6 @@
   },
   "dependencies": {
     "doctrine": "1.2.0",
-    "es6-map": "^0.1.3",
-    "es6-set": "^0.1.4",
-    "es6-symbol": "*",
     "eslint-import-resolver-node": "^0.2.0",
     "object-assign": "^4.0.1"
   }

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -1,6 +1,3 @@
-import 'es6-symbol/implement'
-import Map from 'es6-map'
-
 import * as fs from 'fs'
 
 import { createHash } from 'crypto'

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -1,5 +1,3 @@
-import 'es6-symbol/implement'
-import Map from 'es6-map'
 import assign from 'object-assign'
 
 import fs from 'fs'

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -1,7 +1,3 @@
-import 'es6-symbol/implement'
-import Map from 'es6-map'
-import Set from 'es6-set'
-
 import ExportMap, { recursivePatternCapture } from '../core/getExports'
 
 module.exports = function (context) {

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -1,6 +1,3 @@
-import 'es6-symbol/implement'
-import Map from 'es6-map'
-
 import Exports from '../core/getExports'
 import importDeclaration from '../importDeclaration'
 import declaredScope from '../core/declaredScope'

--- a/src/rules/no-deprecated.js
+++ b/src/rules/no-deprecated.js
@@ -1,5 +1,3 @@
-import Map from 'es6-map'
-
 import Exports from '../core/getExports'
 import declaredScope from '../core/declaredScope'
 

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -1,7 +1,3 @@
-import 'es6-symbol/implement'
-import Map from 'es6-map'
-import Set from 'es6-set'
-
 import resolve from '../core/resolve'
 
 module.exports = function (context) {

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -3,8 +3,6 @@
  * @author Ben Mosher
  */
 
-import 'es6-symbol/implement'
-
 import resolve from '../core/resolve'
 
 module.exports = function (context) {

--- a/tests/src/package.js
+++ b/tests/src/package.js
@@ -1,5 +1,3 @@
-import 'es6-symbol/implement'
-
 var expect = require('chai').expect
 
 var path = require('path')


### PR DESCRIPTION
Drop direct support for Node 0.10 by removing ponyfills for `Map`/`Set`/`Symbol`. (see #230)

Node 0.12 support not impacted by this PR. (yet.)