### PR TITLE
Allow the resolver to have a relative path so it can be project specific

### DIFF
--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -145,7 +145,11 @@ function resolverReducer(resolvers, map) {
 
 function requireResolver(name) {
   try {
-    return require(`eslint-import-resolver-${name}`)
+    if (path.isAbsolute(name)) {
+      return require(`eslint-import-resolver-${name}`);
+    } else {
+      return require(path.resolve(name));
+   }
   } catch (err) {
     throw new Error(`unable to load resolver "${name}".`)
   }


### PR DESCRIPTION
I've been trying to use the webpack plugin but I have too many complexities

We have 4 builds, with 4 slightly different webpack configurations - files are spread between the configurations with different aliases for each. We use NormalModuleReplacementPlugin to do some aliasing on the fly (btw I am not proud of this, I inherited it).

Its been alot easier to write a custom resolver for our project - moving code from the webpack config to a common place and referencing it from the webpack config and our resolver.

Would you accept this change? I can add documentation if needed & accepted.