### PR TITLE
Fix `order`s `newline-between` for multiline imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - Ignore namespace / ES7 re-exports in [`no-mutable-exports`]. ([#317], fixed by [#322]. thanks [@borisyankov] + [@jfmengels])
 - Make [`no-extraneous-dependencies`] handle scoped packages ([#316], thanks [@jfmengels])
+- Make [`order`]'s `newline-between` option handle multiline import statements ([#313], thanks [@singles])
 
 ## [1.7.0] - 2016-05-06
 ### Added

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -111,7 +111,7 @@ function convertGroupsToRanks(groups) {
 
 function makeNewlinesBetweenReport (context, imported, newlinesBetweenImports) {
   const getLineDifference = (currentImport, previousImport) => {
-    return currentImport.node.loc.start.line - previousImport.node.loc.start.line
+    return currentImport.node.loc.start.line - previousImport.node.loc.end.line
   }
   let previousImport = imported[0]
 

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -206,6 +206,44 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+    // Option newlines-between: 'never' with multiline imports #1
+    test({
+      code: `
+        import path from 'path';
+
+        import {
+            I,
+            Want,
+            Couple,
+            Imports,
+            Here
+        } from 'bar';
+        import external from 'external'
+      `,
+      options: [{ 'newlines-between': 'always' }]
+    }),
+    // Option newlines-between: 'always' with multiline imports #2
+    test({
+      code: `
+        import path from 'path';
+        import net
+          from 'net';
+
+        import external from 'external'
+      `,
+      options: [{ 'newlines-between': 'always' }]
+    }),
+    // Option newlines-between: 'always' with multiline imports #3
+    test({
+      code: `
+        import foo
+          from '../../../../this/will/be/very/long/path/and/therefore/this/import/has/to/be/in/two/lines';
+
+        import bar
+          from './sibling';
+      `,
+      options: [{ 'newlines-between': 'always' }]
+    }),
   ],
   invalid: [
     // builtin before external module (require)


### PR DESCRIPTION
Partly-fixes #313.