### PR TITLE
`no-extraneous-dependencies`: add support/option for `optionalDependencies'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Added
 - [`newline-after-import`], new rule. ([#245], thanks [@singles])
+- Added an `optionalDependencies` option to [`no-extraneous-dependencies`] to allow/forbid optional dependencies ([#266], thanks [@jfmengels]).
 
 ## resolvers/webpack/0.2.4 - 2016-04-29
 ### Changed
@@ -210,6 +211,7 @@ for info on changes for earlier releases.
 [#286]: https://github.com/benmosher/eslint-plugin-import/issues/286
 [#281]: https://github.com/benmosher/eslint-plugin-import/issues/281
 [#272]: https://github.com/benmosher/eslint-plugin-import/issues/272
+[#266]: https://github.com/benmosher/eslint-plugin-import/issues/266
 [#216]: https://github.com/benmosher/eslint-plugin-import/issues/216
 [#214]: https://github.com/benmosher/eslint-plugin-import/issues/214
 [#210]: https://github.com/benmosher/eslint-plugin-import/issues/210

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -8,11 +8,12 @@ The closest parent `package.json` will be used. If no `package.json` is found, t
 This rule supports the following options:
 
 `devDependencies`: If set to `false`, then the rule will show an error when `devDependencies` are imported. Defaults to `true`.
+`optionalDependencies`: If set to `false`, then the rule will show an error when `optionalDependencies` are imported. Defaults to `true`.
 
 You can set the options like this:
 
 ```js
-"import/no-extraneous-dependencies": ["error", {"devDependencies": false}]
+"import/no-extraneous-dependencies": ["error", {"devDependencies": false, "optionalDependencies": false}]
 ```
 
 
@@ -34,6 +35,9 @@ Given the following `package.json`:
     "eslint": "^2.4.0",
     "eslint-plugin-ava": "^1.3.0",
     "xo": "^0.13.0"
+  },
+  "optionalDependencies": {
+    "lodash.isarray": "^4.0.0"
   }
 }
 ```
@@ -48,6 +52,10 @@ import _ from 'lodash';
 /* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": false}] */
 import test from 'ava';
 var test = require('ava');
+
+/* eslint import/no-extraneous-dependencies: ["error", {"optionalDependencies": false}] */
+import isArray from 'lodash.isarray';
+var isArray = require('lodash.isarray');
 ```
 
 
@@ -60,6 +68,7 @@ var foo = require('./foo');
 
 import test from 'ava';
 import find from 'lodash.find';
+import find from 'lodash.isarray';
 ```
 
 

--- a/tests/files/package.json
+++ b/tests/files/package.json
@@ -9,5 +9,8 @@
   "dependencies": {
     "lodash.cond": "^4.3.0",
     "pkg-up": "^1.0.0"
+  },
+  "optionalDependencies": {
+    "lodash.isarray": "^4.0.0"
   }
 }

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -20,6 +20,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({ code: 'var foo = require("pkg-up")'}),
     test({ code: 'import "fs"'}),
     test({ code: 'import "./foo"'}),
+    test({ code: 'import "lodash.isarray"'}),
 
     // 'project' type
     test({
@@ -32,7 +33,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "not-a-dependency"',
       errors: [{
         ruleId: 'no-extraneous-dependencies',
-        message: '\'not-a-dependency\' is not listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+        message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
     test({
@@ -40,22 +41,38 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{devDependencies: false}],
       errors: [{
         ruleId: 'no-extraneous-dependencies',
-        message: '\'eslint\' is not listed in the project\'s dependencies, not devDependencies.',
+        message: '\'eslint\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
     test({
-      code: 'var foo = require("not-a-dependency");',
+      code: 'import "lodash.isarray"',
+      options: [{optionalDependencies: false}],
       errors: [{
         ruleId: 'no-extraneous-dependencies',
-        message: '\'not-a-dependency\' is not listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+        message: '\'lodash.isarray\' should be listed in the project\'s dependencies, not optionalDependencies.',
       }],
     }),
     test({
-      code: 'var eslint = require("eslint");',
+      code: 'var foo = require("not-a-dependency")',
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+      }],
+    }),
+    test({
+      code: 'var eslint = require("eslint")',
       options: [{devDependencies: false}],
       errors: [{
         ruleId: 'no-extraneous-dependencies',
-        message: '\'eslint\' is not listed in the project\'s dependencies, not devDependencies.',
+        message: '\'eslint\' should be listed in the project\'s dependencies, not devDependencies.',
+      }],
+    }),
+    test({
+      code: 'var eslint = require("lodash.isarray")',
+      options: [{optionalDependencies: false}],
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'lodash.isarray\' should be listed in the project\'s dependencies, not optionalDependencies.',
       }],
     }),
   ],


### PR DESCRIPTION
`no-extraneous-dependencies`: add both support for and an option to disable `optionalDependencies' (fixes #266).

I've changed the error message a bit, as I don't see how the previous one actually made sense (for the `devDependency` error).