### PR TITLE
Adding handling for multiple Webpack configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- Added support for multiple webpack configs ([#181], thanks [@GreenGremlin])
+
+## [Unreleased]
 ### Fixed
 - `export * from 'foo'` now properly ignores a `default` export from `foo`, if any. ([#328]/[#332], thanks [@jkimbo])
   This impacts all static analysis of imported names. ([`default`], [`named`], [`namespace`], [`export`])

--- a/resolvers/webpack/README.md
+++ b/resolvers/webpack/README.md
@@ -25,7 +25,8 @@ or with explicit config file name:
 ---
 settings:
   import/resolver:
-    webpack: { config: 'webpack.dev.config.js' }
+    webpack:
+      config: 'webpack.dev.config.js'
 ```
 
 or with explicit config file name:
@@ -34,6 +35,7 @@ or with explicit config file name:
 ---
 settings:
   import/resolver:
-    webpack: { config: 'webpack.multiple.config.js' }
-    config-index: 1
+    webpack:
+      config: 'webpack.multiple.config.js'
+      config-index: 1   # take the config at index 1
 ```

--- a/resolvers/webpack/README.md
+++ b/resolvers/webpack/README.md
@@ -11,6 +11,8 @@ Will look for `webpack.config.js` as a sibling of the first ancestral `package.j
 or a `config` parameter may be provided with another filename/path either relative to the
 `package.json`, or a complete, absolute path.
 
+If multiple webpack configurations are found the first configuration containing a resolve section will be used. Optionally, the `config-index` (zero-based) setting can be used to select a specific configuration.
+
 ```yaml
 ---
 settings:
@@ -24,4 +26,14 @@ or with explicit config file name:
 settings:
   import/resolver:
     webpack: { config: 'webpack.dev.config.js' }
+```
+
+or with explicit config file name:
+
+```yaml
+---
+settings:
+  import/resolver:
+    webpack: { config: 'webpack.multiple.config.js' }
+    config-index: 1
 ```

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -40,6 +40,7 @@ exports.resolve = function (source, file, settings) {
 
   try {
     var configPath = get(settings, 'config')
+      , configIndex = get(settings, 'config-index')
       , packageDir
       , extension
 
@@ -94,9 +95,14 @@ exports.resolve = function (source, file, settings) {
   }
 
   if (Array.isArray(webpackConfig)) {
-    webpackConfig = find(webpackConfig, function findFirstWithResolve(config) {
-      return !!config.resolve;
-    });
+    if (typeof configIndex !== 'undefined' && webpackConfig.length > configIndex) {
+      webpackConfig = webpackConfig[configIndex]
+    }
+    else {
+      webpackConfig = find(webpackConfig, function findFirstWithResolve(config) {
+        return !!config.resolve
+      })
+    }
   }
 
   // externals

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -93,6 +93,12 @@ exports.resolve = function (source, file, settings) {
     webpackConfig = {}
   }
 
+  if (Array.isArray(webpackConfig)) {
+    webpackConfig = find(webpackConfig, function findFirstWithResolve(config) {
+      return !!config.resolve;
+    });
+  }
+
   // externals
   if (findExternal(source, webpackConfig.externals)) return { found: true, path: null }
 

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -37,7 +37,7 @@ describe("config", function () {
       .and.equal(path.join(__dirname, 'config-extensions', 'src', 'main-module.js'))
   })
 
-  it.only("finds the first config with a resolve section", function () {
+  it("finds the first config with a resolve section", function () {
     var settings = {
       config: path.join(__dirname, './files/webpack.config.multiple.js'),
     }

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -36,4 +36,14 @@ describe("config", function () {
       .to.have.property('path')
       .and.equal(path.join(__dirname, 'config-extensions', 'src', 'main-module.js'))
   })
+
+  it("finds the first config with a resolve section", function () {
+    var settings = {
+      config: path.join(__dirname, './files/webpack.config.multiple.js'),
+    }
+
+    expect(resolve('main-module', file, settings))
+      .to.have.property('resolve')
+      .and.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
+  })
 })

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -45,4 +45,14 @@ describe("config", function () {
     expect(resolve('main-module', file, settings)).to.have.property('path')
         .and.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
   })
+
+  it("finds the config at option config-index", function () {
+    var settings = {
+      config: path.join(__dirname, './files/webpack.config.multiple.js'),
+      'config-index': 2,
+    }
+
+    expect(resolve('foo', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'some', 'goofy', 'path', 'foo.js'))
+  })
 })

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -37,13 +37,12 @@ describe("config", function () {
       .and.equal(path.join(__dirname, 'config-extensions', 'src', 'main-module.js'))
   })
 
-  it("finds the first config with a resolve section", function () {
+  it.only("finds the first config with a resolve section", function () {
     var settings = {
       config: path.join(__dirname, './files/webpack.config.multiple.js'),
     }
 
-    expect(resolve('main-module', file, settings))
-      .to.have.property('resolve')
-      .and.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
+    expect(resolve('main-module', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
   })
 })

--- a/resolvers/webpack/test/files/webpack.config.multiple.js
+++ b/resolvers/webpack/test/files/webpack.config.multiple.js
@@ -5,11 +5,16 @@ module.exports = [{
 }, {
   name: 'two',
   resolve: {
+    root: path.join(__dirname, 'src'),
+    fallback: path.join(__dirname, 'fallback'),
+  },
+}, {
+  name: 'three',
+  resolve: {
     alias: {
       'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
     },
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),
-    fallback: path.join(__dirname, 'fallback'),
   },
 }]

--- a/resolvers/webpack/test/files/webpack.config.multiple.js
+++ b/resolvers/webpack/test/files/webpack.config.multiple.js
@@ -1,0 +1,15 @@
+var path = require('path')
+
+module.exports = [{
+  name: 'one',
+}, {
+  name: 'two',
+  resolve: {
+    alias: {
+      'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
+    },
+    modulesDirectories: ['node_modules', 'bower_components'],
+    root: path.join(__dirname, 'src'),
+    fallback: path.join(__dirname, 'fallback'),
+  },
+}]


### PR DESCRIPTION
If the Webpack config is an array, then this change will use the first config that includes a resolve section.