### PR TITLE
Support webpack configs that export a function

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -68,6 +68,10 @@ exports.resolve = function (source, file, settings) {
     webpackConfig = {}
   }
 
+  if( typeof webpackConfig === 'function' ) {
+    webpackConfig = webpackConfig()
+  }
+
   if (webpackConfig && webpackConfig.default) {
     log('Using ES6 module "default" key instead of module.exports.')
     webpackConfig = webpackConfig.default

--- a/resolvers/webpack/test/files/webpack.function.config.js
+++ b/resolvers/webpack/test/files/webpack.function.config.js
@@ -1,0 +1,36 @@
+var path = require('path')
+var pluginsTest = require('webpack-resolver-plugin-test')
+
+module.exports = function() {
+  return {
+    resolve: {
+      alias: {
+        'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
+        'some-alias': path.join(__dirname, 'some'),
+      },
+      modulesDirectories: ['node_modules', 'bower_components'],
+      root: path.join(__dirname, 'src'),
+      fallback: path.join(__dirname, 'fallback'),
+    },
+
+    externals: [
+      { 'jquery': 'jQuery' },
+      'bootstrap',
+      function (context, request, callback) {
+        if (request === 'underscore') {
+          return callback(null, 'underscore')
+        }
+        callback()
+      },
+    ],
+
+    plugins: [
+      new pluginsTest.ResolverPlugin([
+        new pluginsTest.SimpleResolver(
+          path.join(__dirname, 'some', 'bar', 'bar.js'),
+          path.join(__dirname, 'some', 'bar')
+        ),
+      ]),
+    ],
+  }
+}

--- a/resolvers/webpack/test/root.js
+++ b/resolvers/webpack/test/root.js
@@ -24,4 +24,13 @@ describe("root", function () {
       .property('path')
       .to.equal(path.join(__dirname, 'files', 'bower_components', 'typeahead.js'))
   })
+  it("supports definition as a function", function () {
+    expect(resolve('main-module', file, { config: "webpack.function.config.js" }))
+      .property('path')
+      .to.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
+    expect(resolve('typeahead', file, { config: "webpack.function.config.js" }))
+      .property('path')
+      .to.equal(path.join(__dirname, 'files', 'bower_components', 'typeahead.js'))
+  })
+
 })


### PR DESCRIPTION
Webpack 2 supports webpack configuration files that export a function (see https://webpack.github.io/docs/roadmap.html). This commit adds support for this by testing if the `require`ed config is a function, and if so, executing it.