### PR TITLE
Make imports-first treat directives as an exception

### DIFF
--- a/tests/src/rules/imports-first.js
+++ b/tests/src/rules/imports-first.js
@@ -11,6 +11,9 @@ ruleTester.run('imports-first', rule, {
                   export { x, y }" })
   , test({ code: "import { x } from 'foo'; import { y } from './bar'" })
   , test({ code: "import { x } from './foo'; import { y } from 'bar'" })
+  , test({ code: "'use directive';\
+                  import { x } from 'foo';" })
+  ,
   ],
   invalid: [
     test({ code: "import { x } from './foo';\
@@ -28,5 +31,11 @@ ruleTester.run('imports-first', rule, {
          , options: ['absolute-first']
          , errors: 1
          })
+  , test({ code: "import { x } from 'foo';\
+                  'use directive';\
+                  import { y } from 'bar';"
+         , errors: 1
+         })
+  ,
   ]
 })


### PR DESCRIPTION
Fixes #255. Per discussion in that issue, directives need to appear at the top of a file in order to be considered directives. This isn't usually a problem because modules remove the need for `'use strict'`, but we use a custom directive as part of our build system. This PR makes `imports-first` understand directives and not throw errors when those appear above import statements.

cc/ @benmosher, let me know if anything else is needed; I didn't see a contributing file in the repo so not sure what the best practices are.