### PR TITLE
Fix prefer default in multiple named export case

### DIFF
--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -96,7 +96,9 @@ module.exports = function (context) {
             return
           }
 
-          if (nextStatement && (!nextRequireCall || !containsNodeOrEqual(nextStatement, nextRequireCall))) {
+          if (nextStatement &&
+             (!nextRequireCall || !containsNodeOrEqual(nextStatement, nextRequireCall))) {
+
             checkForNewLine(statementWithRequireCall, nextStatement, 'require')
           }
         })

--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -15,7 +15,15 @@ module.exports = function(context) {
       }
     },
     'ExportNamedDeclaration': function(node) {
-      namedExportCount++
+      if (node.declaration &&
+          node.declaration.declarations.length &&
+          node.declaration.declarations[0].id.type === 'ObjectPattern') {
+
+        namedExportCount += node.declaration.declarations[0].id.properties.length
+      } else {
+        namedExportCount++
+      }
+
       namedExportNode = node
     },
     'ExportDefaultDeclaration': function() {
@@ -23,7 +31,7 @@ module.exports = function(context) {
     },
 
     'Program:exit': function() {
-      if (namedExportCount === 1 &&  specifierExportCount < 2 && !hasDefaultExport) {
+      if (namedExportCount === 1 && specifierExportCount < 2 && !hasDefaultExport) {
         context.report(namedExportNode, 'Prefer default export.')
       }
     },

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -23,6 +23,10 @@ ruleTester.run('prefer-default-export', rule, {
       }),
     test({
       code: `
+        export const { foo, bar } = item;`,
+      }),
+    test({
+      code: `
         export { foo as default }`,
       }),
   ],


### PR DESCRIPTION
Fixes #342. Instead of counting the number of `ExportNamedDeclaration` nodes, we count the number of properties in its child `ObjectPattern`.

A couple other style fixes.