### PR TITLE
Fix newline-after-import rule for require

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lodash.cond": "^4.3.0",
     "lodash.endswith": "^4.0.1",
     "lodash.find": "^4.3.0",
+    "lodash.findindex": "^4.3.0",
     "object-assign": "^4.0.1",
     "pkg-up": "^1.0.0"
   }

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -7,6 +7,20 @@ const ruleTester = new RuleTester()
 
 ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
   valid: [
+    "var path = require('path');\nvar foo = require('foo');\n",
+    "a(require('b'), require('c'), require('d'));",
+    {
+      code: "import path from 'path';\nimport foo from 'foo';\n",
+      parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: "import path from 'path';import foo from 'foo';\n",
+      parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: "import path from 'path';import foo from 'foo';\n\nvar bar = 42;",
+      parserOptions: { sourceType: 'module' },
+    },
     {
       code: "import foo from 'foo';\n\nvar foo = 'bar';",
       parserOptions: { sourceType: 'module' }
@@ -37,7 +51,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
     {
       code: "import foo from 'foo';\nexport default function() {};",
       errors: [ {
-        line: 2,
+        line: 1,
         column: 1,
         message: IMPORT_ERROR_MESSAGE
       } ],
@@ -46,7 +60,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
     {
       code: "var foo = require('foo-module');\nvar something = 123;",
       errors: [ {
-        line: 2,
+        line: 1,
         column: 1,
         message: REQUIRE_ERROR_MESSAGE
       } ],
@@ -56,12 +70,12 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       code: "import foo from 'foo';\nvar a = 123;\n\nimport { bar } from './bar-lib';\nvar b=456;",
       errors: [
       {
-        line: 2,
+        line: 1,
         column: 1,
         message: IMPORT_ERROR_MESSAGE
       },
       {
-        line: 5,
+        line: 4,
         column: 1,
         message: IMPORT_ERROR_MESSAGE
       }],
@@ -71,12 +85,12 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       code: "var foo = require('foo-module');\nvar a = 123;\n\nvar bar = require('bar-lib');\nvar b=456;",
       errors: [
         {
-          line: 2,
+          line: 1,
           column: 1,
           message: REQUIRE_ERROR_MESSAGE
         },
         {
-          line: 5,
+          line: 4,
           column: 1,
           message: REQUIRE_ERROR_MESSAGE
         }],
@@ -86,16 +100,78 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       code: "var foo = require('foo-module');\nvar a = 123;\n\nrequire('bar-lib');\nvar b=456;",
       errors: [
         {
-          line: 2,
+          line: 1,
           column: 1,
           message: REQUIRE_ERROR_MESSAGE
         },
         {
-          line: 5,
+          line: 4,
           column: 1,
           message: REQUIRE_ERROR_MESSAGE
         }],
       parserOptions: { sourceType: 'module' }
     },
+    {
+      code: "var path = require('path');\nvar foo = require('foo');\nvar bar = 42;",
+      errors: [ {
+        line: 2,
+        column: 1,
+        message: REQUIRE_ERROR_MESSAGE,
+      } ]
+    },
+    {
+      code: "var assign = Object.assign || require('object-assign');\nvar foo = require('foo');\nvar bar = 42;",
+      errors: [ {
+        line: 2,
+        column: 1,
+        message: REQUIRE_ERROR_MESSAGE,
+      } ]
+    },
+    {
+      code: "function a() {\nvar assign = Object.assign || require('object-assign');\nvar foo = require('foo');\nvar bar = 42; }",
+      errors: [ {
+        line: 3,
+        column: 1,
+        message: REQUIRE_ERROR_MESSAGE,
+      } ]
+    },
+    {
+      code: "require('a');\nfoo(require('b'), require('c'), require('d'));\nrequire('d');\nvar foo = 'bar';",
+      errors: [
+        {
+          line: 3,
+          column: 1,
+          message: REQUIRE_ERROR_MESSAGE
+        },
+      ]
+    },
+    {
+      code: "require('a');\nfoo(\nrequire('b'),\nrequire('c'),\nrequire('d')\n);\nvar foo = 'bar';",
+      errors: [
+        {
+          line: 6,
+          column: 1,
+          message: REQUIRE_ERROR_MESSAGE
+        }
+      ]
+    },
+    {
+      code: "import path from 'path';\nimport foo from 'foo';\nvar bar = 42;",
+      errors: [ {
+        line: 2,
+        column: 1,
+        message: IMPORT_ERROR_MESSAGE,
+      } ],
+      parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: "import path from 'path';import foo from 'foo';var bar = 42;",
+      errors: [ {
+        line: 1,
+        column: 25,
+        message: IMPORT_ERROR_MESSAGE,
+      } ],
+      parserOptions: { sourceType: 'module' },
+    },
   ]
-});
+})


### PR DESCRIPTION
This PR fixes #318.

Actually I’m not convinced that this rule really makes sense for commonjs, there are just too many edge-cases and no way to say which to exclude from this rule, e.g. the following:

```js
require('a');
foo(require('b'), require('c'), require('d'));
var assign = Object.assign || require('object-assign');
const nightwatchConfig = { seleniumPath: require('selenium-standalone').path };
```

I’ve tried my best to handle those cases.