### PR TITLE
Remove peerDependency on eslint-plugin-import

### DIFF
--- a/resolvers/node/package.json
+++ b/resolvers/node/package.json
@@ -27,9 +27,6 @@
     "object-assign": "^4.0.1",
     "resolve": "^1.1.6"
   },
-  "peerDependencies": {
-    "eslint-plugin-import": ">=1.4.0"
-  },
   "devDependencies": {
     "chai": "^3.4.1",
     "mocha": "^2.3.4"


### PR DESCRIPTION
eslint-import-resolver-node is not intended to be installed as a sibling of eslint-plugin-import, which is the sole purpose of `peerDependencies`

closes #437