### PR TITLE
Enable `quotes` rule for eslint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,3 +13,7 @@ rules:
   comma-dangle: [2, always-multiline]
   eqeqeq: [2, "allow-null"]
   no-shadow: 1
+  quotes:
+    - 2
+    - single
+    - allowTemplateLiterals: true

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -352,7 +352,7 @@ function captureDoc(...nodes) {
     // capture XSDoc
     n.leadingComments.forEach(comment => {
       // skip non-block comments
-      if (comment.value.slice(0, 4) !== "*\n *") return
+      if (comment.value.slice(0, 4) !== '*\n *') return
       try {
         metadata.doc = doctrine.parse(comment.value, { unwrap: true })
       } catch (err) {

--- a/src/core/hash.js
+++ b/src/core/hash.js
@@ -29,14 +29,14 @@ export function hashArray(hash, array) {
 }
 
 export function hashObject(hash, object) {
-  hash.update("{")
+  hash.update('{')
   Object.keys(object).sort().forEach(key => {
     hash.update(stringify(key))
     hash.update(':')
     hashify(hash, object[key])
-    hash.update(",")
+    hash.update(',')
   })
-  hash.update("}")
+  hash.update('}')
 
   return hash
 }

--- a/src/core/parse.js
+++ b/src/core/parse.js
@@ -3,11 +3,11 @@ import assign from 'object-assign'
 
 export default function (content, context) {
 
-  if (context == null) throw new Error("need context to parse properly")
+  if (context == null) throw new Error('need context to parse properly')
 
   let { parserOptions, parserPath } = context
 
-  if (!parserPath) throw new Error("parserPath is required!")
+  if (!parserPath) throw new Error('parserPath is required!')
 
   // hack: espree blows up with frozen options
   parserOptions = assign({}, parserOptions)


### PR DESCRIPTION
I missed those quotes while doing other PR: https://github.com/benmosher/eslint-plugin-import/pull/245#discussion_r61135535 :)

Now it should be harder to miss that :)