### PR TITLE
Fix crash with `newline-after-import` related to the use of switch cases (fixes #386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - Added new rule [`no-restricted-paths`]. ([#155]/[#371], thanks [@lo1tuma])
 - [`import/core-modules` setting]: allow configuration of additional module names,
   to be treated as builtin modules (a la `path`, etc. in Node). ([#275] + [#365], thanks [@sindresorhus] for driving)
+### Fixed
+- Fixed crash with `newline-after-import` related to the use of switch cases. (fixes [#386], thanks [@ljharb] for reporting) ([#395])
 
 ## [1.9.2] - 2016-06-21
 ### Fixed
@@ -231,6 +233,7 @@ for info on changes for earlier releases.
 [`prefer-default-export`]: ./docs/rules/prefer-default-export.md
 [`no-restricted-paths`]: ./docs/rules/no-restricted-paths.md
 
+[#395]: https://github.com/benmosher/eslint-plugin-import/pull/395
 [#371]: https://github.com/benmosher/eslint-plugin-import/pull/371
 [#365]: https://github.com/benmosher/eslint-plugin-import/pull/365
 [#359]: https://github.com/benmosher/eslint-plugin-import/pull/359
@@ -263,6 +266,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#386]: https://github.com/benmosher/eslint-plugin-import/issues/386
 [#373]: https://github.com/benmosher/eslint-plugin-import/issues/373
 [#370]: https://github.com/benmosher/eslint-plugin-import/issues/370
 [#348]: https://github.com/benmosher/eslint-plugin-import/issues/348
@@ -334,3 +338,4 @@ for info on changes for earlier releases.
 [@le0nik]: https://github.com/le0nik
 [@scottnonnenberg]: https://github.com/scottnonnenberg
 [@sindresorhus]: https://github.com/sindresorhus
+[@ljharb]: https://github.com/ljharb

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -15,18 +15,19 @@ function containsNodeOrEqual(outerNode, innerNode) {
 }
 
 function getScopeBody(scope) {
-    const { body } = scope.block
+    if (scope.block.type === 'SwitchStatement') {
+      return []
+    }
 
-    if (body.type === 'BlockStatement') {
+    const { body } = scope.block
+    if (body && body.type === 'BlockStatement') {
         return body.body
     }
 
     return body
 }
 
-function findNodeIndexInScopeBody(scope, nodeToFind) {
-    const body = getScopeBody(scope)
-
+function findNodeIndexInScopeBody(body, nodeToFind) {
     return findIndex(body, (node) => containsNodeOrEqual(node, nodeToFind))
 }
 
@@ -87,7 +88,7 @@ module.exports = function (context) {
       scopes.forEach(function ({ scope, requireCalls }) {
         requireCalls.forEach(function (node, index) {
           const scopeBody = getScopeBody(scope)
-          const nodePosition = findNodeIndexInScopeBody(scope, node)
+          const nodePosition = findNodeIndexInScopeBody(scopeBody, node)
           const statementWithRequireCall = scopeBody[nodePosition]
           const nextStatement = scopeBody[nodePosition + 1]
           const nextRequireCall = requireCalls[index + 1]

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -9,6 +9,15 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
   valid: [
     "var path = require('path');\nvar foo = require('foo');\n",
     "a(require('b'), require('c'), require('d'));",
+    `function foo() {
+      switch (renderData.modalViewKey) {
+        case 'value':
+          var bar = require('bar');
+          return bar(renderData, options)
+        default:
+          return renderData.mainModalContent.clone()
+      }
+    }`,
     {
       code: "import path from 'path';\nimport foo from 'foo';\n",
       parserOptions: { sourceType: 'module' },


### PR DESCRIPTION
Fix crash with `newline-after-import` related to the use of switch cases (fixes #386)

The error came because a switch case has a scope

- I've added a small safe-guard that should prevent the same kind of crash in this part of the code
- I have made it so no errors can come from inside switch cases. I tried returning the switch case `cases` items, but then it reports an error even if I space them correctly. Maybe someone wants to take a further look into it, but I'm out of time right now.

cc @ljharb @singles