### PR TITLE
Move 'interpret' to webpack loader's package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "es6-set": "^0.1.4",
     "es6-symbol": "*",
     "eslint-import-resolver-node": "^0.2.0",
-    "interpret": "^1.0.0",
     "lodash.cond": "^4.3.0",
     "lodash.endswith": "^4.0.1",
     "lodash.find": "^4.3.0",

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "array-find": "^1.0.0",
     "find-root": "^0.1.1",
+    "interpret": "^1.0.0",
     "is-absolute": "^0.2.3",
     "lodash.get": "^3.7.0",
     "resolve": "^1.1.6"


### PR DESCRIPTION
Users downloading the package from npm might have had problems since it wasn't downloading this required dependency.

Fixes #286