### PR TITLE
Add no-mutable-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
+### Added
+- add [`no-mutable-exports`] rule ([#290], thanks [@josh])
+
 ## resolvers/webpack/0.2.2 - 2016-04-27
 ### Added
 - `interpret` configs (such as `.babel.js`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - `interpret` dependency was declared in the wrong `package.json`.
    Thanks [@jonboiser] for sleuthing ([#286]) and fixing ([#289]).
->>>>>>> upstream/master
 
 ## resolvers/webpack/0.2.2 - 2016-04-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 [`no-named-as-default-member`]: ./docs/rules/no-named-as-default-member.md
 [`no-deprecated`]: ./docs/rules/no-deprecated.md
 [`no-extraneous-dependencies`]: ./docs/rules/no-extraneous-dependencies.md
+[`no-mutable-exports`]: ./docs/rules/no-mutable-exports.md
 
 **Module systems:**
 

--- a/docs/rules/no-mutable-exports.md
+++ b/docs/rules/no-mutable-exports.md
@@ -1,0 +1,23 @@
+# no-mutable-exports
+
+Forbids the use of mutable exports with `var` or `let`.
+
+## Rule Details
+
+Valid:
+
+```js
+export const count = 1
+export function getCount() {}
+```
+
+...whereas here exports will be reported:
+
+```js
+export let count = 2
+export var count = 3
+```
+
+## When Not To Use It
+
+If your environment correctly implements mutable export bindings.

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export const rules = {
   'namespace': require('./rules/namespace'),
   'no-namespace': require('./rules/no-namespace'),
   'export': require('./rules/export'),
+  'no-mutable-exports': require('./rules/no-mutable-exports'),
   'extensions': require('./rules/extensions'),
 
   'no-named-as-default': require('./rules/no-named-as-default'),

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -1,10 +1,28 @@
 module.exports = function (context) {
+  function checkDeclaration(node) {
+    const {kind} = node
+    if (kind === 'var' || kind === 'let') {
+      context.report(node, `Exporting mutable '${kind}' binding, use 'const' instead.`)
+    }
+  }
+
+  function handleExportNamed(node) {
+    const variables = context.getScope().variables
+
+    if (node.declaration)  {
+      checkDeclaration(node.declaration)
+    } else {
+      node.specifiers.forEach(specifier => {
+        variables.forEach(variable => {
+          if (variable.name === specifier.local.name) {
+            variable.defs.forEach(def => checkDeclaration(def.parent))
+          }
+        })
+      })
+    }
+  }
+
   return {
-    'ExportNamedDeclaration': function (node) {
-      const kind = node.declaration.kind
-      if (kind === 'var' || kind === 'let') {
-        context.report(node, `Exporting mutable '${kind}' binding, use 'const' instead.`)
-      }
-    },
+    'ExportNamedDeclaration': handleExportNamed,
   }
 }

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -3,7 +3,7 @@ module.exports = function (context) {
     'ExportNamedDeclaration': function (node) {
       const kind = node.declaration.kind
       if (kind === 'var' || kind === 'let') {
-        context.report(node, `Exporting mutable '${kind}' binding, use const instead.`)
+        context.report(node, `Exporting mutable '${kind}' binding, use 'const' instead.`)
       }
     },
   }

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -1,0 +1,10 @@
+module.exports = function (context) {
+	return {
+		'ExportNamedDeclaration': function (node) {
+      const kind = node.declaration.kind
+      if (kind === 'var' || kind === 'let') {
+        context.report(node, `Exporting mutable '${kind}' binding, use const instead.`)
+      }
+		},
+	}
+}

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -1,10 +1,10 @@
 module.exports = function (context) {
-	return {
-		'ExportNamedDeclaration': function (node) {
+  return {
+    'ExportNamedDeclaration': function (node) {
       const kind = node.declaration.kind
       if (kind === 'var' || kind === 'let') {
         context.report(node, `Exporting mutable '${kind}' binding, use const instead.`)
       }
-		},
-	}
+    },
+  }
 }

--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -1,0 +1,23 @@
+import {test} from '../utils'
+import {RuleTester} from 'eslint'
+import rule from 'rules/no-mutable-exports'
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-mutable-exports', rule, {
+  valid: [
+    test({ code: 'export const count = 1'}),
+    test({ code: 'export function getCount() {}'}),
+    test({ code: 'export class Counter {}'}),
+  ],
+  invalid: [
+    test({
+      code: 'export let count = 1',
+      errors: ['Exporting mutable \'let\' binding, use const instead.'],
+    }),
+    test({
+      code: 'export var count = 1',
+      errors: ['Exporting mutable \'var\' binding, use const instead.'],
+    }),
+  ],
+})

--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -9,6 +9,8 @@ ruleTester.run('no-mutable-exports', rule, {
     test({ code: 'export const count = 1'}),
     test({ code: 'export function getCount() {}'}),
     test({ code: 'export class Counter {}'}),
+    test({ code: 'const count = 1\nexport { count }'}),
+    test({ code: 'const count = 1\nexport { count as counter }'}),
   ],
   invalid: [
     test({
@@ -17,6 +19,22 @@ ruleTester.run('no-mutable-exports', rule, {
     }),
     test({
       code: 'export var count = 1',
+      errors: ['Exporting mutable \'var\' binding, use \'const\' instead.'],
+    }),
+    test({
+      code: 'let count = 1\nexport { count }',
+      errors: ['Exporting mutable \'let\' binding, use \'const\' instead.'],
+    }),
+    test({
+      code: 'var count = 1\nexport { count }',
+      errors: ['Exporting mutable \'var\' binding, use \'const\' instead.'],
+    }),
+    test({
+      code: 'let count = 1\nexport { count as counter }',
+      errors: ['Exporting mutable \'let\' binding, use \'const\' instead.'],
+    }),
+    test({
+      code: 'var count = 1\nexport { count as counter }',
       errors: ['Exporting mutable \'var\' binding, use \'const\' instead.'],
     }),
   ],

--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -9,8 +9,21 @@ ruleTester.run('no-mutable-exports', rule, {
     test({ code: 'export const count = 1'}),
     test({ code: 'export function getCount() {}'}),
     test({ code: 'export class Counter {}'}),
+    test({ code: 'export default count = 1'}),
+    test({ code: 'export default function getCount() {}'}),
+    test({ code: 'export default class Counter {}'}),
     test({ code: 'const count = 1\nexport { count }'}),
     test({ code: 'const count = 1\nexport { count as counter }'}),
+    test({ code: 'const count = 1\nexport default count'}),
+    test({ code: 'const count = 1\nexport { count as default }'}),
+    test({ code: 'function getCount() {}\nexport { getCount }'}),
+    test({ code: 'function getCount() {}\nexport { getCount as getCounter }'}),
+    test({ code: 'function getCount() {}\nexport default getCount'}),
+    test({ code: 'function getCount() {}\nexport { getCount as default }'}),
+    test({ code: 'class Counter {}\nexport { Counter }'}),
+    test({ code: 'class Counter {}\nexport { Counter as Count }'}),
+    test({ code: 'class Counter {}\nexport default Counter'}),
+    test({ code: 'class Counter {}\nexport { Counter as default }'}),
   ],
   invalid: [
     test({
@@ -35,6 +48,14 @@ ruleTester.run('no-mutable-exports', rule, {
     }),
     test({
       code: 'var count = 1\nexport { count as counter }',
+      errors: ['Exporting mutable \'var\' binding, use \'const\' instead.'],
+    }),
+    test({
+      code: 'let count = 1\nexport default count',
+      errors: ['Exporting mutable \'let\' binding, use \'const\' instead.'],
+    }),
+    test({
+      code: 'var count = 1\nexport default count',
       errors: ['Exporting mutable \'var\' binding, use \'const\' instead.'],
     }),
   ],

--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -13,11 +13,11 @@ ruleTester.run('no-mutable-exports', rule, {
   invalid: [
     test({
       code: 'export let count = 1',
-      errors: ['Exporting mutable \'let\' binding, use const instead.'],
+      errors: ['Exporting mutable \'let\' binding, use \'const\' instead.'],
     }),
     test({
       code: 'export var count = 1',
-      errors: ['Exporting mutable \'var\' binding, use const instead.'],
+      errors: ['Exporting mutable \'var\' binding, use \'const\' instead.'],
     }),
   ],
 })


### PR DESCRIPTION
Hey @benmosher, this plugin is pretty rad :metal:.

I added a rule to prevent the use of `export let` and `export var`. ES module export bindings are supposed to be *live* which is a pretty interesting concept, but tricky to shim correctly. Most CJS or AMD transpilers don't cover these cases correctly. So I'm just trying to avoid them in our code base until native implementations are finally here. `export const` is usually what you want anyway.

http://www.2ality.com/2014/09/es6-modules-final.html
http://stackoverflow.com/questions/32558514/javascript-es6-export-const-vs-export-let