### PR TITLE
Add no-namespace rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Added
 - report resolver errors at the top of the linted file
+- add `no-namespace` rule
 
 ## [1.4.0] - 2016-03-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Style guide:
 * Report AMD `require` and `define` calls. ([`no-amd`])
 * Ensure all imports appear before other statements ([`imports-first`])
 * Report repeated import of the same module in multiple places ([`no-duplicates`])
+* Report namespace imports ([`no-namespace`])
 
 [`no-commonjs`]: ./docs/rules/no-commonjs.md
 [`no-amd`]: ./docs/rules/no-amd.md
 [`imports-first`]: ./docs/rules/imports-first.md
 [`no-duplicates`]: ./docs/rules/no-duplicates.md
+[`no-namespace`]: ./docs/rules/no-namespace.md
 
 Work in progress:
 

--- a/docs/rules/no-namespace.md
+++ b/docs/rules/no-namespace.md
@@ -1,0 +1,24 @@
+# no-namespace
+
+Reports if namespace import is used.
+
+## Rule Details
+
+Valid:
+
+```js
+import defaultExport from './foo'
+import { a, b }  from './bar'
+import defaultExport, { a, b }  from './foobar'
+```
+
+...whereas here imports will be reported:
+
+```js
+import * as foo from 'foo';
+import defaultExport, * as foo from 'foo';
+```
+
+## When Not To Use It
+
+If you want to use namespaces, you don't want to use this rule.

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export const rules = {
   'named': require('./rules/named'),
   'default': require('./rules/default'),
   'namespace': require('./rules/namespace'),
+  'no-namespace': require('./rules/no-namespace'),
   'export': require('./rules/export'),
 
   'no-named-as-default': require('./rules/no-named-as-default'),

--- a/src/rules/no-namespace.js
+++ b/src/rules/no-namespace.js
@@ -1,0 +1,17 @@
+/**
+ * @fileoverview Rule to disallow namespace import
+ * @author Radek Benkel
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+
+module.exports = function (context) {
+  return {
+    'ImportNamespaceSpecifier': function (node) {
+      context.report(node, `Unexpected namespace import.`)
+    },
+  }
+}

--- a/tests/src/rules/no-namespace.js
+++ b/tests/src/rules/no-namespace.js
@@ -1,0 +1,44 @@
+import { RuleTester } from 'eslint'
+
+const ERROR_MESSAGE = 'Unexpected namespace import.';
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-namespace', require('rules/no-namespace'), {
+  valid: [
+    { code: "import { a, b } from 'foo';", parserOptions: { sourceType: 'module' } },
+    { code: "import { a, b } from './foo';", parserOptions: { sourceType: 'module' } },
+    { code: "import bar from 'bar';", parserOptions: { sourceType: 'module' } },
+    { code: "import bar from './bar';", parserOptions: { sourceType: 'module' } }
+  ],
+
+  invalid: [
+    {
+      code: "import * as foo from 'foo';",
+      errors: [ {
+        line: 1,
+        column: 8,
+        message: ERROR_MESSAGE
+      } ],
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "import defaultExport, * as foo from 'foo';",
+      errors: [ {
+        line: 1,
+        column: 23,
+        message: ERROR_MESSAGE
+      } ],
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "import * as foo from './foo';",
+      errors: [ {
+        line: 1,
+        column: 8,
+        message: ERROR_MESSAGE
+      } ],
+      parserOptions: { sourceType: 'module' }
+    }
+  ]
+});


### PR DESCRIPTION
# no-namespace

Reports if namespace import is used.

## Rule Details

Valid:

```js
import defaultExport from './foo'
import { a, b }  from './bar'
import defaultExport, { a, b }  from './foobar'
```

...whereas here imports will be reported:

```js
import * as foo from 'foo';
import defaultExport, * as foo from 'foo';
```

## Motivation:

One should only import names which are needed in current scope, nothing more.

Additonally, users of tools like [rollup.js](http://rollupjs.org/) or [webpack](https://webpack.github.io/) 2.0 which support tree shaking would benefit in a smaller bundle size because unused exports that are not imported can be eliminated.

If all names are required in addition to separate named exports, developer might export default object with all required members:

```js
export const FOO = 1;
export const BAR = 2;

export default {
	FOO,
	BAR
}
```
