### PR TITLE
Add `newlines-between` option to `order` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Added
 - [`newline-after-import`], new rule. ([#245], thanks [@singles])
 - Added an `optionalDependencies` option to [`no-extraneous-dependencies`] to allow/forbid optional dependencies ([#266], thanks [@jfmengels]).
+- Added `newlines-between` option to [`order`] rule ([#298], thanks [@singles])
 
 ## resolvers/webpack/0.2.4 - 2016-04-29
 ### Changed

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -73,7 +73,9 @@ var path = require('path');
 
 This rule supports the following options:
 
-`groups`: How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are: `"builtin"`, `"external"`, `"internal"`, `"parent"`, `"sibling"`, `"index"`. The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
+### `groups: [array]`:
+
+How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are: `"builtin"`, `"external"`, `"internal"`, `"parent"`, `"sibling"`, `"index"`. The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
 ```js
 [
   'builtin', // Built-in types are first
@@ -89,3 +91,53 @@ You can set the options like this:
 ```js
 "import/order": ["error", {"groups": ["index", "sibling", "parent", "internal", "external", "builtin"]}]
 ```
+
+### `newlines-between: [always|never]`:
+
+
+Enforces or forbids new lines between import groups:
+
+- If omitted, assertion messages will be neither enforced nor forbidden.
+- If set to `always`, a new line between each group will be enforced, and new lines inside a group will be forbidden.
+- If set to `never`, no new lines are allowed in the entire import section.
+
+With the default group setting, the following will be invalid:
+
+```js
+/* eslint import/order: ["error", {"newlines-between": "always"}] */
+import fs from 'fs';
+import path from 'path';
+import index from './';
+import sibling from './foo';
+```
+
+```js
+/* eslint import/order: ["error", {"newlines-between": "never"}] */
+import fs from 'fs';
+import path from 'path';
+
+import index from './';
+
+import sibling from './foo';
+```
+
+while those will be valid:
+
+```js
+/* eslint import/order: ["error", {"newlines-between": "always"}] */
+import fs from 'fs';
+import path from 'path';
+
+import index from './';
+
+import sibling from './foo';
+```
+
+```js
+/* eslint import/order: ["error", {"newlines-between": "never"}] */
+import fs from 'fs';
+import path from 'path';
+import index from './';
+import sibling from './foo';
+```
+

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -160,6 +160,52 @@ ruleTester.run('order', rule, {
         var index = require('./');
       `,
     }),
+    // Option: newlines-between: 'always'
+    test({
+      code: `
+        var fs = require('fs');
+        var index = require('./');
+        var path = require('path');
+
+        var sibling = require('./foo');
+
+        var relParent1 = require('../foo');
+        var relParent3 = require('../');
+        var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling'],
+            ['parent', 'external'],
+          ],
+          'newlines-between': 'always',
+        },
+      ],
+    }),
+    // Option: newlines-between: 'never'
+    test({
+      code: `
+        var fs = require('fs');
+        var index = require('./');
+        var path = require('path');
+        var sibling = require('./foo');
+        var relParent1 = require('../foo');
+        var relParent3 = require('../');
+        var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling'],
+            ['parent', 'external'],
+          ],
+          'newlines-between': 'never',
+        },
+      ],
+    }),
   ],
   invalid: [
     // builtin before external module (require)
@@ -412,6 +458,131 @@ ruleTester.run('order', rule, {
         ruleId: 'order',
         message: '`fs` import should occur after import of `../foo/bar`',
       }],
+    }),
+    // Option newlines-between: 'never' - should report unnecessary line between groups
+    test({
+      code: `
+        var fs = require('fs');
+        var index = require('./');
+        var path = require('path');
+
+        var sibling = require('./foo');
+
+        var relParent1 = require('../foo');
+        var relParent3 = require('../');
+        var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling'],
+            ['parent', 'external'],
+          ],
+          'newlines-between': 'never',
+        },
+      ],
+      errors: [
+        {
+          line: 4,
+          message: 'There should be no empty line between import groups',
+        },
+        {
+          line: 6,
+          message: 'There should be no empty line between import groups',
+        },
+      ],
+    }),
+    // // Option newlines-between: 'always' - should report lack of newline between groups
+    test({
+      code: `
+        var fs = require('fs');
+        var index = require('./');
+        var path = require('path');
+        var sibling = require('./foo');
+        var relParent1 = require('../foo');
+        var relParent3 = require('../');
+        var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling'],
+            ['parent', 'external'],
+          ],
+          'newlines-between': 'always',
+        },
+      ],
+      errors: [
+        {
+          line: 4,
+          message: 'There should be one empty line between import groups',
+        },
+        {
+          line: 5,
+          message: 'There should be one empty line between import groups',
+        },
+      ],
+    }),
+    //Option newlines-between: 'always' should report too many empty lines between import groups
+    test({
+      code: `
+        var fs = require('fs');
+        var index = require('./');
+
+
+
+        var sibling = require('./foo');
+        var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling', 'parent', 'external']
+          ],
+          'newlines-between': 'always',
+        },
+      ],
+      errors: [
+        {
+          line: 3,
+          message: 'There should be one empty line between import groups',
+        },
+      ],
+    }),
+    //Option newlines-between: 'always' should report unnecessary empty lines space between import groups
+    test({
+      code: `
+        var fs = require('fs');
+
+        var path = require('path');
+        var index = require('./');
+
+        var sibling = require('./foo');
+
+        var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling', 'parent', 'external']
+          ],
+          'newlines-between': 'always',
+        },
+      ],
+      errors: [
+        {
+          line: 2,
+          message: 'There should be no empty line within import group',
+        },
+        {
+          line: 7,
+          message: 'There should be no empty line within import group',
+        },
+      ],
     }),
   ],
 })


### PR DESCRIPTION
Checks existence of new lines between and inside import groups.

Implements #282.