### PR TITLE
Allow no-restricted-paths to restrict from packages

### DIFF
--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -16,22 +16,22 @@ module.exports = function noRestrictedPaths(context) {
   })
 
   function checkForRestrictedImportPath(importPath, node) {
-      const absoluteImportPath = resolve(importPath, context)
+    const absoluteImportPath = resolve(importPath, context)
 
-      if (!absoluteImportPath) {
-        return
+    if (!absoluteImportPath) {
+      return
+    }
+
+    matchingZones.forEach((zone) => {
+      const absoluteFrom = path.resolve(basePath, zone.from)
+
+      if (containsPath(absoluteImportPath, absoluteFrom)) {
+        context.report({
+          node,
+          message: `Unexpected path "${importPath}" imported in restricted zone.`,
+        })
       }
-
-      matchingZones.forEach((zone) => {
-        const absoluteFrom = path.resolve(basePath, zone.from)
-
-        if (containsPath(absoluteImportPath, absoluteFrom)) {
-          context.report({
-            node,
-            message: `Unexpected path "${importPath}" imported in restricted zone.`,
-          })
-        }
-      })
+    })
   }
 
   return {

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -23,7 +23,11 @@ module.exports = function noRestrictedPaths(context) {
     }
 
     matchingZones.forEach((zone) => {
-      const absoluteFrom = path.resolve(basePath, zone.from)
+      // If the path starts with a '.' we need to resolve it as a local path,
+      // otherwise, we assume it is a package.
+      const absoluteFrom = zone.from.startsWith('.')
+        ? path.resolve(basePath, zone.from)
+        : zone.from
 
       if (containsPath(absoluteImportPath, absoluteFrom)) {
         context.report({

--- a/tests/src/rules/no-restricted-paths.js
+++ b/tests/src/rules/no-restricted-paths.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { RuleTester } from 'eslint'
 import rule from 'rules/no-restricted-paths'
 
@@ -26,6 +27,13 @@ ruleTester.run('no-restricted-paths', rule, {
       filename: testFilePath('./restricted-paths/client/a.js'),
       options: [ {
         zones: [ { target: './tests/files/restricted-paths/client', from: './tests/files/restricted-paths/other' } ],
+      } ],
+    }),
+    test({
+      code: 'import b from "my-package/public/a.js"',
+      filename: testFilePath('./restricted-paths/client/a.js'),
+      options: [ {
+        zones: [ { target: './tests/files/restricted-paths/client', from: 'my-package/private' } ],
       } ],
     }),
   ],
@@ -88,6 +96,21 @@ ruleTester.run('no-restricted-paths', rule, {
         message: 'Unexpected path "../server/b.js" imported in restricted zone.',
         line: 1,
         column: 19,
+      } ],
+    }),
+    test({
+      code: 'import b from "my-package/private/a.js"',
+      settings: {'import/resolve': {'paths': [
+        path.join('tests', 'files', 'my-package'),
+      ]}},
+      filename: testFilePath('./restricted-paths/client/a.js'),
+      options: [ {
+        zones: [ { target: './tests/files/restricted-paths/client', from: 'my-package/private' } ],
+      } ],
+      errors: [ {
+        message: 'Unexpected path "my-package/private/a.js" imported in restricted zone.',
+        line: 1,
+        column: 15,
       } ],
     }),
   ],


### PR DESCRIPTION
I am working in a project where we have a package installed that has
a "private" directory with some files in it that are not intended to be
part of the public API. It would be nice to be able to restrict these
files from being imported with configuration like:

```json
"import/no-restricted-paths": ["error", {
  "zones": [
    { "target": ".", "from": "my-package/private" },
  ],
}],
```

This commit takes a swing at making this work. I am not entirely sure if
this is the right approach and I was unable to get the specs running the
way I wanted, but I hope this can at least get the ball rolling.

I'm happy to finish this up with a little direction, or feel free to take what
I've started and run with it.