### PR TITLE
add `allowComputed` option to `namespace` (fixes #456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-### Modified
+### Added
+- `allowComputed` option for [`namespace`] rule. If set to `true`, won't report
+  computed member references to namespaces. (see [#456])
+
+### Changed
 - Modified [`no-nodejs-modules`] error message to include the module's name ([#453], [#461])
 
 ## [1.12.0] - 2016-07-26
@@ -307,7 +311,11 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+<<<<<<< 30e55b65d6a8a08585aa72c51f8e5871d9a832a6
 [#453]: https://github.com/benmosher/eslint-plugin-import/issues/453
+=======
+[#456]: https://github.com/benmosher/eslint-plugin-import/issues/456
+>>>>>>> add `allowComputed` option to `namespace` (fixes #456)
 [#441]: https://github.com/benmosher/eslint-plugin-import/issues/441
 [#423]: https://github.com/benmosher/eslint-plugin-import/issues/423
 [#415]: https://github.com/benmosher/eslint-plugin-import/issues/415

--- a/docs/rules/namespace.md
+++ b/docs/rules/namespace.md
@@ -67,6 +67,24 @@ function deepTrouble() {
 
 ```
 
+### Options
+
+#### `allowComputed`
+
+Defaults to `false`. When false, will report the following:
+
+```js
+/*eslint import/namespace: [2, { allowComputed: false }]*/
+import * as a from './a'
+
+function f(x) {
+  return a[x] // Unable to validate computed reference to imported namespace 'a'.
+}
+```
+
+When set to `true`, the above computed namespace member reference is allowed, but
+still can't be statically analyzed any further.
+
 ## Further Reading
 
 - Lee Byron's [ES7] export proposal

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -4,7 +4,30 @@ import Exports from '../core/getExports'
 import importDeclaration from '../importDeclaration'
 import declaredScope from '../core/declaredScope'
 
-module.exports = function (context) {
+exports.meta = {
+  schema: [
+    {
+      'type': 'object',
+      'properties': {
+        'allowComputed': {
+          'description':
+            'If `false`, will report computed (and thus, un-lintable) references ' +
+            'to namespace members.',
+          'type': 'boolean',
+          'default': false,
+        },
+      },
+      'additionalProperties': false,
+    },
+  ],
+}
+
+exports.create = function namespaceRule(context) {
+
+  // read options
+  const {
+    allowComputed = false,
+  } = context.options[0] || {}
 
   const namespaces = new Map()
 
@@ -93,9 +116,11 @@ module.exports = function (context) {
              dereference.type === 'MemberExpression') {
 
         if (dereference.computed) {
-          context.report(dereference.property,
-            'Unable to validate computed reference to imported namespace \'' +
-            dereference.object.name + '\'.')
+          if (!allowComputed) {
+            context.report(dereference.property,
+              'Unable to validate computed reference to imported namespace \'' +
+              dereference.object.name + '\'.')
+          }
           return
         }
 

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -87,6 +87,12 @@ const valid = [
     parser: 'babel-eslint',
   }),
 
+  // #456: optionally ignore computed references
+  test({
+    code: `import * as names from './named-exports'; console.log(names['a']);`,
+    options: [{ allowComputed: true }],
+  }),
+
   ...SYNTAX_CASES,
 ]
 


### PR DESCRIPTION
Changed my mind, too much work to make this a separate rule, and it can easily be exposed as an option in v1.x. 😅

I'm not even sure if it should default to `true` in v2...