### PR TITLE
remove for-of syntax from rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 ### Fixed
-- pinned `es6-symbol` dependency to `^3.1.0` instead of `*` 😳 ([#415])
+- removing `Symbol` dependencies (i.e. `for-of` loops) due to Node 0.10 polyfill
+  issue (see [#415]). Should not make any discernible semantic difference.
 
 ## [1.10.2] - 2016-07-04
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "doctrine": "1.2.x",
     "es6-map": "^0.1.3",
     "es6-set": "^0.1.4",
-    "es6-symbol": "^3.1.0",
     "eslint-import-resolver-node": "^0.2.0",
     "lodash.cond": "^4.3.0",
     "lodash.endswith": "^4.0.1",

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -1,4 +1,3 @@
-import 'es6-symbol/implement'
 import Map from 'es6-map'
 
 import * as fs from 'fs'

--- a/src/core/resolve.js
+++ b/src/core/resolve.js
@@ -1,4 +1,3 @@
-import 'es6-symbol/implement'
 import Map from 'es6-map'
 import Set from 'es6-set'
 import assign from 'object-assign'

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -1,4 +1,3 @@
-import 'es6-symbol/implement'
 import Map from 'es6-map'
 import Set from 'es6-set'
 
@@ -32,11 +31,11 @@ module.exports = function (context) {
         addNamed(node.declaration.id.name, node.declaration.id)
       }
 
-      if (node.declaration.declarations != null) {
-        for (let declaration of node.declaration.declarations) {
-          recursivePatternCapture(declaration.id, v => addNamed(v.name, v))
-        }
-      }
+      if (node.declaration.declarations == null) return
+
+      node.declaration.declarations.forEach(declaration => {
+        recursivePatternCapture(declaration.id, v => addNamed(v.name, v))
+      })
     },
 
     'ExportAllDeclaration': function (node) {
@@ -62,15 +61,15 @@ module.exports = function (context) {
     },
 
     'Program:exit': function () {
-      for (let [name, nodes] of named) {
-        if (nodes.size <= 1) continue
+      named.forEach((nodes, name) => {
+        if (nodes.size <= 1) return
 
-        for (let node of nodes) {
+        nodes.forEach(node => {
           if (name === 'default') {
             context.report(node, 'Multiple default exports.')
           } else context.report(node, `Multiple exports of name '${name}'.`)
-        }
-      }
+        })
+      })
     },
   }
 }

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -32,7 +32,7 @@ module.exports = function (context) {
           return
         }
 
-        for (let specifier of declaration.specifiers) {
+        declaration.specifiers.forEach((specifier) => {
           switch (specifier.type) {
             case 'ImportNamespaceSpecifier':
               if (!imports.size) {
@@ -51,7 +51,7 @@ module.exports = function (context) {
               break
             }
           }
-        }
+        })
       }
       body.forEach(processBodyStatement)
     },
@@ -129,28 +129,23 @@ module.exports = function (context) {
 
         if (pattern.type !== 'ObjectPattern') return
 
-        for (let property of pattern.properties) {
-
+        pattern.properties.forEach((property) => {
           if (property.key.type !== 'Identifier') {
             context.report({
               node: property,
               message: 'Only destructure top-level names.',
             })
-            continue
-          }
-
-          if (!namespace.has(property.key.name)) {
+          } else if (!namespace.has(property.key.name)) {
             context.report({
               node: property,
               message: makeMessage(property.key, path),
             })
-            continue
+          } else {
+            path.push(property.key.name)
+            testKey(property.value, namespace.get(property.key.name).namespace, path)
+            path.pop()
           }
-
-          path.push(property.key.name)
-          testKey(property.value, namespace.get(property.key.name).namespace, path)
-          path.pop()
-        }
+        })
       }
 
       testKey(id, namespaces.get(init.name))

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -1,4 +1,3 @@
-import 'es6-symbol/implement'
 import Map from 'es6-map'
 
 import Exports from '../core/getExports'

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -1,4 +1,3 @@
-import 'es6-symbol/implement'
 import Map from 'es6-map'
 import Set from 'es6-set'
 

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -5,13 +5,13 @@ import Set from 'es6-set'
 import resolve from '../core/resolve'
 
 function checkImports(imported, context) {
-  for (let [module, nodes] of imported.entries()) {
+  imported.forEach((nodes, module) => {
     if (nodes.size > 1) {
-      for (let node of nodes) {
+      nodes.forEach((node) => {
         context.report(node, `'${module}' imported multiple times.`)
-      }
+      })
     }
-  }
+  })
 }
 
 module.exports = function (context) {

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -7,15 +7,15 @@ module.exports = function (context) {
   }
 
   function checkDeclarationsInScope({variables}, name) {
-    for (let variable of variables) {
+    variables.forEach((variable) => {
       if (variable.name === name) {
-        for (let def of variable.defs) {
+        variable.defs.forEach((def) => {
           if (def.type === 'Variable') {
             checkDeclaration(def.parent)
           }
-        }
+        })
       }
-    }
+    })
   }
 
   function handleExportDefault(node) {
@@ -32,9 +32,9 @@ module.exports = function (context) {
     if (node.declaration)  {
       checkDeclaration(node.declaration)
     } else if (!node.source) {
-      for (let specifier of node.specifiers) {
+      node.specifiers.forEach((specifier) => {
         checkDeclarationsInScope(scope, specifier.local.name)
-      }
+      })
     }
   }
 

--- a/src/rules/no-named-as-default-member.js
+++ b/src/rules/no-named-as-default-member.js
@@ -57,10 +57,11 @@ module.exports = function(context) {
     if (!isDestructure) return
 
     const objectName = node.init.name
-    for (const { key } of node.id.properties) {
-      if (key == null) continue  // true for rest properties
-      storePropertyLookup(objectName, key.name, key)
-    }
+    node.id.properties.forEach(({key}) => {
+      if (key != null) { // rest properties are null
+        storePropertyLookup(objectName, key.name, key)
+      }
+    })
   }
 
   function handleProgramExit() {
@@ -68,19 +69,19 @@ module.exports = function(context) {
       const fileImport = fileImports.get(objectName)
       if (fileImport == null) return
 
-      for (const {propName, node} of lookups) {
-        if (!fileImport.exportMap.namespace.has(propName)) continue
-
-        context.report({
-          node,
-          message: (
-            `Caution: \`${objectName}\` also has a named export ` +
-            `\`${propName}\`. Check if you meant to write ` +
-            `\`import {${propName}} from '${fileImport.sourcePath}'\` ` +
-            'instead.'
-          ),
-        })
-      }
+      lookups.forEach(({propName, node}) => {
+        if (fileImport.exportMap.namespace.has(propName)) {
+          context.report({
+            node,
+            message: (
+              `Caution: \`${objectName}\` also has a named export ` +
+              `\`${propName}\`. Check if you meant to write ` +
+              `\`import {${propName}} from '${fileImport.sourcePath}'\` ` +
+              'instead.'
+            ),
+          })
+        }
+      })
     })
   }
 

--- a/src/rules/no-named-as-default-member.js
+++ b/src/rules/no-named-as-default-member.js
@@ -5,7 +5,6 @@
  * See LICENSE in root directory for full license.
  */
 
-import 'es6-symbol/implement'
 import Map from 'es6-map'
 
 import Exports from '../core/getExports'

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -3,8 +3,6 @@
  * @author Ben Mosher
  */
 
-import 'es6-symbol/implement'
-
 import resolve from '../core/resolve'
 
 module.exports = function (context) {

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -53,15 +53,17 @@ module.exports = function (context) {
     const modules = call.arguments[0]
     if (modules.type !== 'ArrayExpression') return
 
-    for (let element of modules.elements) {
-      if (element.type !== 'Literal') continue
-      if (typeof element.value !== 'string') continue
+    modules.elements.forEach((element) => {
+      if (element.type === 'Literal' &&
+          typeof element.value === 'string') {
 
-      if (element.value === 'require' ||
-          element.value === 'exports') continue // magic modules: http://git.io/vByan
-
-      checkSourceValue(element)
-    }
+        // magic modules: http://git.io/vByan
+        if (element.value !== 'require' &&
+            element.value !== 'exports') {
+          checkSourceValue(element)
+        }
+      }
+    })
   }
 
   const visitors = {

--- a/tests/src/package.js
+++ b/tests/src/package.js
@@ -1,5 +1,3 @@
-import 'es6-symbol/implement'
-
 var expect = require('chai').expect
 
 var path = require('path')
@@ -36,10 +34,10 @@ describe('package', function () {
   it('exports all configs', function (done) {
     fs.readdir(path.join(process.cwd(), 'config'), function (err, files) {
       if (err) { done(err); return }
-      for (let file of files) {
-        if (file[0] === '.') continue
+      files.forEach(file => {
+        if (file[0] === '.') return
         expect(module.configs).to.have.property(file.slice(0, -3)) // drop '.js'
-      }
+      })
       done()
     })
   })


### PR DESCRIPTION
There appear to be complications due to pollution of global scope with `Symbol` polyfill on Node 0.10.

Seems like the gentle thing is to fix it in 1.x, since 2.x will (a) be released soon and (b) support Node LTSs >= 4.

### tasks

- [x] remove `for .. of` loops from everywhere (replace with `#forEach`)
- [x] jettison `es6-symbol`

(fixes #415, hopefully)