### PR TITLE
Allow filename patterns for rule no-extraneous-dependencies.

### DIFF
--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -25,25 +25,13 @@ You can also use globs instead of literal booleans:
 "import/no-extraneous-dependencies": ["error", {"devDependencies": "*.test.js"}]
 ```
 
-You can also use regular expressions instead of literal booleans or globs (note: the string must begin and end with `/`):
+When using a glob, the setting will be activated if the name of the file being linted matches the given glob. In addition, you can use an array to specify multiple globs:
 
 ```js
-"import/no-extraneous-dependencies": ["error", {"devDependencies": "/test|spec/"}]
+"import/no-extraneous-dependencies": ["error", {"devDependencies": ['*.test.js', '*.spec.js']}]
 ```
 
-If you are using JavaScript configuration (e.g., `.eslintrc.js`), then you can use a RegExp literal instead of a string:
-
-```js
-"import/no-extraneous-dependencies": ["error", {"devDependencies": /test|spec/}]
-```
-
-When using a glob or regular expression, the setting will be activated if the name of the file being linted matches the given glob or regular expression. In addition, you can use an array to specify multiple globs or regular expressions:
-
-```js
-"import/no-extraneous-dependencies": ["error", {"devDependencies": [/test/, '/spec/', '*.test.js', '*.spec.js']}]
-```
-
-When using an array of globs or regular expressions, the setting will be activated if the name of the file being linted matches a single glob or regular expression in the array.
+When using an array of globs, the setting will be activated if the name of the file being linted matches a single glob in the array.
 
 ## Rule Details
 

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -19,13 +19,7 @@ You can set the options like this:
 "import/no-extraneous-dependencies": ["error", {"devDependencies": false, "optionalDependencies": false, "peerDependencies": false}]
 ```
 
-You can also use globs instead of literal booleans:
-
-```js
-"import/no-extraneous-dependencies": ["error", {"devDependencies": "*.test.js"}]
-```
-
-When using a glob, the setting will be activated if the name of the file being linted matches the given glob. In addition, you can use an array to specify multiple globs:
+You can also use an array of globs instead of literal booleans:
 
 ```js
 "import/no-extraneous-dependencies": ["error", {"devDependencies": ['*.test.js', '*.spec.js']}]

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -31,7 +31,7 @@ If you are using JavaScript configuration (e.g., `.eslintrc.js`), then you can u
 "import/no-extraneous-dependencies": ["error", {"devDependencies": /test|spec/}]
 ```
 
-When using a regular expression the result of running [`test`] against the name of the file being linted is used as the boolean value. For example, the above configurations will allow the import of `devDependencies` in files whose names include `test` or `spec`.
+When using a regular expression, the setting will be activated if the name of the file being linted matches the given regular expression. For example, the above configurations will allow the import of `devDependencies` in files whose names include `test` or `spec`.
 
 ## Rule Details
 
@@ -99,5 +99,3 @@ import react from 'react';
 ## When Not To Use It
 
 If you do not have a `package.json` file in your project.
-
-[`test`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test "RegExp.prototype.test"

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -19,10 +19,16 @@ You can set the options like this:
 "import/no-extraneous-dependencies": ["error", {"devDependencies": false, "optionalDependencies": false, "peerDependencies": false}]
 ```
 
-You can also use regular expressions instead of literal booleans:
+You can also use globs instead of literal booleans:
 
 ```js
-"import/no-extraneous-dependencies": ["error", {"devDependencies": "test|spec"}]
+"import/no-extraneous-dependencies": ["error", {"devDependencies": "*.test.js"}]
+```
+
+You can also use regular expressions instead of literal booleans or globs (note: the string must begin and end with `/`):
+
+```js
+"import/no-extraneous-dependencies": ["error", {"devDependencies": "/test|spec/"}]
 ```
 
 If you are using JavaScript configuration (e.g., `.eslintrc.js`), then you can use a RegExp literal instead of a string:
@@ -31,7 +37,13 @@ If you are using JavaScript configuration (e.g., `.eslintrc.js`), then you can u
 "import/no-extraneous-dependencies": ["error", {"devDependencies": /test|spec/}]
 ```
 
-When using a regular expression, the setting will be activated if the name of the file being linted matches the given regular expression. For example, the above configurations will allow the import of `devDependencies` in files whose names include `test` or `spec`.
+When using a glob or regular expression, the setting will be activated if the name of the file being linted matches the given glob or regular expression. In addition, you can use an array to specify multiple globs or regular expressions:
+
+```js
+"import/no-extraneous-dependencies": ["error", {"devDependencies": [/test/, '/spec/', '*.test.js', '*.spec.js']}]
+```
+
+When using an array of globs or regular expressions, the setting will be activated if the name of the file being linted matches a single glob or regular expression in the array.
 
 ## Rule Details
 

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -19,6 +19,19 @@ You can set the options like this:
 "import/no-extraneous-dependencies": ["error", {"devDependencies": false, "optionalDependencies": false, "peerDependencies": false}]
 ```
 
+You can also use regular expressions instead of literal booleans:
+
+```js
+"import/no-extraneous-dependencies": ["error", {"devDependencies": "test|spec"}]
+```
+
+If you are using JavaScript configuration (e.g., `.eslintrc.js`), then you can use a RegExp literal instead of a string:
+
+```js
+"import/no-extraneous-dependencies": ["error", {"devDependencies": /test|spec/}]
+```
+
+When using a regular expression the result of running [`test`] against the name of the file being linted is used as the boolean value. For example, the above configurations will allow the import of `devDependencies` in files whose names include `test` or `spec`.
 
 ## Rule Details
 
@@ -86,3 +99,5 @@ import react from 'react';
 ## When Not To Use It
 
 If you do not have a `package.json` file in your project.
+
+[`test`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test "RegExp.prototype.test"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lodash.endswith": "^4.0.1",
     "lodash.find": "^4.3.0",
     "lodash.findindex": "^4.3.0",
+    "minimatch": "^3.0.3",
     "object-assign": "^4.0.1",
     "pkg-dir": "^1.0.0",
     "pkg-up": "^1.0.0"

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -78,7 +78,7 @@ function testConfig(config, filename) {
     return config
   }
   // Account for the possibility of an array for multiple configuration
-  return [].concat(config).some(c =>  minimatch(filename, c))
+  return config.some(c => minimatch(filename, c))
 }
 
 module.exports = function (context) {
@@ -113,9 +113,9 @@ module.exports.schema = [
   {
     'type': 'object',
     'properties': {
-      'devDependencies': { 'type': ['boolean', 'string', 'array'] },
-      'optionalDependencies': { 'type': ['boolean', 'string', 'array'] },
-      'peerDependencies': { 'type': ['boolean', 'string', 'array'] },
+      'devDependencies': { 'type': ['boolean', 'array'] },
+      'optionalDependencies': { 'type': ['boolean', 'array'] },
+      'peerDependencies': { 'type': ['boolean', 'array'] },
     },
     'additionalProperties': false,
   },

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -71,8 +71,17 @@ function reportIfMissing(context, deps, depsOptions, node, name) {
   context.report(node, missingErrorMessage(packageName))
 }
 
+function testConfig(config, filename) {
+  if (typeof config === 'boolean' || typeof config === 'undefined') {
+    return config
+  }
+  const pattern = new RegExp(config) // `config` is either a string or RegExp
+  return pattern.test(filename)
+}
+
 module.exports = function (context) {
   const options = context.options[0] || {}
+  const filename = context.getFilename()
   const deps = getDependencies(context)
 
   if (!deps) {
@@ -80,9 +89,9 @@ module.exports = function (context) {
   }
 
   const depsOptions = {
-    allowDevDeps: options.devDependencies !== false,
-    allowOptDeps: options.optionalDependencies !== false,
-    allowPeerDeps: options.peerDependencies !== false,
+    allowDevDeps: testConfig(options.devDependencies, filename) !== false,
+    allowOptDeps: testConfig(options.optionalDependencies, filename) !== false,
+    allowPeerDeps: testConfig(options.peerDependencies, filename) !== false,
   }
 
   // todo: use module visitor from module-utils core
@@ -102,9 +111,9 @@ module.exports.schema = [
   {
     'type': 'object',
     'properties': {
-      'devDependencies': { 'type': 'boolean' },
-      'optionalDependencies': { 'type': 'boolean' },
-      'peerDependencies': { 'type': 'boolean' },
+      'devDependencies': { 'type': ['boolean', 'string', 'object'] },
+      'optionalDependencies': { 'type': ['boolean', 'string', 'object'] },
+      'peerDependencies': { 'type': ['boolean', 'string', 'object'] },
     },
     'additionalProperties': false,
   },

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -78,20 +78,7 @@ function testConfig(config, filename) {
     return config
   }
   // Account for the possibility of an array for multiple configuration
-  return [].concat(config).some(c => {
-    if (typeof c === 'object') {
-      // `c` is a literal RegExp
-      return c.test(filename)
-    }
-    // By this point `c` must be a string.
-    if (/^\/.+\/$/.test(c)) {
-      // `c` is a string representation of a RegExp.
-      const pattern = new RegExp(c.substring(1, c.length - 1))
-      return pattern.test(filename)
-    }
-    // `c` must be a string representing a glob
-    return minimatch(filename, c)
-  })
+  return [].concat(config).some(c =>  minimatch(filename, c))
 }
 
 module.exports = function (context) {
@@ -126,9 +113,9 @@ module.exports.schema = [
   {
     'type': 'object',
     'properties': {
-      'devDependencies': { 'type': ['boolean', 'string', 'object', 'array'] },
-      'optionalDependencies': { 'type': ['boolean', 'string', 'object', 'array'] },
-      'peerDependencies': { 'type': ['boolean', 'string', 'object', 'array'] },
+      'devDependencies': { 'type': ['boolean', 'string', 'array'] },
+      'optionalDependencies': { 'type': ['boolean', 'string', 'array'] },
+      'peerDependencies': { 'type': ['boolean', 'string', 'array'] },
     },
     'additionalProperties': false,
   },

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -73,11 +73,11 @@ function reportIfMissing(context, deps, depsOptions, node, name) {
 }
 
 function testConfig(config, filename) {
-  // Simplest configuration first
+  // Simplest configuration first, either a boolean or nothing.
   if (typeof config === 'boolean' || typeof config === 'undefined') {
     return config
   }
-  // Account for the possibility of an array for multiple configuration
+  // Array of globs.
   return config.some(c => minimatch(filename, c))
 }
 

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -37,7 +37,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
-      options: [{devDependencies: '*.spec.js'}],
+      options: [{devDependencies: ['*.spec.js']}],
       filename: 'foo.spec.js',
     }),
     test({
@@ -101,7 +101,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
-      options: [{devDependencies: '*.test.js'}],
+      options: [{devDependencies: ['*.test.js']}],
       filename: 'foo.tes.js',
       errors: [{
         ruleId: 'no-extraneous-dependencies',

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -37,27 +37,12 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
-      options: [{devDependencies: /test|spec/}],
-      filename: 'foo.test.js',
-    }),
-    test({
-      code: 'import chai from "chai"',
-      options: [{devDependencies: '/test|spec/'}],
-      filename: 'foo.spec.js',
-    }),
-    test({
-      code: 'import chai from "chai"',
       options: [{devDependencies: '*.spec.js'}],
       filename: 'foo.spec.js',
     }),
     test({
       code: 'import chai from "chai"',
       options: [{devDependencies: ['*.test.js', '*.spec.js']}],
-      filename: 'foo.spec.js',
-    }),
-    test({
-      code: 'import chai from "chai"',
-      options: [{devDependencies: [/\.test\.js$/, /\.spec\.js$/]}],
       filename: 'foo.spec.js',
     }),
   ],
@@ -116,24 +101,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
-      options: [{devDependencies: /test|spec/}],
-      filename: 'foo.tes.js',
-      errors: [{
-        ruleId: 'no-extraneous-dependencies',
-        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
-      }],
-    }),
-    test({
-      code: 'import chai from "chai"',
-      options: [{devDependencies: '/test|spec/'}],
-      filename: 'foo.tes.js',
-      errors: [{
-        ruleId: 'no-extraneous-dependencies',
-        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
-      }],
-    }),
-    test({
-      code: 'import chai from "chai"',
       options: [{devDependencies: '*.test.js'}],
       filename: 'foo.tes.js',
       errors: [{
@@ -143,7 +110,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
-      options: [{devDependencies: ['*.test.js', /test\.js$/, '/test/']}],
+      options: [{devDependencies: ['*.test.js', '*.spec.js']}],
       filename: 'foo.tes.js',
       errors: [{
         ruleId: 'no-extraneous-dependencies',

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -38,12 +38,27 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'import chai from "chai"',
       options: [{devDependencies: /test|spec/}],
-      filename: 'glob.test.js',
+      filename: 'foo.test.js',
     }),
     test({
       code: 'import chai from "chai"',
-      options: [{devDependencies: 'test|spec'}],
-      filename: 'glob.spec.js',
+      options: [{devDependencies: '/test|spec/'}],
+      filename: 'foo.spec.js',
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: '*.spec.js'}],
+      filename: 'foo.spec.js',
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: ['*.test.js', '*.spec.js']}],
+      filename: 'foo.spec.js',
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: [/\.test\.js$/, /\.spec\.js$/]}],
+      filename: 'foo.spec.js',
     }),
   ],
   invalid: [
@@ -110,7 +125,25 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
-      options: [{devDependencies: 'test|spec'}],
+      options: [{devDependencies: '/test|spec/'}],
+      filename: 'foo.tes.js',
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
+      }],
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: '*.test.js'}],
+      filename: 'foo.tes.js',
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
+      }],
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: ['*.test.js', /test\.js$/, '/test/']}],
       filename: 'foo.tes.js',
       errors: [{
         ruleId: 'no-extraneous-dependencies',

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -35,6 +35,16 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "importType"',
       settings: { 'import/resolver': { node: { paths: [ path.join(__dirname, '../../files') ] } } },
     }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: /test|spec/}],
+      filename: 'glob.test.js',
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: 'test|spec'}],
+      filename: 'glob.spec.js',
+    }),
   ],
   invalid: [
     test({
@@ -87,6 +97,24 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       errors: [{
         ruleId: 'no-extraneous-dependencies',
         message: '\'glob\' should be listed in the project\'s dependencies, not devDependencies.',
+      }],
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: /test|spec/}],
+      filename: 'foo.tes.js',
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
+      }],
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: 'test|spec'}],
+      filename: 'foo.tes.js',
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
     test({


### PR DESCRIPTION
Following the suggestion in https://github.com/benmosher/eslint-plugin-import/issues/470#issuecomment-237035169.

Fixes #470.