### PR TITLE
named: should ignore ignored modules for re-exported names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`imports-first`] now allows directives (i.e. `'use strict'`) strictly before
   any imports ([#256], thanks [@lemonmade])
 
+### Fixed
+- [`named`] now properly ignores the source module if a name is re-exported from
+  an ignored file (i.e. `node_modules`). Also improved the reported error.
+
 ## [1.5.0] - 2016-04-18
 ### Added
 - report resolver errors at the top of the linted file

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import Exports from '../core/getExports'
 
 module.exports = function (context) {
@@ -20,9 +21,20 @@ module.exports = function (context) {
     node.specifiers.forEach(function (im) {
       if (im.type !== type) return
 
-      if (!imports.get(im[key].name)) {
-        context.report(im[key],
-          im[key].name + ' not found in \'' + node.source.value + '\'')
+      const deepLookup = imports.hasDeep(im[key].name)
+
+      if (!deepLookup.found) {
+        if (deepLookup.path.length > 1) {
+          const deepPath = deepLookup.path
+            .map(i => path.relative(path.dirname(context.getFilename()), i.path))
+            .join(' -> ')
+
+          context.report(im[key],
+            `${im[key].name} not found via ${deepPath}`)
+        } else {
+          context.report(im[key],
+            im[key].name + ' not found in \'' + node.source.value + '\'')
+        }
       }
     })
   }

--- a/tests/files/re-export-default.js
+++ b/tests/files/re-export-default.js
@@ -1,0 +1,7 @@
+export const baz = "baz? really?"
+
+export { default as bar } from './default-export'
+export { default as foo } from './named-default-export'
+
+// should allow conversion from CJS to ES6 as follows:
+export { default as common } from './common'

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -160,7 +160,7 @@ ruleTester.run('named', rule, {
     test({
       code: 'import { baz } from "./broken-trampoline"',
       parser: 'babel-eslint',
-      errors: ["baz not found in './broken-trampoline'"],
+      errors: ["baz not found via broken-trampoline.js -> named-exports.js"],
     }),
 
     // parse errors
@@ -213,7 +213,7 @@ ruleTester.run('named', rule, {
     test({
       code: 'import { common } from "./re-export-default"',
       // todo: better error message
-      errors: ["common not found in './re-export-default'"],
+      errors: ["common not found via re-export-default.js -> common.js"],
     }),
   ],
 })

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -89,6 +89,13 @@ ruleTester.run('named', rule, {
     // issue #210: shameless self-reference
     test({ code: 'import { me, soGreat } from "./narcissist"' }),
 
+    // issue #251: re-export default as named
+    test({ code: 'import { foo, bar, baz } from "./re-export-default"' }),
+    test({
+      code: 'import { common } from "./re-export-default"',
+      settings: { 'import/ignore': ['common'] },
+    }),
+
   ],
 
   invalid: [
@@ -196,6 +203,17 @@ ruleTester.run('named', rule, {
       code: 'import { baz } from "./bar"',
       settings: { 'import/ignore': ['bar'] },
       errors: ["baz not found in './bar'"],
+    }),
+
+    // issue #251
+    test({
+      code: 'import { foo, bar, bap } from "./re-export-default"',
+      errors: ["bap not found in './re-export-default'"],
+    }),
+    test({
+      code: 'import { common } from "./re-export-default"',
+      // todo: better error message
+      errors: ["common not found in './re-export-default'"],
     }),
   ],
 })


### PR DESCRIPTION
fixes #251: will assume you know what you're doing when you re-export from a non-ES-module.