### PR TITLE
[webpack-resolver] Allowing externals to be a function

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -190,7 +190,15 @@ function findExternal(source, externals) {
   }
 
   if (typeof externals === 'function') {
-    throw new Error('unable to handle function externals')
+    var functionExternalFound = false
+    externals.call(null, null, source, function(err, value) {
+      if (err) {
+        functionExternalFound = false
+      } else {
+        functionExternalFound = findExternal(source, value)
+      }
+    })
+    return functionExternalFound
   }
 
   // else, vanilla object

--- a/resolvers/webpack/test/externals.js
+++ b/resolvers/webpack/test/externals.js
@@ -19,6 +19,12 @@ describe("externals", function () {
     expect(resolved).to.have.property('path', null)
   })
 
+  it("works on a function", function () {
+    var resolved = webpack.resolve('underscore', file)
+    expect(resolved).to.have.property('found', true)
+    expect(resolved).to.have.property('path', null)
+  })
+
   it("returns null for core modules", function () {
     var resolved = webpack.resolve('fs', file)
     expect(resolved).to.have.property('found', true)

--- a/resolvers/webpack/test/files/webpack.config.js
+++ b/resolvers/webpack/test/files/webpack.config.js
@@ -13,5 +13,11 @@ module.exports = {
   externals: [
     { 'jquery': 'jQuery' },
     'bootstrap',
+    function (context, request, callback) {
+      if (request === 'underscore') {
+        return callback(null, 'underscore');
+      };
+      callback();
+    }
   ],
 }


### PR DESCRIPTION
This is a basic fix for #349. It handles externals being a function. I really only tested it against the functionality of `webpack-node-externals`, so it's likely not fully complete, but at least it's a step in the right direction. And this seems to be a relatively less-used feature of Webpack.

One thing that is definitely incompatible is that the callback function must be sync, or else the external function won't resolve in time. Thankfully, the `webpack-node-externals` function is sync, so it handles that usage perfectly.