### PR TITLE
release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - Added an `optionalDependencies` option to [`no-extraneous-dependencies`] to allow/forbid optional dependencies ([#266], thanks [@jfmengels]).
 - Added `newlines-between` option to [`order`] rule ([#298], thanks [@singles])
 - add [`no-mutable-exports`] rule ([#290], thanks [@josh])
-- [`import/extensions` setting]: a whitelist of file extensions to parse as modules
+- [`import/extensions` setting]: a list of file extensions to parse as modules
   and search for `export`s. If unspecified, all extensions are considered valid (for now).
   In v2, this will likely default to `['.js', MODULE_EXT]`. ([#297], to fix [#267])
 
@@ -237,7 +237,7 @@ Unpublished from npm and re-released as 0.13.0. See [#170].
 ### Changed
 - Ignore [`import/ignore` setting] if exports are actually found in the parsed module. Does
 this to support use of `jsnext:main` in `node_modules` without the pain of
-managing a whitelist or a nuanced blacklist.
+managing an allow list or a nuanced deny list.
 
 ## [0.11.0] - 2015-11-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- [`namespace`] exception for get property from `namespace` import, which are re-export from commonjs module ([#416])
 
 ## [1.13.0] - 2016-08-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- [`import/parsers` setting]: parse some dependencies (i.e. TypeScript!) with a different parser than the ESLint-configured parser.
+
 ### Fixed
 - [`namespace`] exception for get property from `namespace` import, which are re-export from commonjs module ([#416])
 
@@ -260,6 +263,7 @@ for info on changes for earlier releases.
 [`import/cache` setting]: ./README.md#importcache
 [`import/ignore` setting]: ./README.md#importignore
 [`import/extensions` setting]: ./README.md#importextensions
+[`import/parsers` setting]: ./README.md#importparsers
 [`import/core-modules` setting]: ./README.md#importcore-modules
 [`import/external-module-folders` setting]: ./README.md#importexternal-module-folders
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Changed
 - Modified [`no-nodejs-modules`] error message to include the module's name ([#453], [#461])
 
+### Fixed
+- [`import/extensions` setting] is respected in spite of the appearance of imports
+  in an imported file. (fixes [#478], thaks [@rhys-vdw])
+
 ## [1.12.0] - 2016-07-26
 ### Added
 - [`import/external-module-folders` setting]: a possibility to configure folders for "external" modules ([#444], thanks [@zloirock])
@@ -311,6 +315,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#478]: https://github.com/benmosher/eslint-plugin-import/issues/478
 [#456]: https://github.com/benmosher/eslint-plugin-import/issues/456
 [#453]: https://github.com/benmosher/eslint-plugin-import/issues/453
 [#441]: https://github.com/benmosher/eslint-plugin-import/issues/441
@@ -399,3 +404,4 @@ for info on changes for earlier releases.
 [@ljharb]: https://github.com/ljharb
 [@rhettlivingston]: https://github.com/rhettlivingston
 [@zloirock]: https://github.com/zloirock
+[@rhys-vdw]: https://github.com/rhys-vdw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-### Modified
+### Added
+- `allowComputed` option for [`namespace`] rule. If set to `true`, won't report
+  computed member references to namespaces. (see [#456])
+
+### Changed
 - Modified [`no-nodejs-modules`] error message to include the module's name ([#453], [#461])
 
 ## [1.12.0] - 2016-07-26
@@ -307,7 +311,11 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+<<<<<<< 30e55b65d6a8a08585aa72c51f8e5871d9a832a6
 [#453]: https://github.com/benmosher/eslint-plugin-import/issues/453
+=======
+[#456]: https://github.com/benmosher/eslint-plugin-import/issues/456
+>>>>>>> add `allowComputed` option to `namespace` (fixes #456)
 [#441]: https://github.com/benmosher/eslint-plugin-import/issues/441
 [#423]: https://github.com/benmosher/eslint-plugin-import/issues/423
 [#415]: https://github.com/benmosher/eslint-plugin-import/issues/415

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+
+## [1.13.0] - 2016-08-11
 ### Added
 - `allowComputed` option for [`namespace`] rule. If set to `true`, won't report
   computed member references to namespaces. (see [#456])
@@ -13,7 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - [`import/extensions` setting] is respected in spite of the appearance of imports
-  in an imported file. (fixes [#478], thaks [@rhys-vdw])
+  in an imported file. (fixes [#478], thanks [@rhys-vdw])
 
 ## [1.12.0] - 2016-07-26
 ### Added
@@ -348,7 +350,8 @@ for info on changes for earlier releases.
 [#119]: https://github.com/benmosher/eslint-plugin-import/issues/119
 [#89]: https://github.com/benmosher/eslint-plugin-import/issues/89
 
-[Unreleased]: https://github.com/benmosher/eslint-plugin-import/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/benmosher/eslint-plugin-import/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.11.1...v1.12.0
 [1.11.1]: https://github.com/benmosher/eslint-plugin-import/compare/v1.11.0...v1.11.1
 [1.11.0]: https://github.com/benmosher/eslint-plugin-import/compare/v1.10.3...v1.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Modified
+- Modified [`no-nodejs-modules`] error message to include the module's name ([#453], [#461])
 
 ## [1.12.0] - 2016-07-26
 ### Added
@@ -269,6 +271,7 @@ for info on changes for earlier releases.
 [`prefer-default-export`]: ./docs/rules/prefer-default-export.md
 [`no-restricted-paths`]: ./docs/rules/no-restricted-paths.md
 
+[#461]: https://github.com/benmosher/eslint-plugin-import/pull/461
 [#444]: https://github.com/benmosher/eslint-plugin-import/pull/444
 [#428]: https://github.com/benmosher/eslint-plugin-import/pull/428
 [#395]: https://github.com/benmosher/eslint-plugin-import/pull/395
@@ -304,6 +307,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#453]: https://github.com/benmosher/eslint-plugin-import/issues/453
 [#441]: https://github.com/benmosher/eslint-plugin-import/issues/441
 [#423]: https://github.com/benmosher/eslint-plugin-import/issues/423
 [#415]: https://github.com/benmosher/eslint-plugin-import/issues/415

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,11 +311,8 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
-<<<<<<< 30e55b65d6a8a08585aa72c51f8e5871d9a832a6
-[#453]: https://github.com/benmosher/eslint-plugin-import/issues/453
-=======
 [#456]: https://github.com/benmosher/eslint-plugin-import/issues/456
->>>>>>> add `allowComputed` option to `namespace` (fixes #456)
+[#453]: https://github.com/benmosher/eslint-plugin-import/issues/453
 [#441]: https://github.com/benmosher/eslint-plugin-import/issues/441
 [#423]: https://github.com/benmosher/eslint-plugin-import/issues/423
 [#415]: https://github.com/benmosher/eslint-plugin-import/issues/415

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ You may set the following settings in your `.eslintrc`:
 
 #### `import/extensions`
 
-A whitelist of file extensions that will be parsed as modules and inspected for
+A list of file extensions that will be parsed as modules and inspected for
 `export`s.
 
 This will default to `['.js']` in the next major revision of this plugin, unless
@@ -207,7 +207,7 @@ Note that this is different from (and likely a subset of) any `import/resolver`
 extensions settings, which may include `.json`, `.coffee`, etc. which will still
 factor into the `no-unresolved` rule.
 
-Also, `import/ignore` patterns will overrule this whitelist, so `node_modules` that
+Also, `import/ignore` patterns will overrule this list, so `node_modules` that
 end in `.js` will still be ignored by default.
 
 #### `import/ignore`

--- a/README.md
+++ b/README.md
@@ -265,6 +265,32 @@ Contribution of more such shared configs for other platforms are welcome!
 
 An array of folders. Resolved modules only from those folders will be considered as "external". By default - `["node_modules"]`. Makes sense if you have configured your path or webpack to handle your internal paths differently and want to considered modules from some folders, for example `bower_components` or `jspm_modules`, as "external".
 
+#### `import/parsers`
+
+A map from parsers to file extension arrays. If a file extension is matched, the
+dependency parser will require and use the map key as the parser instead of the
+configured ESLint parser. This is useful if you're inter-op-ing with TypeScript
+directly using Webpack, for example:
+
+```yaml
+# .eslintrc.yml
+settings:
+  import/parsers:
+    typescript-eslint-parser: [ .ts, .tsx ]
+```
+
+In this case, [`typescript-eslint-parser`](https://github.com/eslint/typescript-eslint-parser) must be installed and require-able from
+the running `eslint` module's location (i.e., install it as a peer of ESLint).
+
+This is currently only tested with `typescript-eslint-parser` but should theoretically
+work with any moderately ESTree-compliant parser.
+
+It's difficult to say how well various plugin features will be supported, too,
+depending on how far down the rabbit hole goes. Submit an issue if you find strange
+behavior beyond here, but steel your heart against the likely outcome of closing
+with `wontfix`.
+
+
 #### `import/resolver`
 
 See [resolvers](#resolvers).

--- a/docs/rules/namespace.md
+++ b/docs/rules/namespace.md
@@ -67,6 +67,24 @@ function deepTrouble() {
 
 ```
 
+### Options
+
+#### `allowComputed`
+
+Defaults to `false`. When false, will report the following:
+
+```js
+/*eslint import/namespace: [2, { allowComputed: false }]*/
+import * as a from './a'
+
+function f(x) {
+  return a[x] // Unable to validate computed reference to imported namespace 'a'.
+}
+```
+
+When set to `true`, the above computed namespace member reference is allowed, but
+still can't be statically analyzed any further.
+
 ## Further Reading
 
 - Lee Byron's [ES7] export proposal

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -8,7 +8,9 @@ The closest parent `package.json` will be used. If no `package.json` is found, t
 This rule supports the following options:
 
 `devDependencies`: If set to `false`, then the rule will show an error when `devDependencies` are imported. Defaults to `true`.
+
 `optionalDependencies`: If set to `false`, then the rule will show an error when `optionalDependencies` are imported. Defaults to `true`.
+
 `peerDependencies`: If set to `false`, then the rule will show an error when `peerDependencies` are imported. Defaults to `false`.
 
 You can set the options like this:

--- a/import.sublime-project
+++ b/import.sublime-project
@@ -3,7 +3,7 @@
 	[
 		{
 			"path": ".",
-			"folder_exclude_patterns": ["reports", "node_modules", "lib"]
+			"folder_exclude_patterns": ["coverage", "node_modules", "lib"]
 		}
 	],
     "SublimeLinter":

--- a/import.sublime-project
+++ b/import.sublime-project
@@ -12,7 +12,11 @@
         {
             "eslint":
             {
-                "chdir": "${project}/"
+                "chdir": "${project}"
+            },
+            "eslint_d":
+            {
+                "chdir": "${project}"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -53,16 +53,18 @@
     "coveralls": "^2.11.4",
     "cross-env": "^2.0.0",
     "eslint": "2.x",
-    "eslint-plugin-import": "next",
     "eslint-import-resolver-node": "file:./resolvers/node",
     "eslint-import-resolver-webpack": "file:./resolvers/webpack",
+    "eslint-plugin-import": "next",
     "gulp": "^3.9.0",
     "gulp-babel": "6.1.2",
     "istanbul": "^0.4.0",
     "mocha": "^2.2.1",
     "nyc": "^7.0.0",
     "redux": "^3.0.4",
-    "rimraf": "2.5.2"
+    "rimraf": "2.5.2",
+    "typescript": "^1.8.10",
+    "typescript-eslint-parser": "^0.1.1"
   },
   "peerDependencies": {
     "eslint": "2.x - 3.x"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "memo-parser"
   ],
   "scripts": {
-    "watch": "cross-env NODE_PATH=./lib gulp watch-test",
+    "watch": "cross-env NODE_PATH=./src mocha --watch --compilers js:babel-register --recursive tests/src",
     "cover": "gulp pretest && cross-env NODE_PATH=./lib istanbul cover --dir reports/coverage _mocha tests/lib/ -- --recursive -R progress",
     "posttest": "eslint ./src",
     "test": "cross-env BABEL_ENV=test NODE_PATH=./src nyc mocha --recursive tests/src -t 5s",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Import with sanity.",
   "main": "lib/index.js",
   "directories": {

--- a/resolvers/node/CHANGELOG.md
+++ b/resolvers/node/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this resolver will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
+## v0.2.3 - 2016-08-20
+### Added
+- debug logging (use `DEBUG=eslint-plugin-import:resolver:node eslint [...]`)
+
 ## v0.2.2 - 2016-07-14
 ### Fixed
 - Node resolver no longer declares the import plugin as a `peerDependency`. See [#437]

--- a/resolvers/node/index.js
+++ b/resolvers/node/index.js
@@ -2,13 +2,25 @@ var resolve = require('resolve')
   , path = require('path')
   , assign = require('object-assign')
 
+var log = require('debug')('eslint-plugin-import:resolver:node')
+
 exports.interfaceVersion = 2
 
 exports.resolve = function (source, file, config) {
-  if (resolve.isCore(source)) return { found: true, path: null }
+  log('Resolving:', source, 'from:', file)
+  var resolvedPath
+
+  if (resolve.isCore(source)) {
+    log('resolved to core')
+    return { found: true, path: null }
+  }
+
   try {
-    return { found: true, path: resolve.sync(source, opts(file, config)) }
+    resolvedPath = resolve.sync(source, opts(file, config))
+    log('Resolved to:', resolvedPath)
+    return { found: true, path: resolvedPath }
   } catch (err) {
+    log('resolve threw error:', err)
     return { found: false }
   }
 }

--- a/resolvers/node/package.json
+++ b/resolvers/node/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/benmosher/eslint-plugin-import",
   "dependencies": {
+    "debug": "^2.2.0",
     "object-assign": "^4.0.1",
     "resolve": "^1.1.6"
   },

--- a/resolvers/node/package.json
+++ b/resolvers/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-node",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Node default behavior import resolution plugin for eslint-plugin-import.",
   "main": "index.js",
   "scripts": {

--- a/resolvers/webpack/CHANGELOG.md
+++ b/resolvers/webpack/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## Unreleased
+### Added
+- support for Webpack 2 + `module` package.json key! ([#475], thanks [@taion])
+
 ### Changed
 - don't swallow errors, assume config exists ([#435], thanks [@Kovensky])
 

--- a/resolvers/webpack/CHANGELOG.md
+++ b/resolvers/webpack/CHANGELOG.md
@@ -5,6 +5,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+## 0.5.1 - 2016-08-11
+### Fixed
+- don't throw and die if no webpack config is found
+
 ## 0.5.0 - 2016-08-11
 ### Added
 - support for Webpack 2 + `module` package.json key! ([#475], thanks [@taion])

--- a/resolvers/webpack/CHANGELOG.md
+++ b/resolvers/webpack/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## Unreleased
+
+## 0.5.0 - 2016-08-11
 ### Added
 - support for Webpack 2 + `module` package.json key! ([#475], thanks [@taion])
 

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -61,7 +61,12 @@ exports.resolve = function (source, file, settings) {
   configPath = findConfigPath(configPath, packageDir)
 
   log('Config path resolved to:', configPath)
-  webpackConfig = require(configPath)
+  if (configPath) {
+    webpackConfig = require(configPath)
+  } else {
+    log("No config path found relative to", file, "; using {}")
+    webpackConfig = {}
+  }
 
   if (webpackConfig && webpackConfig.default) {
     log('Using ES6 module "default" key instead of module.exports.')

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-webpack",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Resolve paths to dependencies, given a webpack.config.js. Plugin for eslint-plugin-import.",
   "main": "index.js",
   "scripts": {

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -32,10 +32,14 @@
     "interpret": "^1.0.0",
     "is-absolute": "^0.2.3",
     "lodash.get": "^3.7.0",
-    "node-libs-browser": "^1.0.0"
+    "node-libs-browser": "^1.0.0",
+    "object-assign": "^4.1.0",
+    "resolve": "^1.1.7",
+    "semver": "^5.3.0"
   },
   "peerDependencies": {
-    "eslint-plugin-import": ">=1.4.0"
+    "eslint-plugin-import": ">=1.4.0",
+    "webpack": "^1.11.0 || ^2.1.0-beta || ^2.1.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-webpack",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Resolve paths to dependencies, given a webpack.config.js. Plugin for eslint-plugin-import.",
   "main": "index.js",
   "scripts": {

--- a/resolvers/webpack/test/package-mains/module/package.json
+++ b/resolvers/webpack/test/package-mains/module/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "lib/index.js",
+  "module": "src/index.js"
+}

--- a/resolvers/webpack/test/packageMains.js
+++ b/resolvers/webpack/test/packageMains.js
@@ -9,6 +9,11 @@ var file = path.join(__dirname, 'package-mains', 'dummy.js')
 
 describe("packageMains", function () {
 
+  it("captures module", function () {
+    expect(webpack.resolve('./module', file)).property('path')
+      .to.equal(path.join(__dirname, 'package-mains', 'module', 'src', 'index.js'))
+  })
+
   it("captures jsnext", function () {
     expect(webpack.resolve('./jsnext', file)).property('path')
       .to.equal(path.join(__dirname, 'package-mains', 'jsnext', 'src', 'index.js'))
@@ -27,6 +32,11 @@ describe("packageMains", function () {
   it("uses configured packageMains, if provided", function () {
     expect(webpack.resolve('./webpack', file, { config: 'webpack.alt.config.js' })).property('path')
       .to.equal(path.join(__dirname, 'package-mains', 'webpack', 'index.js'))
+  })
+
+  it("always defers to module, regardless of config", function () {
+    expect(webpack.resolve('./module', file, { config: 'webpack.alt.config.js' })).property('path')
+      .to.equal(path.join(__dirname, 'package-mains', 'module', 'src', 'index.js'))
   })
 
   it("always defers to jsnext:main, regardless of config", function () {

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -5,11 +5,15 @@ import * as fs from 'fs'
 import { createHash } from 'crypto'
 import * as doctrine from 'doctrine'
 
+import debug from 'debug'
+
 import parse from './parse'
 import resolve, { relative as resolveRelative } from './resolve'
 import isIgnored, { hasValidExtension } from './ignore'
 
 import { hashObject } from './hash'
+
+const log = debug('eslint-plugin-import:ExportMap')
 
 const exportCache = new Map()
 
@@ -96,8 +100,9 @@ export default class ExportMap {
     var m = new ExportMap(path)
 
     try {
-      var ast = parse(content, context)
+      var ast = parse(path, content, context)
     } catch (err) {
+      log('parse error:', path, err)
       m.errors.push(err)
       return m // can't continue
     }

--- a/src/core/getExports.js
+++ b/src/core/getExports.js
@@ -7,7 +7,7 @@ import * as doctrine from 'doctrine'
 
 import parse from './parse'
 import resolve, { relative as resolveRelative } from './resolve'
-import isIgnored from './ignore'
+import isIgnored, { hasValidExtension } from './ignore'
 
 import { hashObject } from './hash'
 
@@ -69,6 +69,12 @@ export default class ExportMap {
         return exportMap
       }
       // future: check content equality?
+    }
+
+    // check valid extensions first
+    if (!hasValidExtension(path, context)) {
+      exportCache.set(cacheKey, null)
+      return null
     }
 
     const content = fs.readFileSync(path, { encoding: 'utf8' })

--- a/src/core/ignore.js
+++ b/src/core/ignore.js
@@ -26,7 +26,7 @@ export default function ignore(path, context) {
     : ['node_modules']
 
   // check extension list first (cheap)
-  if (!validExtensions(context).has(extname(path))) return true
+  if (!hasValidExtension(path, context)) return true
 
   if (ignoreStrings.length === 0) return false
 
@@ -36,4 +36,8 @@ export default function ignore(path, context) {
   }
 
   return false
+}
+
+export function hasValidExtension(path, context) {
+  return validExtensions(context).has(extname(path))
 }

--- a/src/core/ignore.js
+++ b/src/core/ignore.js
@@ -13,10 +13,25 @@ function validExtensions({ settings }) {
   // breaking: default to '.js'
   // cachedSet = new Set(settings['import/extensions'] || [ '.js' ])
   cachedSet = 'import/extensions' in settings
-    ? new Set(settings['import/extensions'])
+    ? makeValidExtensionSet(settings)
     : { has: () => true } // the set of all elements
 
   return cachedSet
+}
+
+function makeValidExtensionSet(settings) {
+  // start with explicit JS-parsed extensions
+  const exts = new Set(settings['import/extensions'])
+
+  // all alternate parser extensions are also valid
+  if ('import/parsers' in settings) {
+    for (let parser in settings['import/parsers']) {
+      settings['import/parsers'][parser]
+        .forEach(ext => exts.add(ext))
+    }
+  }
+
+  return exts
 }
 
 export default function ignore(path, context) {

--- a/src/core/ignore.js
+++ b/src/core/ignore.js
@@ -25,7 +25,7 @@ export default function ignore(path, context) {
     ? [].concat(context.settings['import/ignore'])
     : ['node_modules']
 
-  // check extension whitelist first (cheap)
+  // check extension list first (cheap)
   if (!validExtensions(context).has(extname(path))) return true
 
   if (ignoreStrings.length === 0) return false

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -131,9 +131,12 @@ exports.create = function namespaceRule(context) {
           break
         }
 
+        const exported = namespace.get(dereference.property.name)
+        if (exported == null) return
+
         // stash and pop
         namepath.push(dereference.property.name)
-        namespace = namespace.get(dereference.property.name).namespace
+        namespace = exported.namespace
         dereference = dereference.parent
       }
 

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -4,7 +4,30 @@ import Exports from '../core/getExports'
 import importDeclaration from '../importDeclaration'
 import declaredScope from '../core/declaredScope'
 
-module.exports = function (context) {
+exports.meta = {
+  schema: [
+    {
+      'type': 'object',
+      'properties': {
+        'allowComputed': {
+          'description':
+            'If `false`, will report computed (and thus, un-lintable) references ' +
+            'to namespace members.',
+          'type': 'boolean',
+          'default': false,
+        },
+      },
+      'additionalProperties': false,
+    },
+  ],
+}
+
+exports.create = function namespaceRule(context) {
+
+  // read options
+  const {
+    allowComputed = false,
+  } = context.options[0] || {}
 
   const namespaces = new Map()
 
@@ -93,9 +116,11 @@ module.exports = function (context) {
              dereference.type === 'MemberExpression') {
 
         if (dereference.computed) {
-          context.report(dereference.property,
-            'Unable to validate computed reference to imported namespace \'' +
-            dereference.object.name + '\'.')
+          if (!allowComputed) {
+            context.report(dereference.property,
+              'Unable to validate computed reference to imported namespace \'' +
+              dereference.object.name + '\'.')
+          }
           return
         }
 

--- a/src/rules/no-nodejs-modules.js
+++ b/src/rules/no-nodejs-modules.js
@@ -3,7 +3,7 @@ import isStaticRequire from '../core/staticRequire'
 
 function reportIfMissing(context, node, name) {
   if (importType(name, context) === 'builtin') {
-    context.report(node, 'Do not import Node.js builtin modules')
+    context.report(node, 'Do not import Node.js builtin module "' + name + '"')
   }
 }
 

--- a/tests/files/commonjs-namespace/a.js
+++ b/tests/files/commonjs-namespace/a.js
@@ -1,0 +1,1 @@
+export { default as b } from './b'

--- a/tests/files/commonjs-namespace/b.js
+++ b/tests/files/commonjs-namespace/b.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/tests/files/typescript.ts
+++ b/tests/files/typescript.ts
@@ -1,0 +1,5 @@
+type X = { y: string | null }
+
+export function getX() : X {
+  return null
+}

--- a/tests/files/typescript.ts
+++ b/tests/files/typescript.ts
@@ -1,5 +1,5 @@
-type X = { y: string | null }
+type X = string
 
-export function getX() : X {
-  return null
+export function getFoo() : X {
+  return "foo"
 }

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -292,4 +292,19 @@ describe('getExports', function () {
     })
   })
 
+  context('issue #478: never parse non-whitelist extensions', function () {
+    const context = Object.assign({}, fakeContext,
+      { settings: { 'import/extensions': ['.js'] } })
+
+    let imports
+    before('load imports', function () {
+      imports = ExportMap.get('./typescript.ts', context)
+    })
+
+    it('returns nothing for a TypeScript file', function () {
+      expect(imports).not.to.exist
+    })
+
+  })
+
 })

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -83,11 +83,12 @@ describe('getExports', function () {
     var imports = ExportMap.parse(
       path,
       contents,
-      { parserPath: 'babel-eslint' }
+      { parserPath: 'babel-eslint', settings: {} }
     )
 
-    expect(imports).to.exist
-    expect(imports.get('default')).to.exist
+    expect(imports, 'imports').to.exist
+    expect(imports.errors).to.be.empty
+    expect(imports.get('default'), 'default export').to.exist
     expect(imports.has('Bar')).to.be.true
   })
 
@@ -187,6 +188,7 @@ describe('getExports', function () {
           sourceType: 'module',
           attachComment: true,
         },
+        settings: {},
       })
     })
 
@@ -197,6 +199,7 @@ describe('getExports', function () {
           sourceType: 'module',
           attachComment: true,
         },
+        settings: {},
       })
     })
   })
@@ -303,6 +306,37 @@ describe('getExports', function () {
 
     it('returns nothing for a TypeScript file', function () {
       expect(imports).not.to.exist
+    })
+
+  })
+
+  context('alternate parsers', function () {
+    const configs = [
+      // ['string form', { 'typescript-eslint-parser': '.ts' }],
+      ['array form', { 'typescript-eslint-parser': ['.ts', '.tsx'] }],
+    ]
+
+    configs.forEach(([description, parserConfig]) => {
+      describe(description, function () {
+        const context = Object.assign({}, fakeContext,
+          { settings: {
+            'import/extensions': ['.js'],
+            'import/parsers': parserConfig,
+          } })
+
+        let imports
+        before('load imports', function () {
+          imports = ExportMap.get('./typescript.ts', context)
+        })
+
+        it('returns something for a TypeScript file', function () {
+          expect(imports).to.exist
+        })
+
+        it('has export (getFoo)', function () {
+          expect(imports.has('getFoo')).to.be.true
+        })
+      })
     })
 
   })

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -296,7 +296,7 @@ describe('getExports', function () {
   })
 
   context('issue #478: never parse non-whitelist extensions', function () {
-    const context = Object.assign({}, fakeContext,
+    const context = assign({}, fakeContext,
       { settings: { 'import/extensions': ['.js'] } })
 
     let imports
@@ -318,7 +318,7 @@ describe('getExports', function () {
 
     configs.forEach(([description, parserConfig]) => {
       describe(description, function () {
-        const context = Object.assign({}, fakeContext,
+        const context = assign({}, fakeContext,
           { settings: {
             'import/extensions': ['.js'],
             'import/parsers': parserConfig,

--- a/tests/src/core/parse.js
+++ b/tests/src/core/parse.js
@@ -5,17 +5,20 @@ import parse from 'core/parse'
 import { getFilename } from '../utils'
 
 describe('parse(content, { settings, ecmaFeatures })', function () {
+  const path = getFilename('jsx.js')
   let content
 
   before((done) =>
-    fs.readFile(getFilename('jsx.js'), { encoding: 'utf8' },
+    fs.readFile(path, { encoding: 'utf8' },
       (err, f) => { if (err) { done(err) } else { content = f; done() }}))
 
-  it("doesn't support JSX by default", function () {
-    expect(() => parse(content, { parserPath: 'espree' })).to.throw(Error)
+  it('doesn\'t support JSX by default', function () {
+    expect(() => parse(path, content, { parserPath: 'espree' })).to.throw(Error)
   })
+
   it('infers jsx from ecmaFeatures when using stock parser', function () {
-    expect(() => parse(content, { parserPath: 'espree', parserOptions: { sourceType: 'module', ecmaFeatures: { jsx: true } } }))
+    expect(() => parse(path, content, { settings: {}, parserPath: 'espree', parserOptions: { sourceType: 'module', ecmaFeatures: { jsx: true } } }))
       .not.to.throw(Error)
   })
+
 })

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -87,6 +87,12 @@ const valid = [
     parser: 'babel-eslint',
   }),
 
+  // #456: optionally ignore computed references
+  test({
+    code: `import * as names from './named-exports'; console.log(names['a']);`,
+    options: [{ allowComputed: true }],
+  }),
+
   ...SYNTAX_CASES,
 ]
 

--- a/tests/src/rules/no-nodejs-modules.js
+++ b/tests/src/rules/no-nodejs-modules.js
@@ -5,10 +5,10 @@ import { RuleTester } from 'eslint'
 const ruleTester = new RuleTester()
     , rule = require('rules/no-nodejs-modules')
 
-const errors = [{
+const error = message => ({
   ruleId: 'no-nodejs-modules',
-  message: 'Do not import Node.js builtin modules',
-}]
+  message,
+})
 
 ruleTester.run('no-nodejs-modules', rule, {
   valid: [
@@ -30,19 +30,19 @@ ruleTester.run('no-nodejs-modules', rule, {
   invalid: [
     test({
       code: 'import path from "path"',
-      errors,
+      errors: [error('Do not import Node.js builtin module "path"')],
     }),
     test({
       code: 'import fs from "fs"',
-      errors,
+      errors: [error('Do not import Node.js builtin module "fs"')],
     }),
     test({
       code: 'var path = require("path")',
-      errors,
+      errors: [error('Do not import Node.js builtin module "path"')],
     }),
     test({
       code: 'var fs = require("fs")',
-      errors,
+      errors: [error('Do not import Node.js builtin module "fs"')],
     }),
   ],
 })

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -57,7 +57,7 @@ export const SYNTAX_CASES = [
   test({ code: 'export default x' }),
   test({ code: 'export default class x {}' }),
 
-  // issue #267: parser whitelist
+  // issue #267: parser opt-in extension list
   test({
     code: 'import json from "./data.json"',
     settings: { 'import/extensions': ['.js'] }, // breaking: remove for v2

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -84,4 +84,8 @@ export const SYNTAX_CASES = [
     code: 'export * from "./issue-370-commonjs-namespace/bar"',
     settings: { 'import/ignore': ['foo'] },
   }),
+
+  test({
+    code: 'import * as a from "./commonjs-namespace/a"; a.b',
+  }),
  ]


### PR DESCRIPTION
cc @jfmengels. I want to get `import/parsers` published so I can use it at work.

Also I clearly forgot to do this for 1.13.0 😳, only changes are the bugfix for #416 (PR #499) and `import/parsers` via #503. I have QA'd.

**PR summary:**
- #499: fix #416 
- #503: add `import/parsers` to support ES-module-compliant alt-JS interop

It'd probably be good if you took a look at the `import/parsers` config schema. Though v2 is on the horizon so we could break it if needed/desired as part of that release... only thing I'm thinking is whether it should be glob- or regex-based instead of array-of-extensions. I like AoE mostly for consistency with `import/extensions`, and it's easy to grok. Con: less powerful, but could be enhanced to support glob/regex later if desired.