### PR TITLE
Add `newline-after-import` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 * Report namespace imports ([`no-namespace`])
 * Ensure consistent use of file extension within the import path ([`extensions`])
 * Enforce a convention in module import order ([`order`])
+* Enforce a newline after import statements ([`newline-after-import`])
 
 [`imports-first`]: ./docs/rules/imports-first.md
 [`no-duplicates`]: ./docs/rules/no-duplicates.md

--- a/docs/rules/newline-after-import.md
+++ b/docs/rules/newline-after-import.md
@@ -1,8 +1,10 @@
 # newline-after-import
 
-Reports if there's no new line after last import in group.
+Reports if there's no new line after last import/require in group.
 
 ## Rule Details
+
+**NOTE**: In each of those examples you can replace `import` call with `require`.
 
 Valid:
 

--- a/docs/rules/newline-after-import.md
+++ b/docs/rules/newline-after-import.md
@@ -1,0 +1,38 @@
+# newline-after-import
+
+Reports if there's no new line after last import in group.
+
+## Rule Details
+
+Valid:
+
+```js
+import defaultExport from './foo'
+
+const FOO = 'BAR'
+```
+
+```js
+import defaultExport from './foo'
+import { bar }  from 'bar-lib'
+
+const FOO = 'BAR'
+```
+
+...whereas here imports will be reported:
+
+```js
+import * as foo from 'foo'
+const FOO = 'BAR'
+```
+
+```js
+import * as foo from 'foo'
+const FOO = 'BAR'
+
+import { bar }  from 'bar-lib'
+```
+
+## When Not To Use It
+
+If you like to visually group module imports with its usage, you don't want to use this rule.

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export const rules = {
   'no-extraneous-dependencies': require('./rules/no-extraneous-dependencies'),
   'no-nodejs-modules': require('./rules/no-nodejs-modules'),
   'order': require('./rules/order'),
+  'newline-after-import': require('./rules/newline-after-import'),
 
   // metadata-based
   'no-deprecated': require('./rules/no-deprecated'),

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Rule to enforce new line after import not followed by another import.
+ * @author Radek Benkel
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+function getLineDifference(node, nextToken) {
+  return nextToken.loc.start.line - node.loc.start.line
+}
+
+module.exports = function (context) {
+  return {
+    'ImportDeclaration': function (node) {
+      const nextToken = context.getSourceCode(node).getTokenAfter(node)
+
+      if (!nextToken) {
+        return
+      }
+
+      if (getLineDifference(node, nextToken) === 1
+          && nextToken.type === 'Keyword' && nextToken.value !== 'import')
+      {
+        context.report({
+          loc: nextToken.loc.start,
+          message: 'Expected empty line after import statement not followed by another import.',
+        })
+      }
+    },
+  }
+}

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -1,0 +1,49 @@
+import { RuleTester } from 'eslint'
+
+const ERROR_MESSAGE = 'Expected empty line after import statement not followed by another import.';
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
+  valid: [
+    {
+      code: "import foo from 'foo';\n\nvar foo = 'bar';",
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "import foo from 'foo';\nimport { bar } from './bar-lib';",
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "import foo from 'foo';\n\nvar a = 123;\n\nimport { bar } from './bar-lib';",
+      parserOptions: { sourceType: 'module' }
+    },
+  ],
+
+  invalid: [
+    {
+      code: "import foo from 'foo';\nexport default function() {};",
+      errors: [ {
+        line: 2,
+        column: 1,
+        message: ERROR_MESSAGE
+      } ],
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "import foo from 'foo';\nvar a = 123;\n\nimport { bar } from './bar-lib';\nvar b=456;",
+      errors: [
+      {
+        line: 2,
+        column: 1,
+        message: ERROR_MESSAGE
+      },
+      {
+        line: 5,
+        column: 1,
+        message: ERROR_MESSAGE
+      }],
+      parserOptions: { sourceType: 'module' }
+    },
+  ]
+});

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -1,6 +1,7 @@
 import { RuleTester } from 'eslint'
 
-const ERROR_MESSAGE = 'Expected empty line after import statement not followed by another import.';
+const IMPORT_ERROR_MESSAGE = 'Expected empty line after import statement not followed by another import.';
+const REQUIRE_ERROR_MESSAGE = 'Expected empty line after require statement not followed by another require.';
 
 const ruleTester = new RuleTester()
 
@@ -11,6 +12,14 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { sourceType: 'module' }
     },
     {
+      code: "var foo = require('foo-module');\n\nvar foo = 'bar';",
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "require('foo-module');\n\nvar foo = 'bar';",
+      parserOptions: { sourceType: 'module' }
+    },
+    {
       code: "import foo from 'foo';\nimport { bar } from './bar-lib';",
       parserOptions: { sourceType: 'module' }
     },
@@ -18,6 +27,10 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       code: "import foo from 'foo';\n\nvar a = 123;\n\nimport { bar } from './bar-lib';",
       parserOptions: { sourceType: 'module' }
     },
+    {
+      code: "var foo = require('foo-module');\n\nvar a = 123;\n\nvar bar = require('bar-lib');",
+      parserOptions: { sourceType: 'module' }
+    }
   ],
 
   invalid: [
@@ -26,7 +39,16 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       errors: [ {
         line: 2,
         column: 1,
-        message: ERROR_MESSAGE
+        message: IMPORT_ERROR_MESSAGE
+      } ],
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "var foo = require('foo-module');\nvar something = 123;",
+      errors: [ {
+        line: 2,
+        column: 1,
+        message: REQUIRE_ERROR_MESSAGE
       } ],
       parserOptions: { sourceType: 'module' }
     },
@@ -36,13 +58,43 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       {
         line: 2,
         column: 1,
-        message: ERROR_MESSAGE
+        message: IMPORT_ERROR_MESSAGE
       },
       {
         line: 5,
         column: 1,
-        message: ERROR_MESSAGE
+        message: IMPORT_ERROR_MESSAGE
       }],
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "var foo = require('foo-module');\nvar a = 123;\n\nvar bar = require('bar-lib');\nvar b=456;",
+      errors: [
+        {
+          line: 2,
+          column: 1,
+          message: REQUIRE_ERROR_MESSAGE
+        },
+        {
+          line: 5,
+          column: 1,
+          message: REQUIRE_ERROR_MESSAGE
+        }],
+      parserOptions: { sourceType: 'module' }
+    },
+    {
+      code: "var foo = require('foo-module');\nvar a = 123;\n\nrequire('bar-lib');\nvar b=456;",
+      errors: [
+        {
+          line: 2,
+          column: 1,
+          message: REQUIRE_ERROR_MESSAGE
+        },
+        {
+          line: 5,
+          column: 1,
+          message: REQUIRE_ERROR_MESSAGE
+        }],
       parserOptions: { sourceType: 'module' }
     },
   ]


### PR DESCRIPTION
# newline-after-import (#244)

Reports if there's no new line after last import in group.

## Rule Details

Valid:

```js
import defaultExport from './foo'

const FOO = 'BAR'
```

```js
import defaultExport from './foo'
import { bar }  from 'bar-lib'

const FOO = 'BAR'
```

...whereas here imports will be reported:

```js
import * as foo from 'foo'
const FOO = 'BAR'
```

```js
import * as foo from 'foo'
const FOO = 'BAR'

import { bar }  from 'bar-lib'
```

## When Not To Use It

If you like to visually group module imports with its usage, you don't want to use this rule.