### PR TITLE
Unresolved extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`newline-after-import`], new rule. ([#245], thanks [@singles])
 - Added an `optionalDependencies` option to [`no-extraneous-dependencies`] to allow/forbid optional dependencies ([#266], thanks [@jfmengels]).
 
+### Fixed
+- [`extensions`]: fallback to source path for extension enforcement if imported
+  module is not resolved. Also, never report for builtins (i.e. `path`). ([#296])
+
 ## resolvers/webpack/0.2.4 - 2016-04-29
 ### Changed
 - automatically find webpack config with `interpret`-able extensions ([#287], thanks [@taion])
@@ -190,6 +194,7 @@ for info on changes for earlier releases.
 [`named`]: ./docs/rules/named.md
 [`newline-after-import`]: ./docs/rules/newline-after-import.md
 
+[#296]: https://github.com/benmosher/eslint-plugin-import/pull/296
 [#289]: https://github.com/benmosher/eslint-plugin-import/pull/289
 [#288]: https://github.com/benmosher/eslint-plugin-import/pull/288
 [#287]: https://github.com/benmosher/eslint-plugin-import/pull/287

--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -54,6 +54,8 @@ import bar from './bar';
 import Component from './Component'
 
 import express from 'express/index';
+
+import * as path from 'path';
 ```
 
 The following patterns are considered problems when configuration set to "always":
@@ -78,6 +80,8 @@ import bar from './bar.json';
 import Component from './Component.jsx'
 
 import express from 'express/index.js';
+
+import * as path from 'path';
 ```
 
 ## When Not To Use It

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ var reporter = 'spec'
 
 gulp.task('test', ['pretest'], function () {
   return gulp.src('tests/lib/**/*.js', { read: false })
-    .pipe(mocha({ reporter: reporter, grep: process.env.TEST_GREP }))
+    .pipe(mocha({ reporter: reporter, grep: process.env.TEST_GREP, timeout: 5000 }))
   // NODE_PATH=./lib mocha --recursive --reporter dot tests/lib/
 })
 

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -8,7 +8,7 @@ function constant(value) {
   return () => value
 }
 
-function isBuiltIn(name) {
+export function isBuiltIn(name) {
   return builtinModules.indexOf(name) !== -1
 }
 

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -32,6 +32,14 @@ ruleTester.run('extensions', rule, {
       options: [ 'never' ],
       settings: { 'import/resolve': { 'extensions': [ '.js', '.jsx', '.json' ] } },
     }),
+
+    // unresolved (#271/#295)
+    test({ code: 'import path from "path"' }),
+    test({ code: 'import path from "path"', options: [ 'never' ] }),
+    test({ code: 'import path from "path"', options: [ 'always' ] }),
+    test({ code: 'import thing from "./fake-file.js"', options: [ 'always' ] }),
+    test({ code: 'import thing from "non-package"', options: [ 'never' ] }),
+
   ],
 
   invalid: [
@@ -116,6 +124,29 @@ ruleTester.run('extensions', rule, {
       ],
     }),
 
+    // unresolved (#271/#295)
+    test({
+      code: 'import thing from "./fake-file.js"',
+      options: [ 'never' ],
+      errors: [
+        {
+            message: 'Unexpected use of file extension "js" for "./fake-file.js"',
+            line: 1,
+            column: 19,
+        },
+      ],
+    }),
+    test({
+      code: 'import thing from "non-package"',
+      options: [ 'always' ],
+      errors: [
+        {
+            message: 'Missing file extension for "non-package"',
+            line: 1,
+            column: 19,
+        },
+      ],
+    }),
+
   ],
 })
-

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -1,6 +1,6 @@
 import { RuleTester } from 'eslint'
-import rule from 'rules/extensions';
-import { test } from '../utils';
+import rule from 'rules/extensions'
+import { test } from '../utils'
 
 const ruleTester = new RuleTester()
 
@@ -10,28 +10,28 @@ ruleTester.run('extensions', rule, {
     test({ code: 'import dot from "./file.with.dot"' }),
     test({
       code: 'import a from "a/index.js"',
-      options: [ 'always' ]
+      options: [ 'always' ],
     }),
     test({
       code: 'import dot from "./file.with.dot.js"',
-      options: [ 'always' ]
+      options: [ 'always' ],
     }),
     test({
       code: [
         'import a from "a"',
         'import packageConfig from "./package.json"',
       ].join('\n'),
-      options: [ { json: 'always', js: 'never' } ]
+      options: [ { json: 'always', js: 'never' } ],
     }),
     test({
       code: [
         'import lib from "./bar"',
         'import component from "./bar.jsx"',
-        'import data from "./bar.json"'
+        'import data from "./bar.json"',
       ].join('\n'),
       options: [ 'never' ],
-      settings: { 'import/resolve': { 'extensions': [ '.js', '.jsx', '.json' ] } }
-    })
+      settings: { 'import/resolve': { 'extensions': [ '.js', '.jsx', '.json' ] } },
+    }),
   ],
 
   invalid: [
@@ -40,8 +40,8 @@ ruleTester.run('extensions', rule, {
       errors: [ {
         message: 'Unexpected use of file extension "js" for "a/index.js"',
         line: 1,
-        column: 15
-      } ]
+        column: 15,
+      } ],
     }),
     test({
       code: 'import a from "a"',
@@ -49,19 +49,19 @@ ruleTester.run('extensions', rule, {
       errors: [ {
         message: 'Missing file extension "js" for "a"',
         line: 1,
-        column: 15
-      } ]
+        column: 15,
+      } ],
     }),
     test({
       code: 'import dot from "./file.with.dot"',
-      options: [ "always" ],
+      options: [ 'always' ],
       errors: [
         {
           message: 'Missing file extension "js" for "./file.with.dot"',
           line: 1,
-          column: 17
-        }
-      ]
+          column: 17,
+        },
+      ],
     }),
     test({
       code: [
@@ -74,20 +74,20 @@ ruleTester.run('extensions', rule, {
         {
           message: 'Unexpected use of file extension "js" for "a/index.js"',
           line: 1,
-          column: 15
+          column: 15,
         },
         {
           message: 'Missing file extension "json" for "./package"',
           line: 2,
-          column: 27
-        }
-      ]
+          column: 27,
+        },
+      ],
     }),
     test({
       code: [
         'import lib from "./bar.js"',
         'import component from "./bar.jsx"',
-        'import data from "./bar.json"'
+        'import data from "./bar.json"',
       ].join('\n'),
       options: [ 'never' ],
       settings: { 'import/resolve': { 'extensions': [ '.js', '.jsx', '.json' ] } },
@@ -95,15 +95,15 @@ ruleTester.run('extensions', rule, {
         {
             message: 'Unexpected use of file extension "js" for "./bar.js"',
             line: 1,
-            column: 17
-        }
-      ]
+            column: 17,
+        },
+      ],
     }),
     test({
       code: [
         'import lib from "./bar.js"',
         'import component from "./bar.jsx"',
-        'import data from "./bar.json"'
+        'import data from "./bar.json"',
       ].join('\n'),
       options: [ { json: 'always', js: 'never', jsx: 'never' } ],
       settings: { 'import/resolve': { 'extensions': [ '.js', '.jsx', '.json' ] } },
@@ -111,11 +111,11 @@ ruleTester.run('extensions', rule, {
         {
             message: 'Unexpected use of file extension "js" for "./bar.js"',
             line: 1,
-            column: 17
-        }
-      ]
-    })
+            column: 17,
+        },
+      ],
+    }),
 
-  ]
+  ],
 })
 


### PR DESCRIPTION
Fixes #295 and #271. 

Actually made the rule work report on violations in spite of file resolution; it will use the source path if the file doesn't exist. I think this is probably ideal, in contrast to other rules that ignore unresolved files (in spite of my previous comments).

I also added an early exit for builtins (i.e. `path`) regardless of the options, built on @jfmengels' `importType` infrastructure. I figure even with `always` mode enabled, it should be possible to import from core modules.

Also, note that `extension` is `""` when the provided path is `null` or has no extension, thus the added `!extension` check for the extension-enforcing branch.

Feedback from @vvo, @lo1tuma, @sindresorhus, @jfmengels appreciated.