### PR TITLE
allow multiple named export through variable deconstructing fixes #342

### DIFF
--- a/docs/rules/prefer-default-export.md
+++ b/docs/rules/prefer-default-export.md
@@ -49,3 +49,10 @@ export { foo, bar }
 const foo = 'foo';
 export { foo as default }
 ```
+
+```javascript
+// good5.js
+
+// export multiple vars through deconstructing.
+export const { foo, bar } = baz;
+```

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash.endswith": "^4.0.1",
     "lodash.find": "^4.3.0",
     "lodash.findindex": "^4.3.0",
+    "lodash.get": "4.3.0",
     "object-assign": "^4.0.1",
     "pkg-up": "^1.0.0"
   }

--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -1,5 +1,8 @@
 'use strict'
 
+import get from 'lodash.get'
+// import forEach from 'lodash.forEach'
+
 module.exports = function(context) {
   let namedExportCount = 0
   let specifierExportCount = 0
@@ -15,7 +18,12 @@ module.exports = function(context) {
       }
     },
     'ExportNamedDeclaration': function(node) {
-      namedExportCount++
+      const properties = get(node, 'declaration.declarations[0].id.properties')
+      if (properties) {
+        namedExportCount = namedExportCount + properties.length
+      } else {
+        namedExportCount++
+      }
       namedExportNode = node
     },
     'ExportDefaultDeclaration': function() {

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -25,6 +25,11 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         export { foo as default }`,
       }),
+    test({
+      code: `
+        export const { foo, bar } = baz;`,
+      }),
+
   ],
   invalid: [
     test({
@@ -39,6 +44,14 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         const foo = 'foo';
         export { foo };`,
+      errors: [{
+        ruleId: 'ExportNamedDeclaration',
+        message: 'Prefer default export.',
+      }],
+    }),
+    test({
+      code: `
+        export const { foo } = baz;`,
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Prefer default export.',


### PR DESCRIPTION
This PR fixes #342 by allowing to export more than one variable using variable deconstructing