### PR TITLE
support alt-JS dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- [`import/parsers` setting]: parse some dependencies (i.e. TypeScript!) with a different parser than the ESLint-configured parser.
+
 ### Fixed
 - [`namespace`] exception for get property from `namespace` import, which are re-export from commonjs module ([#416])
 
@@ -260,6 +263,7 @@ for info on changes for earlier releases.
 [`import/cache` setting]: ./README.md#importcache
 [`import/ignore` setting]: ./README.md#importignore
 [`import/extensions` setting]: ./README.md#importextensions
+[`import/parsers` setting]: ./README.md#importparsers
 [`import/core-modules` setting]: ./README.md#importcore-modules
 [`import/external-module-folders` setting]: ./README.md#importexternal-module-folders
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,32 @@ Contribution of more such shared configs for other platforms are welcome!
 
 An array of folders. Resolved modules only from those folders will be considered as "external". By default - `["node_modules"]`. Makes sense if you have configured your path or webpack to handle your internal paths differently and want to considered modules from some folders, for example `bower_components` or `jspm_modules`, as "external".
 
+#### `import/parsers`
+
+A map from parsers to file extension arrays. If a file extension is matched, the
+dependency parser will require and use the map key as the parser instead of the
+configured ESLint parser. This is useful if you're inter-op-ing with TypeScript
+directly using Webpack, for example:
+
+```yaml
+# .eslintrc.yml
+settings:
+  import/parsers:
+    typescript-eslint-parser: [ .ts, .tsx ]
+```
+
+In this case, [`typescript-eslint-parser`](https://github.com/eslint/typescript-eslint-parser) must be installed and require-able from
+the running `eslint` module's location (i.e., install it as a peer of ESLint).
+
+This is currently only tested with `typescript-eslint-parser` but should theoretically
+work with any moderately ESTree-compliant parser.
+
+It's difficult to say how well various plugin features will be supported, too,
+depending on how far down the rabbit hole goes. Submit an issue if you find strange
+behavior beyond here, but steel your heart against the likely outcome of closing
+with `wontfix`.
+
+
 #### `import/resolver`
 
 See [resolvers](#resolvers).

--- a/package.json
+++ b/package.json
@@ -53,16 +53,18 @@
     "coveralls": "^2.11.4",
     "cross-env": "^2.0.0",
     "eslint": "2.x",
-    "eslint-plugin-import": "next",
     "eslint-import-resolver-node": "file:./resolvers/node",
     "eslint-import-resolver-webpack": "file:./resolvers/webpack",
+    "eslint-plugin-import": "next",
     "gulp": "^3.9.0",
     "gulp-babel": "6.1.2",
     "istanbul": "^0.4.0",
     "mocha": "^2.2.1",
     "nyc": "^7.0.0",
     "redux": "^3.0.4",
-    "rimraf": "2.5.2"
+    "rimraf": "2.5.2",
+    "typescript": "^1.8.10",
+    "typescript-eslint-parser": "^0.1.1"
   },
   "peerDependencies": {
     "eslint": "2.x - 3.x"

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -5,11 +5,15 @@ import * as fs from 'fs'
 import { createHash } from 'crypto'
 import * as doctrine from 'doctrine'
 
+import debug from 'debug'
+
 import parse from './parse'
 import resolve, { relative as resolveRelative } from './resolve'
 import isIgnored, { hasValidExtension } from './ignore'
 
 import { hashObject } from './hash'
+
+const log = debug('eslint-plugin-import:ExportMap')
 
 const exportCache = new Map()
 
@@ -96,8 +100,9 @@ export default class ExportMap {
     var m = new ExportMap(path)
 
     try {
-      var ast = parse(content, context)
+      var ast = parse(path, content, context)
     } catch (err) {
+      log('parse error:', path, err)
       m.errors.push(err)
       return m // can't continue
     }

--- a/src/core/ignore.js
+++ b/src/core/ignore.js
@@ -13,10 +13,25 @@ function validExtensions({ settings }) {
   // breaking: default to '.js'
   // cachedSet = new Set(settings['import/extensions'] || [ '.js' ])
   cachedSet = 'import/extensions' in settings
-    ? new Set(settings['import/extensions'])
+    ? makeValidExtensionSet(settings)
     : { has: () => true } // the set of all elements
 
   return cachedSet
+}
+
+function makeValidExtensionSet(settings) {
+  // start with explicit JS-parsed extensions
+  const exts = new Set(settings['import/extensions'])
+
+  // all alternate parser extensions are also valid
+  if ('import/parsers' in settings) {
+    for (let parser in settings['import/parsers']) {
+      settings['import/parsers'][parser]
+        .forEach(ext => exts.add(ext))
+    }
+  }
+
+  return exts
 }
 
 export default function ignore(path, context) {

--- a/tests/files/typescript.ts
+++ b/tests/files/typescript.ts
@@ -1,5 +1,5 @@
-type X = { y: string | null }
+type X = string
 
-export function getX() : X {
-  return null
+export function getFoo() : X {
+  return "foo"
 }

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -83,11 +83,12 @@ describe('getExports', function () {
     var imports = ExportMap.parse(
       path,
       contents,
-      { parserPath: 'babel-eslint' }
+      { parserPath: 'babel-eslint', settings: {} }
     )
 
-    expect(imports).to.exist
-    expect(imports.get('default')).to.exist
+    expect(imports, 'imports').to.exist
+    expect(imports.errors).to.be.empty
+    expect(imports.get('default'), 'default export').to.exist
     expect(imports.has('Bar')).to.be.true
   })
 
@@ -187,6 +188,7 @@ describe('getExports', function () {
           sourceType: 'module',
           attachComment: true,
         },
+        settings: {},
       })
     })
 
@@ -197,6 +199,7 @@ describe('getExports', function () {
           sourceType: 'module',
           attachComment: true,
         },
+        settings: {},
       })
     })
   })
@@ -303,6 +306,37 @@ describe('getExports', function () {
 
     it('returns nothing for a TypeScript file', function () {
       expect(imports).not.to.exist
+    })
+
+  })
+
+  context('alternate parsers', function () {
+    const configs = [
+      // ['string form', { 'typescript-eslint-parser': '.ts' }],
+      ['array form', { 'typescript-eslint-parser': ['.ts', '.tsx'] }],
+    ]
+
+    configs.forEach(([description, parserConfig]) => {
+      describe(description, function () {
+        const context = Object.assign({}, fakeContext,
+          { settings: {
+            'import/extensions': ['.js'],
+            'import/parsers': parserConfig,
+          } })
+
+        let imports
+        before('load imports', function () {
+          imports = ExportMap.get('./typescript.ts', context)
+        })
+
+        it('returns something for a TypeScript file', function () {
+          expect(imports).to.exist
+        })
+
+        it('has export (getFoo)', function () {
+          expect(imports.has('getFoo')).to.be.true
+        })
+      })
     })
 
   })

--- a/tests/src/core/parse.js
+++ b/tests/src/core/parse.js
@@ -5,17 +5,20 @@ import parse from 'core/parse'
 import { getFilename } from '../utils'
 
 describe('parse(content, { settings, ecmaFeatures })', function () {
+  const path = getFilename('jsx.js')
   let content
 
   before((done) =>
-    fs.readFile(getFilename('jsx.js'), { encoding: 'utf8' },
+    fs.readFile(path, { encoding: 'utf8' },
       (err, f) => { if (err) { done(err) } else { content = f; done() }}))
 
-  it("doesn't support JSX by default", function () {
-    expect(() => parse(content, { parserPath: 'espree' })).to.throw(Error)
+  it('doesn\'t support JSX by default', function () {
+    expect(() => parse(path, content, { parserPath: 'espree' })).to.throw(Error)
   })
+
   it('infers jsx from ecmaFeatures when using stock parser', function () {
-    expect(() => parse(content, { parserPath: 'espree', parserOptions: { sourceType: 'module', ecmaFeatures: { jsx: true } } }))
+    expect(() => parse(path, content, { settings: {}, parserPath: 'espree', parserOptions: { sourceType: 'module', ecmaFeatures: { jsx: true } } }))
       .not.to.throw(Error)
   })
+
 })


### PR DESCRIPTION
Closes #407. Allows TypeScript or other alt-JS dependencies to be configured via [`import/parsers` setting](https://github.com/benmosher/eslint-plugin-import/tree/typescript#importparsers).

cc @santiagoaguiar, @denneulin for feedback since you two 👍'd the original issue I created. 😎