### PR TITLE
Check duplicates for normal imports and flow type imports separately

### DIFF
--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -4,28 +4,35 @@ import Set from 'es6-set'
 
 import resolve from '../core/resolve'
 
+function checkImports(imported, context) {
+  for (let [module, nodes] of imported.entries()) {
+    if (nodes.size > 1) {
+      for (let node of nodes) {
+        context.report(node, `'${module}' imported multiple times.`)
+      }
+    }
+  }
+}
+
 module.exports = function (context) {
   const imported = new Map()
+  const typesImported = new Map()
   return {
     'ImportDeclaration': function (n) {
       // resolved path will cover aliased duplicates
-      let resolvedPath = resolve(n.source.value, context) || n.source.value
+      const resolvedPath = resolve(n.source.value, context) || n.source.value
+      const importMap = n.importKind === 'type' ? typesImported : imported
 
-      if (imported.has(resolvedPath)) {
-        imported.get(resolvedPath).add(n.source)
+      if (importMap.has(resolvedPath)) {
+        importMap.get(resolvedPath).add(n.source)
       } else {
-        imported.set(resolvedPath, new Set([n.source]))
+        importMap.set(resolvedPath, new Set([n.source]))
       }
     },
 
     'Program:exit': function () {
-      for (let [module, nodes] of imported.entries()) {
-        if (nodes.size > 1) {
-          for (let node of nodes) {
-            context.report(node, `'${module}' imported multiple times.`)
-          }
-        }
-      }
+      checkImports(imported, context)
+      checkImports(typesImported, context)
     },
   }
 }

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -15,6 +15,12 @@ ruleTester.run('no-duplicates', rule, {
     // #86: every unresolved module should not show up as 'null' and duplicate
     test({ code: 'import foo from "234artaf";' +
                  'import { shoop } from "234q25ad"' }),
+
+    // #225: ignore duplicate if is a flow type import
+    test({
+      code: "import { x } from './foo'; import type { y } from './foo'",
+      parser: 'babel-eslint',
+    }),
   ],
   invalid: [
     test({
@@ -44,6 +50,12 @@ ruleTester.run('no-duplicates', rule, {
         "'non-existent' imported multiple times.",
         "'non-existent' imported multiple times.",
       ],
+    }),
+
+    test({
+      code: "import type { x } from './foo'; import type { y } from './foo'",
+      parser: 'babel-eslint',
+      errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
     }),
   ],
 })


### PR DESCRIPTION
Fix #225

If import is a flow `type` import, add to separate map for duplicate checking.