### PR TITLE
Add support for Webpack 2 renamed modules key

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -129,6 +129,7 @@ exports.resolve = function (source, file, settings) {
 
       // http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories
       moduleDirectory: get(webpackConfig, ['resolve', 'modulesDirectories'])
+        || get(webpackConfig, ['resolve', 'modules']) // Webpack >= 2
         || ['web_modules', 'node_modules'],
 
       paths: paths,


### PR DESCRIPTION
Hi,

just wanted to start the ball rolling, there most likely will be more work needed to fully support Webpack 2, but that very simple addition is already doing it for me on a project with custom import paths.

Rough changelog: https://gist.github.com/sokra/27b24881210b56bbaff7#resolving-options

If you feel that's okay for a start, I'll update the tests ?


Refs #265