### PR TITLE
do not resolve the source directory. Fixes #367

### DIFF
--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -157,7 +157,7 @@ function requireResolver(name, sourceFile) {
 
   // Try to resolve package with path, relative to closest package.json
   try {
-    const packageDir = pkgDir.sync(resolve(sourceFile))
+    const packageDir = pkgDir.sync(sourceFile)
     return require(join(packageDir, name))
   } catch (err) { /* continue */ }
 

--- a/tests/files/foo-bar-resolver.js
+++ b/tests/files/foo-bar-resolver.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+exports.resolve = function(source, file) {
+    return { found: true, path: path.join(__dirname, 'bar.jsx') };
+};
+
+exports.interfaceVersion = 2;

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -10,6 +10,14 @@ describe('resolve', function () {
     expect(resolve.bind(null, null, null)).to.throw(Error)
   })
 
+  it('loads a custom resolver path', function () {
+    var file = resolve( '../files/foo'
+                      , utils.testContext({ 'import/resolver': './foo-bar-resolver'})
+                      )
+
+    expect(file).to.equal(utils.testFilePath('./bar.jsx'))
+  })
+
   it('respects import/resolve extensions', function () {
     var file = resolve( './jsx/MyCoolComponent'
                       , utils.testContext({ 'import/resolve': { 'extensions': ['.jsx'] }})


### PR DESCRIPTION
You cannot call resolve without a 2nd argument - but because we now pass the source directory, not the modulePath, it will always be absolute so you don't need to.

Added a test as well, covering the situation this fixes and also the situation I use the custom resolver for.