### PR TITLE
Add plugins support for webpack resolver

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -143,7 +143,7 @@ exports.resolve = function (source, file, settings) {
 
   if (Array.isArray(settings.plugins)) {
     resolveOptions = settings.plugins.reduce((currentResolveOptions, plugin) => (
-      plugin(currentResolveOptions)
+      plugin(currentResolveOptions) || currentResolveOptions
     ), resolveOptions)
   }
 

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -123,21 +123,6 @@ exports.resolve = function (source, file, settings) {
     info: {
       originalSource, // original source
       rawSource, // source with stripped loader(same as source, if there wasn't one)
-      webpackConfig,
-    },
-    path: {
-      basedir: path.dirname(file),
-
-      // defined via http://webpack.github.io/docs/configuration.html#resolve-extensions
-      extensions: get(webpackConfig, ['resolve', 'extensions'])
-        || ['', '.webpack.js', '.web.js', '.js'],
-
-      // http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories
-      moduleDirectory: get(webpackConfig, ['resolve', 'modulesDirectories'])
-        || ['web_modules', 'node_modules'],
-
-      paths: paths,
-      packageFilter: packageFilter.bind(null, webpackConfig),
     },
   }
 
@@ -150,7 +135,20 @@ exports.resolve = function (source, file, settings) {
   // otherwise, resolve "normally"
   try {
 
-    return { found: true, path: resolve.sync(resolveOptions.source, resolveOptions.path) }
+    return { found: true, path: resolve.sync(resolveOptions.source, {
+      basedir: path.dirname(file),
+
+      // defined via http://webpack.github.io/docs/configuration.html#resolve-extensions
+      extensions: get(webpackConfig, ['resolve', 'extensions'])
+      || ['', '.webpack.js', '.web.js', '.js'],
+
+      // http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories
+      moduleDirectory: get(webpackConfig, ['resolve', 'modulesDirectories'])
+      || ['web_modules', 'node_modules'],
+
+      paths: paths,
+      packageFilter: packageFilter.bind(null, webpackConfig),
+    }) }
   } catch (err) {
     return { found: false }
   }

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -118,18 +118,23 @@ exports.resolve = function (source, file, settings) {
     else paths.push.apply(paths, fallbackPath)
   }
 
-  let resolveOptions = {
-    source, // source, after resolving alias
+  var resolveOptions = {
+    source: source, // source, after resolving alias
     info: {
-      originalSource, // original source
-      rawSource, // source with stripped loader(same as source, if there wasn't one)
+      originalSource: originalSource, // original source
+      rawSource: rawSource, // source with stripped loader(same as source, if there wasn't one)
     },
   }
 
-  if (Array.isArray(settings.plugins)) {
-    resolveOptions = settings.plugins.reduce((currentResolveOptions, plugin) => (
-      plugin(currentResolveOptions) || currentResolveOptions
-    ), resolveOptions)
+  if (Array.isArray(get(settings, 'plugins'))) {
+    resolveOptions = settings.plugins.reduce(function pluginsReducer(currentResolveOptions, plugin) {
+      if (typeof plugin !== 'function') {
+        return currentResolveOptions
+      }
+
+      return plugin(currentResolveOptions)
+        || currentResolveOptions // allow user to mutate resolveOptions without returning it
+    }, resolveOptions)
   }
 
   // otherwise, resolve "normally"
@@ -140,11 +145,11 @@ exports.resolve = function (source, file, settings) {
 
       // defined via http://webpack.github.io/docs/configuration.html#resolve-extensions
       extensions: get(webpackConfig, ['resolve', 'extensions'])
-      || ['', '.webpack.js', '.web.js', '.js'],
+        || ['', '.webpack.js', '.web.js', '.js'],
 
       // http://webpack.github.io/docs/configuration.html#resolve-modulesdirectories
       moduleDirectory: get(webpackConfig, ['resolve', 'modulesDirectories'])
-      || ['web_modules', 'node_modules'],
+        || ['web_modules', 'node_modules'],
 
       paths: paths,
       packageFilter: packageFilter.bind(null, webpackConfig),


### PR DESCRIPTION
In my project, i use webpack plugin, that modifies path. I'm sure, that so do many other webpack users. For now I have to fork the webpack resolver and apply the plugins inside the `resolve` function.

This PR offers an extension point for users to apply plugins. I don't think it's possible at this point to apply plugins automatically, so user will have to do it manually for now. Here's how that would work:

in `webpack.config.js`
```js
module.exports = {
  ...,
  plugins: [
    new NormalModuleReplacementPlugin(/\/app\//, '/newApp/')
  ]
};
```

in `.eslintrc.js`
```js
module.exports = {
    settings: {

      'import/resolver': {

        webpack: {
          config: './webpack.config.js',
          plugins: [
             (source, { originalSource, rawSource }) => {
               if (/\/app\//.test(source)) {
                 source = source.replace(/\/app\//, '/newApp/');
               }
             }
          ]
        }

      }
    }
};
```

The user is expected to mutate `source` and/or `path` object.
Each plugin receives 2 arguments:

- `source` - is the path to the imported file so far(after resolving `alias` and previous plugins in array)
- `info` is an object with two properties:
  - `originalSource` - is the original path to file, as seen in the `import/require` statement itself
  - `rawSource` - is the same as originalSource, but with loader stripped out

There should be a way for the user to share the plugin options(like `resourceRegExp` and replacer function) between the eslint in webpack configs, but I haven't figured out the best way to do it yet.

Feedback is welcomed!

TODO:

- [ ] Add Documentation