### PR TITLE
Webpack resolver plugin

### DIFF
--- a/resolvers/webpack/test/files/node_modules/webpack-resolver-plugin-test/index.js
+++ b/resolvers/webpack/test/files/node_modules/webpack-resolver-plugin-test/index.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 /**
  * ResolverPlugin
  *
@@ -21,30 +23,27 @@ module.exports.ResolverPlugin = ResolverPlugin;
 /**
  * SimpleResolver for testing
  *
- * @param path
- * @param absolute_alias
- * @param alias
+ * @param file
+ * @param source
  * @constructor
  */
 
-function SimpleResolver(path, absolute_alias, alias) {
-  this.path = path;
-  this.alias = alias;
-  this.absolute_alias = absolute_alias;
+function SimpleResolver(file, source) {
+  this.file = file;
+  this.source = source;
 }
 
 SimpleResolver.prototype.apply = function (resolver) {
 
-  var path = this.path;
-  var alias = this.alias;
-  var absolute_alias = this.absolute_alias;
+  var file = this.file;
+  var source = this.source;
 
   resolver.plugin('directory', function (request, done) {
 
-    if(request.request === alias || request.request === absolute_alias) {
-      resolver.doResolve('file', {
-        path: request.path, request: path
-      }, function (error, result) {
+    var absolutePath = path.resolve(request.path, request.request);
+
+    if (absolutePath === source) {
+      resolver.doResolve('file', { request: file }, function (error, result) {
         return done(undefined, result || undefined);
       });
     }

--- a/resolvers/webpack/test/files/node_modules/webpack-resolver-plugin-test/index.js
+++ b/resolvers/webpack/test/files/node_modules/webpack-resolver-plugin-test/index.js
@@ -1,0 +1,58 @@
+/**
+ * ResolverPlugin
+ *
+ * @param plugins
+ * @param types
+ * @constructor
+ */
+
+function ResolverPlugin(plugins, types) {
+  if(!Array.isArray(plugins)) plugins = [plugins];
+  if(!types) types = ["normal"];
+  else if(!Array.isArray(types)) types = [types];
+
+  this.plugins = plugins;
+  this.types = types;
+}
+
+module.exports.ResolverPlugin = ResolverPlugin;
+
+
+/**
+ * SimpleResolver for testing
+ *
+ * @param path
+ * @param absolute_alias
+ * @param alias
+ * @constructor
+ */
+
+function SimpleResolver(path, absolute_alias, alias) {
+  this.path = path;
+  this.alias = alias;
+  this.absolute_alias = absolute_alias;
+}
+
+SimpleResolver.prototype.apply = function (resolver) {
+
+  var path = this.path;
+  var alias = this.alias;
+  var absolute_alias = this.absolute_alias;
+
+  resolver.plugin('directory', function (request, done) {
+
+    if(request.request === alias || request.request === absolute_alias) {
+      resolver.doResolve('file', {
+        path: request.path, request: path
+      }, function (error, result) {
+        return done(undefined, result || undefined);
+      });
+    }
+
+    return done();
+
+  });
+
+}
+
+module.exports.SimpleResolver = SimpleResolver;

--- a/resolvers/webpack/test/files/webpack.config.js
+++ b/resolvers/webpack/test/files/webpack.config.js
@@ -27,8 +27,7 @@ module.exports = {
     new pluginsTest.ResolverPlugin([
       new pluginsTest.SimpleResolver(
         path.join(__dirname, 'some', 'bar', 'bar.js'),
-        path.join(__dirname, 'some', 'bar'),
-        './some/bar'
+        path.join(__dirname, 'some', 'bar')
       )
     ])
   ]

--- a/resolvers/webpack/test/files/webpack.config.js
+++ b/resolvers/webpack/test/files/webpack.config.js
@@ -1,9 +1,11 @@
 var path = require('path')
+var pluginsTest = require('webpack-resolver-plugin-test')
 
 module.exports = {
   resolve: {
     alias: {
       'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
+      'some-alias': path.join(__dirname, 'some')
     },
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),
@@ -20,4 +22,14 @@ module.exports = {
       callback();
     }
   ],
+
+  plugins: [
+    new pluginsTest.ResolverPlugin([
+      new pluginsTest.SimpleResolver(
+        path.join(__dirname, 'some', 'bar', 'bar.js'),
+        path.join(__dirname, 'some', 'bar'),
+        './some/bar'
+      )
+    ])
+  ]
 }

--- a/resolvers/webpack/test/plugins.js
+++ b/resolvers/webpack/test/plugins.js
@@ -1,0 +1,29 @@
+var chai = require('chai')
+  , expect = chai.expect
+  , path = require('path')
+
+var webpack = require('../index')
+
+var file = path.join(__dirname, 'files', 'dummy.js')
+
+describe("plugins", function () {
+  var resolved, aliasResolved
+
+  before(function () {
+    resolved = webpack.resolve('./some/bar', file)
+    aliasResolved = webpack.resolve('some-alias/bar', file)
+  })
+
+  it("work", function () {
+    expect(resolved).to.have.property('found', true)
+  })
+
+  it("is correct", function () {
+    expect(resolved).to.have.property('path')
+      .and.equal(path.join(__dirname, 'files', 'some', 'bar', 'bar.js'))
+  })
+
+  it("work with alias", function () {
+    expect(aliasResolved).to.have.property('found', true)
+  })
+})


### PR DESCRIPTION
Hello.

I use `webpack.ResolverPlugin` in my project in order to add my own resolvers:

https://github.com/webpack/docs/wiki/list-of-plugins#resolverplugin

`eslint-import-resolver-webpack` is not supporting such a way adding plugins now. This pull request solves the problem (see the code).