### PR TITLE
import/core-modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- [`import/core-modules` setting]: allow configuration of additional module names,
+  to be treated as builtin modules (a la `path`, etc. in Node). ([#275] + [#365], thanks [@sindresorhus] for driving)
 
 ## [1.9.1] - 2016-06-16
 ### Fixed
@@ -201,6 +204,7 @@ for info on changes for earlier releases.
 [`import/cache` setting]: ./README.md#importcache
 [`import/ignore` setting]: ./README.md#importignore
 [`import/extensions` setting]: ./README.md#importextensions
+[`import/core-modules` setting]: ./README.md#importcore-modules
 
 [`no-unresolved`]: ./docs/rules/no-unresolved.md
 [`no-deprecated`]: ./docs/rules/no-deprecated.md
@@ -221,6 +225,7 @@ for info on changes for earlier releases.
 [`no-mutable-exports`]: ./docs/rules/no-mutable-exports.md
 [`prefer-default-export`]: ./docs/rules/prefer-default-export.md
 
+[#365]: https://github.com/benmosher/eslint-plugin-import/pull/365
 [#359]: https://github.com/benmosher/eslint-plugin-import/pull/359
 [#343]: https://github.com/benmosher/eslint-plugin-import/pull/343
 [#332]: https://github.com/benmosher/eslint-plugin-import/pull/332
@@ -258,6 +263,7 @@ for info on changes for earlier releases.
 [#313]: https://github.com/benmosher/eslint-plugin-import/issues/313
 [#286]: https://github.com/benmosher/eslint-plugin-import/issues/286
 [#281]: https://github.com/benmosher/eslint-plugin-import/issues/281
+[#275]: https://github.com/benmosher/eslint-plugin-import/issues/275
 [#272]: https://github.com/benmosher/eslint-plugin-import/issues/272
 [#267]: https://github.com/benmosher/eslint-plugin-import/issues/267
 [#266]: https://github.com/benmosher/eslint-plugin-import/issues/266
@@ -316,3 +322,4 @@ for info on changes for earlier releases.
 [@jkimbo]: https://github.com/jkimbo
 [@le0nik]: https://github.com/le0nik
 [@scottnonnenberg]: https://github.com/scottnonnenberg
+[@sindresorhus]: https://github.com/sindresorhus

--- a/README.md
+++ b/README.md
@@ -231,6 +231,33 @@ settings:
 
 [`jsnext:main`]: https://github.com/rollup/rollup/wiki/jsnext:main
 
+#### `import/core-modules`
+
+An array of additional modules to consider as "core" modules--modules that should
+be considered resolved but have no path on the filesystem. Your resolver may
+already define some of these (for example, the Node resolver knows about `fs` and
+`path`), so you need not redefine those.
+
+For example, Electron exposes an `electron` module:
+
+```js
+import 'electron'  // without extra config, will be flagged as unresolved!
+```
+
+that would otherwise be unresolved. To avoid this, you may provide `electron` as a
+core module:
+
+```yaml
+# .eslintrc.yml
+settings:
+  import/core-modules: [ electron ]
+```
+
+In Electron's specific case, there is a shared config named `electron`
+that specifies this for you.
+
+Contribution of more such shared configs for other platforms are welcome!
+
 #### `import/resolver`
 
 See [resolvers](#resolvers).

--- a/config/electron.js
+++ b/config/electron.js
@@ -1,0 +1,8 @@
+/**
+ * Default settings for Electron applications.
+ */
+module.exports = {
+  settings: {
+    'import/core-modules': ['electron'],
+  },
+}

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -8,12 +8,13 @@ function constant(value) {
   return () => value
 }
 
-export function isBuiltIn(name) {
-  return builtinModules.indexOf(name) !== -1
+export function isBuiltIn(name, settings) {
+  const extras = (settings && settings['import/core-modules']) || []
+  return builtinModules.indexOf(name) !== -1 || extras.indexOf(name) > -1
 }
 
 const externalModuleRegExp = /^\w/
-function isExternalModule(name, path) {
+function isExternalModule(name, settings, path) {
   if (!externalModuleRegExp.test(name)) return false
   return (!path || -1 < path.indexOf(join('node_modules', name)))
 }
@@ -23,7 +24,7 @@ function isScoped(name) {
   return scopedRegExp.test(name)
 }
 
-function isInternalModule(name, path) {
+function isInternalModule(name, settings, path) {
   if (!externalModuleRegExp.test(name)) return false
   return (path && -1 === path.indexOf(join('node_modules', name)))
 }
@@ -53,5 +54,5 @@ const typeTest = cond([
 ])
 
 export default function resolveImportType(name, context) {
-  return typeTest(name, resolve(name, context))
+  return typeTest(name, context.settings, resolve(name, context))
 }

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -54,6 +54,9 @@ function fileExistsWithCaseSync(filepath, cacheSettings) {
 }
 
 export function relative(modulePath, sourceFile, settings) {
+  // check if this is a bonus core module
+  const envCore = envCores.get(settings['import/env'])
+  if (envCore != null && envCore.has(modulePath)) return { path: null, found: true }
 
   const sourceDir = path.dirname(sourceFile)
       , cacheKey = sourceDir + hashObject(settings) + modulePath
@@ -202,3 +205,7 @@ function hashObject(object) {
   settingsShasum.update(JSON.stringify(object))
   return settingsShasum.digest('hex')
 }
+
+const envCores = new Map([
+  ['electron', new Set(['electron'])],
+])

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -55,8 +55,8 @@ function fileExistsWithCaseSync(filepath, cacheSettings) {
 
 export function relative(modulePath, sourceFile, settings) {
   // check if this is a bonus core module
-  const envCore = envCores.get(settings['import/env'])
-  if (envCore != null && envCore.has(modulePath)) return { path: null, found: true }
+  const coreSet = new Set(settings['import/core-modules'])
+  if (coreSet != null && coreSet.has(modulePath)) return { path: null, found: true }
 
   const sourceDir = path.dirname(sourceFile)
       , cacheKey = sourceDir + hashObject(settings) + modulePath
@@ -205,7 +205,3 @@ function hashObject(object) {
   settingsShasum.update(JSON.stringify(object))
   return settingsShasum.digest('hex')
 }
-
-const envCores = new Map([
-  ['electron', new Set(['electron'])],
-])

--- a/src/index.js
+++ b/src/index.js
@@ -29,9 +29,10 @@ export const configs = {
   'errors': require('../config/errors'),
   'warnings': require('../config/warnings'),
 
-  // useful stuff for folks using React
-  'react': require('../config/react'),
-
   // shhhh... work in progress "secret" rules
   'stage-0': require('../config/stage-0'),
+
+  // useful stuff for folks using various environments
+  'react': require('../config/react'),
+  'electron': require('../config/electron'),
 }

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -28,7 +28,7 @@ module.exports = function (context) {
     const importPath = source.value
 
     // don't enforce anything on builtins
-    if (isBuiltIn(importPath)) return
+    if (isBuiltIn(importPath, context.settings)) return
 
     const resolvedPath = resolve(importPath, context)
 

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -58,4 +58,12 @@ describe('importType(name)', function () {
     expect(importType('/malformed', context)).to.equal('unknown')
     expect(importType('   foo', context)).to.equal('unknown')
   })
+
+  it("should return 'builtin' for additional core modules", function() {
+    // without extra config, should be marked external
+    expect(importType('electron', context)).to.equal('external')
+
+    const electronContext = testContext({ 'import/core-modules': ['electron'] })
+    expect(importType('electron', electronContext)).to.equal('builtin')
+  })
 })

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -23,6 +23,8 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({ code: 'import "lodash.isarray"'}),
     test({ code: 'import "@scope/core"'}),
 
+    test({ code: 'import "electron"', settings: { 'import/core-modules': ['electron'] } }),
+
     // 'project' type
     test({
       code: 'import "importType"',

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -312,3 +312,18 @@ ruleTester.run('no-unresolved unknown resolver', rule, {
     }),
   ],
 })
+
+ruleTester.run('no-unresolved electron', rule, {
+  valid: [
+    test({
+      code: 'import "electron"',
+      settings: { 'import/env': 'electron' },
+    }),
+  ],
+  invalid:[
+    test({
+      code: 'import "electron"',
+      errors: [`Unable to resolve path to module 'electron'.`],
+    }),
+  ],
+})

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -317,7 +317,7 @@ ruleTester.run('no-unresolved electron', rule, {
   valid: [
     test({
       code: 'import "electron"',
-      settings: { 'import/env': 'electron' },
+      settings: { 'import/core-modules': ['electron'] },
     }),
   ],
   invalid:[


### PR DESCRIPTION
Fixes #275.

- [x] handle `import/core-modules` in `no-unresolved`
- [x] handle `import/core-modules` in @jfmengels's `importType` support stuff
- [x] create Electron shared config spec-ing `import/core-modules` as `[electron]`

```yaml
settings:
  import/core-modules: [ electron ]
```
