### PR TITLE
`no-mutable-exports`: Handle ES7 export extensions. Fixes #317

### DIFF
--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -31,7 +31,7 @@ module.exports = function (context) {
 
     if (node.declaration)  {
       checkDeclaration(node.declaration)
-    } else {
+    } else if (!node.source) {
       for (let specifier of node.specifiers) {
         checkDeclarationsInScope(scope, specifier.local.name)
       }

--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -24,6 +24,10 @@ ruleTester.run('no-mutable-exports', rule, {
     test({ code: 'class Counter {}\nexport { Counter as Count }'}),
     test({ code: 'class Counter {}\nexport default Counter'}),
     test({ code: 'class Counter {}\nexport { Counter as default }'}),
+    test({
+      parser: 'babel-eslint',
+      code: 'export Something from "./something";',
+    }),
   ],
   invalid: [
     test({


### PR DESCRIPTION
`no-mutable-exports`: Handle ES7 export extensions. Fixes #317 :)