### PR TITLE
prefer-default-export: Support 'export function foo() {}; export const x = 4;'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
+## TBD
+### Fixed
+- [`prefer-default-export`] handles `export function` and `export const` in same file ([#359], thanks [@scottnonnenberg])
+
 ## resolvers/webpack/0.2.5 - 2016-05-23
 ### Added
 - Added support for multiple webpack configs ([#181], thanks [@GreenGremlin])
@@ -225,6 +229,7 @@ for info on changes for earlier releases.
 [`no-mutable-exports`]: ./docs/rules/no-mutable-exports.md
 [`prefer-default-export`]: ./docs/rules/prefer-default-export.md
 
+[#359]: https://github.com/benmosher/eslint-plugin-import/pull/359
 [#343]: https://github.com/benmosher/eslint-plugin-import/pull/343
 [#332]: https://github.com/benmosher/eslint-plugin-import/pull/332
 [#322]: https://github.com/benmosher/eslint-plugin-import/pull/322

--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -38,6 +38,10 @@ module.exports = function(context) {
           captureDeclaration(declaration.id)
         })
       }
+      else {
+        // captures 'export function foo() {}' syntax
+        specifierExportCount++
+      }
 
       namedExportNode = node
     },

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -14,6 +14,15 @@ ruleTester.run('prefer-default-export', rule, {
       }),
     test({
       code: `
+        export default function bar() {};`,
+      }),
+    test({
+      code: `
+        export const foo = 'foo';
+        export function bar() {};`,
+      }),
+    test({
+      code: `
         export const foo = 'foo';
         export default bar;`,
       }),
@@ -56,6 +65,14 @@ ruleTester.run('prefer-default-export', rule, {
     // ...SYNTAX_CASES,
   ],
   invalid: [
+    test({
+      code: `
+        export function bar() {};`,
+      errors: [{
+        ruleId: 'ExportNamedDeclaration',
+        message: 'Prefer default export.',
+      }],
+    }),
     test({
       code: `
         export const foo = 'foo';`,


### PR DESCRIPTION
Fixes #358.

The fixes to support multiple declarations left out a crucial else case.