### PR TITLE
fix #328: properly suppress `default` when looking at * exports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
+## [Unreleased]
+### Fixed
+- `export * from 'foo'` now properly ignores a `default` export from `foo`, if any. ([#328]/[#332], thanks [@jkimbo])
+  This impacts all static analysis of imported names. ([`default`], [`named`], [`namespace`], [`export`])
+
 ## [1.8.0] - 2016-05-11
 ### Added
 - [`prefer-default-export`], new rule. ([#308], thanks [@gavriguy])
@@ -206,10 +211,13 @@ for info on changes for earlier releases.
 [`no-nodejs-modules`]: ./docs/rules/no-nodejs-modules.md
 [`order`]: ./docs/rules/order.md
 [`named`]: ./docs/rules/named.md
+[`default`]: ./docs/rules/default.md
+[`export`]: ./docs/rules/export.md
 [`newline-after-import`]: ./docs/rules/newline-after-import.md
 [`no-mutable-exports`]: ./docs/rules/no-mutable-exports.md
 [`prefer-default-export`]: ./docs/rules/prefer-default-export.md
 
+[#332]: https://github.com/benmosher/eslint-plugin-import/pull/332
 [#322]: https://github.com/benmosher/eslint-plugin-import/pull/322
 [#316]: https://github.com/benmosher/eslint-plugin-import/pull/316
 [#308]: https://github.com/benmosher/eslint-plugin-import/pull/308
@@ -235,6 +243,7 @@ for info on changes for earlier releases.
 [#164]: https://github.com/benmosher/eslint-plugin-import/pull/164
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 
+[#328]: https://github.com/benmosher/eslint-plugin-import/issues/328
 [#317]: https://github.com/benmosher/eslint-plugin-import/issues/317
 [#286]: https://github.com/benmosher/eslint-plugin-import/issues/286
 [#281]: https://github.com/benmosher/eslint-plugin-import/issues/281
@@ -290,3 +299,4 @@ for info on changes for earlier releases.
 [@josh]: https://github.com/josh
 [@borisyankov]: https://github.com/borisyankov
 [@gavriguy]: https://github.com/gavriguy
+[@jkimbo]: https://github.com/jkimbo

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -228,7 +228,8 @@ export default class ExportMap {
     if (this.namespace.has(name)) return true
     if (this.reexports.has(name)) return true
 
-    for (let dep of this.dependencies.values()) {
+    // default exports must be explicitly re-exported (#328)
+    if (name !== 'default') for (let dep of this.dependencies.values()) {
       let innerMap = dep()
 
       // todo: report as unresolved?
@@ -264,7 +265,9 @@ export default class ExportMap {
       return deep
     }
 
-    for (let dep of this.dependencies.values()) {
+
+    // default exports must be explicitly re-exported (#328)
+    if (name !== 'default') for (let dep of this.dependencies.values()) {
       let innerMap = dep()
       // todo: report as unresolved?
       if (!innerMap) continue
@@ -298,7 +301,8 @@ export default class ExportMap {
       return imported.get(local)
     }
 
-    for (let dep of this.dependencies.values()) {
+    // default exports must be explicitly re-exported (#328)
+    if (name !== 'default') for (let dep of this.dependencies.values()) {
       let innerMap = dep()
       // todo: report as unresolved?
       if (!innerMap) continue
@@ -321,7 +325,7 @@ export default class ExportMap {
       callback.call(thisArg, getImport().get(local), name, this))
 
     this.dependencies.forEach(dep => dep().forEach((v, n) =>
-      callback.call(thisArg, v, n, this)))
+      n !== 'default' && callback.call(thisArg, v, n, this)))
   }
 
   // todo: keys, values, entries?

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -229,13 +229,15 @@ export default class ExportMap {
     if (this.reexports.has(name)) return true
 
     // default exports must be explicitly re-exported (#328)
-    if (name !== 'default') for (let dep of this.dependencies.values()) {
-      let innerMap = dep()
+    if (name !== 'default') {
+      for (let dep of this.dependencies.values()) {
+        let innerMap = dep()
 
-      // todo: report as unresolved?
-      if (!innerMap) continue
+        // todo: report as unresolved?
+        if (!innerMap) continue
 
-      if (innerMap.has(name)) return true
+        if (innerMap.has(name)) return true
+      }
     }
 
     return false
@@ -267,18 +269,20 @@ export default class ExportMap {
 
 
     // default exports must be explicitly re-exported (#328)
-    if (name !== 'default') for (let dep of this.dependencies.values()) {
-      let innerMap = dep()
-      // todo: report as unresolved?
-      if (!innerMap) continue
+    if (name !== 'default') {
+      for (let dep of this.dependencies.values()) {
+        let innerMap = dep()
+        // todo: report as unresolved?
+        if (!innerMap) continue
 
-      // safeguard against cycles
-      if (innerMap.path === this.path) continue
+        // safeguard against cycles
+        if (innerMap.path === this.path) continue
 
-      let innerValue = innerMap.hasDeep(name)
-      if (innerValue.found) {
-        innerValue.path.unshift(this)
-        return innerValue
+        let innerValue = innerMap.hasDeep(name)
+        if (innerValue.found) {
+          innerValue.path.unshift(this)
+          return innerValue
+        }
       }
     }
 
@@ -302,16 +306,18 @@ export default class ExportMap {
     }
 
     // default exports must be explicitly re-exported (#328)
-    if (name !== 'default') for (let dep of this.dependencies.values()) {
-      let innerMap = dep()
-      // todo: report as unresolved?
-      if (!innerMap) continue
+    if (name !== 'default') {
+      for (let dep of this.dependencies.values()) {
+        let innerMap = dep()
+        // todo: report as unresolved?
+        if (!innerMap) continue
 
-      // safeguard against cycles
-      if (innerMap.path === this.path) continue
+        // safeguard against cycles
+        if (innerMap.path === this.path) continue
 
-      let innerValue = innerMap.get(name)
-      if (innerValue !== undefined) return innerValue
+        let innerValue = innerMap.get(name)
+        if (innerValue !== undefined) return innerValue
+      }
     }
 
     return undefined

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -50,7 +50,7 @@ module.exports = function (context) {
         return
       }
       let any = false
-      remoteExports.forEach((v, name) => (any = true) && addNamed(name, node))
+      remoteExports.forEach((v, name) => name !== 'default' && (any = true) && addNamed(name, node))
 
       if (!any) {
         context.report(node.source,

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -50,7 +50,10 @@ module.exports = function (context) {
         return
       }
       let any = false
-      remoteExports.forEach((v, name) => name !== 'default' && (any = true) && addNamed(name, node))
+      remoteExports.forEach((v, name) =>
+        name !== 'default' &&
+        (any = true) && // poor man's filter
+        addNamed(name, node))
 
       if (!any) {
         context.report(node.source,

--- a/tests/files/deep-es7/b.js
+++ b/tests/files/deep-es7/b.js
@@ -1,1 +1,2 @@
 export * as c from './c'
+export default 'b'

--- a/tests/files/deep/b.js
+++ b/tests/files/deep/b.js
@@ -1,2 +1,3 @@
 import * as c from './c'
 export { c }
+export default 'b'

--- a/tests/files/re-export.js
+++ b/tests/files/re-export.js
@@ -1,3 +1,6 @@
 export const c = 'foo'
 
 export * from './named-exports'
+
+// #328: this exports only 'foo', not the default.
+export * from './bar'

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -115,5 +115,11 @@ ruleTester.run('default', rule, {
       parser: 'babel-eslint',
       errors: ['No default export found in module.'],
     }),
+
+    // #328: * exports do not include default
+    test({
+      code: 'import barDefault from "./re-export"',
+      errors: [`No default export found in module.`],
+    }),
   ],
 })

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -21,16 +21,15 @@ ruleTester.run('export', rule, {
     test({ code: 'export { bar }; export * from "./export-all"' }),
     test({ code: 'export * from "./export-all"' }),
     test({ code: 'export * from "./does-not-exist"' }),
+
+    // #328: "export * from" does not export a default
+    test({ code: 'export default foo; export * from "./bar"' }),
   ],
 
   invalid: [
     // multiple defaults
     test({
       code: 'export default foo; export default bar',
-      errors: ['Multiple default exports.', 'Multiple default exports.'],
-    }),
-    test({
-      code: 'export default foo; export * from "./default-export"',
       errors: ['Multiple default exports.', 'Multiple default exports.'],
     }),
     test({
@@ -99,5 +98,11 @@ ruleTester.run('export', rule, {
                'Multiple exports of name \'bar\'.'],
     }),
 
+
+    // #328: "export * from" does not export a default
+    test({
+      code: 'export * from "./default-export"',
+      errors: [`No named exports found in module './default-export'.`],
+    }),
   ],
 })

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -217,5 +217,11 @@ ruleTester.run('named', rule, {
       // todo: better error message
       errors: ["common not found via re-export-default.js -> common.js"],
     }),
+
+    // #328: * exports do not include default
+    test({
+      code: 'import { default as barDefault } from "./re-export"',
+      errors: [`default not found in './re-export'`],
+    }),
   ],
 })

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -77,6 +77,7 @@ const valid = [
 
   // names.default is valid export
   test({ code: "import * as names from './default-export';" }),
+  test({ code: "import * as names from './default-export'; console.log(names.default)" }),
   test({
    code: 'export * as names from "./default-export"',
    parser: 'babel-eslint',
@@ -164,6 +165,12 @@ const invalid = [
     errors: [error('c', 'names')],
   }),
 
+  // #328: * exports do not include default
+  test({
+    code: 'import * as ree from "./re-export"; console.log(ree.default)',
+    errors: [`'default' not found in imported namespace 'ree'.`],
+  }),
+
 ]
 
 ///////////////////////
@@ -176,6 +183,9 @@ const invalid = [
     test({ parser, code: `import * as a from "./${folder}/a"; console.log(a.b.c.d.e.f)` }),
     test({ parser, code: `import * as a from "./${folder}/a"; var {b:{c:{d:{e}}}} = a` }),
     test({ parser, code: `import { b } from "./${folder}/a"; var {c:{d:{e}}} = b` }))
+
+    // deep namespaces should include explicitly exported defaults
+    test({ parser, code: `import * as a from "./${folder}/a"; console.log(a.b.default)` }),
 
   invalid.push(
     test({


### PR DESCRIPTION
Supersedes #331, handles `export * from '...'` suppression of `default` in all static analysis rules.

cc @jkimbo