### PR TITLE
Add `absolute-first-group` option to `imports-first`

### DIFF
--- a/docs/rules/imports-first.md
+++ b/docs/rules/imports-first.md
@@ -24,6 +24,31 @@ import bar from './bar'
 import * as _ from 'lodash' // <- reported
 ```
 
+You can also provide `absolute-first-group` option if you would like to visually group your imports. While enabled,
+this code will be considered valid:
+
+```js
+import foo from 'foo'
+
+import bar from './bar'
+```
+
+while those ones not:
+
+```js
+import foo from 'foo'
+import bar from './bar'
+```
+
+```js
+import foo from 'foo'
+
+
+import bar from './bar'
+```
+
+**NOTE**: This option will work only if `absolute-first` is enabled (hence prefix in option name).
+
 TODO: add explanation of imported name hoisting
 
 ## When Not To Use It

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -2,7 +2,8 @@ module.exports = function (context) {
   return {
     'Program': function (n) {
       const body = n.body
-          , absoluteFirst = context.options[0] === 'absolute-first'
+          , absoluteFirst = context.options.indexOf('absolute-first') !== -1
+          , absoluteFirstGroup = context.options.indexOf('absolute-first-group') !== -1
       let last = -1
         , anyRelative = false
       body.forEach(function (node, i){
@@ -15,6 +16,15 @@ module.exports = function (context) {
                 node: node.source,
                 message: 'Absolute imports should come before relative imports.',
               })
+
+              const prevToken = context.getSourceCode(node).getTokenBefore(node)
+              if (absoluteFirstGroup && (node.loc.start.line - prevToken.loc.start.line !== 2)) {
+                context.report({
+                  node: node.source,
+                  message: 'There should be one empty line between ' +
+                           'absolute and relative import sections.',
+                })
+              }
             }
           }
           if (i !== ++last) {

--- a/tests/src/rules/imports-first.js
+++ b/tests/src/rules/imports-first.js
@@ -47,5 +47,33 @@ ruleTester.run('imports-first', rule, {
              message: 'Absolute imports should come before relative imports.'
            } ],
          })
+  , test({ code: "import { x } from './foo';\nimport { y } from 'bar';"
+         , options: ['absolute-first', 'absolute-first-group']
+         , errors: [
+           {
+             line: 2,
+             message: 'Absolute imports should come before relative imports.'
+           },
+           {
+              line: 2,
+              message: 'There should be one empty line between ' +
+                       'absolute and relative import sections.'
+           }
+         ],
+      })
+  , test({ code: "import { x } from './foo';\n\n\n\nimport { y } from 'bar';"
+         , options: ['absolute-first', 'absolute-first-group']
+         , errors: [
+           {
+             line: 5,
+             message: 'Absolute imports should come before relative imports.'
+           },
+           {
+             line: 5,
+             message: 'There should be one empty line between ' +
+                      'absolute and relative import sections.'
+           }
+         ],
+      })
   ]
 })

--- a/tests/src/rules/imports-first.js
+++ b/tests/src/rules/imports-first.js
@@ -16,17 +16,36 @@ ruleTester.run('imports-first', rule, {
     test({ code: "import { x } from './foo';\
                   export { x };\
                   import { y } from './foo';"
-         , errors: 1
+         , errors: [ {
+             line: 1,
+             column: 76,
+             message: 'Import in body of module; reorder to top.'
+         } ],
          })
   , test({ code: "import { x } from './foo';\
                   export { x };\
                   import { y } from './bar';\
                   import { z } from './baz';"
-         , errors: 2
+         , errors: [
+             {
+               line: 1,
+               column: 76,
+               message: 'Import in body of module; reorder to top.'
+             },
+             {
+               line: 1,
+               column: 120,
+               message: 'Import in body of module; reorder to top.'
+             }
+         ],
          })
   , test({ code: "import { x } from './foo'; import { y } from 'bar'"
          , options: ['absolute-first']
-         , errors: 1
+         , errors: [ {
+             line: 1,
+             column: 46,
+             message: 'Absolute imports should come before relative imports.'
+           } ],
          })
   ]
 })


### PR DESCRIPTION
As we're trying to enforce formatting rules for imports like below:

```
import a from `absolute-import`
//new line here
import b from `./relative-import`
import c from `./../../another-relative-import`
//new line here
const whateverElse = '...';
```

this is addition to previously created #245. I have doubts about option name though - it is in fact some kind of visual grouping, yet it doesn't speak to me in 100%.