### PR TITLE
make import/extensions great again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Changed
 - Modified [`no-nodejs-modules`] error message to include the module's name ([#453], [#461])
 
+### Fixed
+- [`import/extensions` setting] is respected in spite of the appearance of imports
+  in an imported file. (fixes [#478], thaks [@rhys-vdw])
+
 ## [1.12.0] - 2016-07-26
 ### Added
 - [`import/external-module-folders` setting]: a possibility to configure folders for "external" modules ([#444], thanks [@zloirock])
@@ -311,6 +315,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#478]: https://github.com/benmosher/eslint-plugin-import/issues/478
 [#456]: https://github.com/benmosher/eslint-plugin-import/issues/456
 [#453]: https://github.com/benmosher/eslint-plugin-import/issues/453
 [#441]: https://github.com/benmosher/eslint-plugin-import/issues/441
@@ -399,3 +404,4 @@ for info on changes for earlier releases.
 [@ljharb]: https://github.com/ljharb
 [@rhettlivingston]: https://github.com/rhettlivingston
 [@zloirock]: https://github.com/zloirock
+[@rhys-vdw]: https://github.com/rhys-vdw

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "memo-parser"
   ],
   "scripts": {
-    "watch": "cross-env NODE_PATH=./lib gulp watch-test",
+    "watch": "cross-env NODE_PATH=./src mocha --watch --compilers js:babel-register --recursive tests/src",
     "cover": "gulp pretest && cross-env NODE_PATH=./lib istanbul cover --dir reports/coverage _mocha tests/lib/ -- --recursive -R progress",
     "posttest": "eslint ./src",
     "test": "cross-env BABEL_ENV=test NODE_PATH=./src nyc mocha --recursive tests/src -t 5s",

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -7,7 +7,7 @@ import * as doctrine from 'doctrine'
 
 import parse from './parse'
 import resolve, { relative as resolveRelative } from './resolve'
-import isIgnored from './ignore'
+import isIgnored, { hasValidExtension } from './ignore'
 
 import { hashObject } from './hash'
 
@@ -69,6 +69,12 @@ export default class ExportMap {
         return exportMap
       }
       // future: check content equality?
+    }
+
+    // check valid extensions first
+    if (!hasValidExtension(path, context)) {
+      exportCache.set(cacheKey, null)
+      return null
     }
 
     const content = fs.readFileSync(path, { encoding: 'utf8' })

--- a/src/core/ignore.js
+++ b/src/core/ignore.js
@@ -26,7 +26,7 @@ export default function ignore(path, context) {
     : ['node_modules']
 
   // check extension list first (cheap)
-  if (!validExtensions(context).has(extname(path))) return true
+  if (!hasValidExtension(path, context)) return true
 
   if (ignoreStrings.length === 0) return false
 
@@ -36,4 +36,8 @@ export default function ignore(path, context) {
   }
 
   return false
+}
+
+export function hasValidExtension(path, context) {
+  return validExtensions(context).has(extname(path))
 }

--- a/tests/files/typescript.ts
+++ b/tests/files/typescript.ts
@@ -1,0 +1,5 @@
+type X = { y: string | null }
+
+export function getX() : X {
+  return null
+}

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -292,4 +292,19 @@ describe('getExports', function () {
     })
   })
 
+  context('issue #478: never parse non-whitelist extensions', function () {
+    const context = Object.assign({}, fakeContext,
+      { settings: { 'import/extensions': ['.js'] } })
+
+    let imports
+    before('load imports', function () {
+      imports = ExportMap.get('./typescript.ts', context)
+    })
+
+    it('returns nothing for a TypeScript file', function () {
+      expect(imports).not.to.exist
+    })
+
+  })
+
 })


### PR DESCRIPTION
Fixes #478 by always respecting `import/extensions`, in spite of file content.