### PR TITLE
Custom resolver path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Added
 - Added support for multiple webpack configs ([#181], thanks [@GreenGremlin])
+- Added support for custom resolvers ([#314] thanks [@le0nik])
 
 ## [Unreleased]
 ### Fixed
@@ -249,6 +250,7 @@ for info on changes for earlier releases.
 [#211]: https://github.com/benmosher/eslint-plugin-import/pull/211
 [#164]: https://github.com/benmosher/eslint-plugin-import/pull/164
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
+[#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
 [#328]: https://github.com/benmosher/eslint-plugin-import/issues/328
 [#317]: https://github.com/benmosher/eslint-plugin-import/issues/317
@@ -307,3 +309,4 @@ for info on changes for earlier releases.
 [@borisyankov]: https://github.com/borisyankov
 [@gavriguy]: https://github.com/gavriguy
 [@jkimbo]: https://github.com/jkimbo
+[@le0nik]: https://github.com/le0nik

--- a/README.md
+++ b/README.md
@@ -123,19 +123,77 @@ In the interest of supporting both of these, v0.11 introduces resolvers.
 Currently [Node] and [Webpack] resolution have been implemented, but the
 resolvers are just npm packages, so [third party packages are supported](https://github.com/benmosher/eslint-plugin-import/wiki/Resolvers) (and encouraged!).
 
-Just install a resolver as `eslint-import-resolver-foo` and reference it as such:
+You can reference resolvers in several ways(in order of precedence):
 
+1. With an absolute path to resolver, used as a `computed property` name, which is supported since Node v4:
+
+`.eslintrc.js`:
+```js
+{
+  settings: {
+    'import/resolver': {
+      [path.resolve('../../../my-resolver')]: { someConfig: value }
+    }
+  }
+}
+```
+
+2. With a path relative to the closest `package.json` file:
+
+
+`.eslintrc.js`:
+```js
+{
+  settings: {
+    'import/resolver': {
+      './my-resolver': { someConfig: value }
+    }
+  }
+}
+```
+
+`.eslintrc.yml`:
+```yaml
+settings:
+  import/resolver: './my-resolver'
+```
+
+3. With an npm module name, like `my-awesome-npm-module`:
+
+`.eslintrc.js`:
+```js
+{
+  settings: {
+    'import/resolver': {
+      'my-awesome-npm-module': { someConfig: value }
+    }
+  }
+}
+```
+
+`.eslintrc.yml`:
+```yaml
+settings:
+  import/resolver: 'my-awesome-npm-module'
+```
+
+4. As a conventional `eslint-import-resolver` name, like `eslint-import-resolver-foo`:
+
+`.eslintrc.js`:
+```js
+{
+  settings: {
+    'import/resolver': {
+      foo: { someConfig: value }
+    }
+  }
+}
+```
+
+`.eslintrc.yml`:
 ```yaml
 settings:
   import/resolver: foo
-```
-
-or with a config object:
-
-```yaml
-settings:
-  import/resolver:
-    foo: { someConfigKey: value }
 ```
 
 If you are interesting in writing a resolver, see the [spec](./resolvers/README.md) for more details.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "es6-symbol": "*",
     "eslint-import-resolver-node": "^0.2.0",
     "find-root": "^1.0.0",
+    "is-absolute": "^0.2.5",
     "lodash.cond": "^4.3.0",
     "lodash.endswith": "^4.0.1",
     "lodash.find": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "gulp-mocha": "^2.2.0",
     "istanbul": "^0.4.0",
     "mocha": "^2.2.1",
+    "pkg-dir": "^1.0.0",
     "redux": "^3.0.4",
     "rimraf": "2.5.2"
   },
@@ -71,7 +72,6 @@
     "es6-set": "^0.1.4",
     "es6-symbol": "*",
     "eslint-import-resolver-node": "^0.2.0",
-    "find-root": "^1.0.0",
     "is-absolute": "^0.2.5",
     "lodash.cond": "^4.3.0",
     "lodash.endswith": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "es6-set": "^0.1.4",
     "es6-symbol": "*",
     "eslint-import-resolver-node": "^0.2.0",
+    "find-root": "^1.0.0",
     "lodash.cond": "^4.3.0",
     "lodash.endswith": "^4.0.1",
     "lodash.find": "^4.3.0",

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -145,7 +145,18 @@ function resolverReducer(resolvers, map) {
 
 function requireResolver(name) {
   try {
-    return require(`eslint-import-resolver-${name}`)
+    // Try to resolve package with absolute path (/Volumes/....)
+    if (path.isAbsolute(name)) {
+      return require(path.resolve(name));
+    }
+
+    try {
+      // Try to resolve package with custom name (@myorg/resolver-name)
+      return require(name)
+    } catch (err) {
+      // Try to resolve package with conventional name
+      return require(`eslint-import-resolver-${name}`)
+    }
   } catch (err) {
     throw new Error(`unable to load resolver "${name}".`)
   }

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -163,9 +163,7 @@ function requireResolver(name, modulePath) {
       try {
         // Try to resolve package with custom name (@myorg/resolver-name)
         return require(name)
-        /* eslint-disable no-shadow */
-      } catch (err) {
-        /* eslint-enable no-shadow */
+      } catch (err) { // eslint-disable-line no-shadow
 
         // Try to resolve package with conventional name
         return require(`eslint-import-resolver-${name}`)

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -147,8 +147,8 @@ function resolverReducer(resolvers, map) {
 function requireResolver(name, modulePath) {
   try {
     // Try to resolve package with absolute path (/Volumes/....)
-    if (path.isAbsolute(name)) {
-      return require(path.resolve(name));
+    if (isAbsolute(name)) {
+      return require(name)
     }
 
     try {

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -2,7 +2,7 @@ import 'es6-symbol/implement'
 import Map from 'es6-map'
 import Set from 'es6-set'
 import assign from 'object-assign'
-import findRoot from 'find-root'
+import pkgDir from 'pkg-dir'
 import isAbsoluteFallback from 'is-absolute'
 
 import fs from 'fs'
@@ -57,7 +57,6 @@ function fileExistsWithCaseSync(filepath, cacheSettings) {
 }
 
 export function relative(modulePath, sourceFile, settings) {
-
   const sourceDir = dirname(sourceFile)
       , cacheKey = sourceDir + hashObject(settings) + modulePath
 
@@ -83,10 +82,10 @@ export function relative(modulePath, sourceFile, settings) {
     function v1() {
       try {
         const path = resolver.resolveImport(modulePath, sourceFile, config)
-        if (path === undefined) return { found: false }
-        return { found: true, path }
+        if (path === undefined) return { found: false, path: null }
+        return { found: true, path: null }
       } catch (err) {
-        return { found: false }
+        return { found: false, path: null }
       }
     }
 
@@ -156,7 +155,7 @@ function requireResolver(name, modulePath) {
 
     try {
       // Try to resolve package with path, relative to closest package.json
-      const packageDir = findRoot(resolve(modulePath))
+      const packageDir = pkgDir.sync(resolve(modulePath))
 
       return require(join(packageDir, name))
     } catch (err) {

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -2,10 +2,13 @@ import 'es6-symbol/implement'
 import Map from 'es6-map'
 import Set from 'es6-set'
 import assign from 'object-assign'
-import findRoot from 'find-root';
+import findRoot from 'find-root'
+import isAbsoluteFallback from 'is-absolute'
 
 import fs from 'fs'
-import { dirname, basename, join } from 'path'
+import { dirname, basename, join, isAbsolute as isAbsoluteNode } from 'path'
+
+const isAbsolute = isAbsoluteNode || isAbsoluteFallback
 
 export const CASE_SENSITIVE_FS = !fs.existsSync(join(__dirname, 'reSOLVE.js'))
 
@@ -153,14 +156,17 @@ function requireResolver(name, modulePath) {
 
     try {
       // Try to resolve package with path, relative to closest package.json
-      const packageDir = findRoot(path.resolve(modulePath));
+      const packageDir = findRoot(resolve(modulePath))
 
-      return require(path.join(packageDir, name));
+      return require(join(packageDir, name))
     } catch (err) {
       try {
         // Try to resolve package with custom name (@myorg/resolver-name)
-        return require(name);
+        return require(name)
+        /* eslint-disable no-shadow */
       } catch (err) {
+        /* eslint-enable no-shadow */
+
         // Try to resolve package with conventional name
         return require(`eslint-import-resolver-${name}`)
       }


### PR DESCRIPTION
With this PR users will be able to require resolvers:

1) With absolute paths (`/Volumes/...`, user can include them as computed property in `.eslintrc.js` config)
2) With paths, relative to closest package.json (`./eslint-plugins/webpack-resolver`)
3) With custom npm modules names (`@myorg/webpack-resolver`)
4) With conventional npm modules names (`webpack` -> `eslint-import-resolver-webpack`)