### PR TITLE
Suggested change to readme

### DIFF
--- a/resolvers/webpack/README.md
+++ b/resolvers/webpack/README.md
@@ -7,6 +7,19 @@ Webpack-literate module resolution plugin for [`eslint-plugin-import`](https://w
 Published separately to allow pegging to a specific version in case of breaking
 changes.
 
+To use with `eslint-plugin-import`, run:
+
+```
+npm i eslint-import-resolver-webpack -g
+```
+
+or if you manage ESLint as a dev dependency:
+
+```
+# inside your project's working tree
+npm install eslint-import-resolver-webpack --save-dev
+```
+
 Will look for `webpack.config.js` as a sibling of the first ancestral `package.json`,
 or a `config` parameter may be provided with another filename/path either relative to the
 `package.json`, or a complete, absolute path.


### PR DESCRIPTION
Took a while to hunt down why my config wasn't working and figured out that I needed to add this dependency only after reading through [#238](https://github.com/benmosher/eslint-plugin-import/issues/238) and noticing [this line in a linked example](https://gist.github.com/ravasthi/abcfee465411fc45a8bc28decb9d8e5e#file-package-json-L24).

I think adding this line may add some clarity and save time for several other webpack / eslint noobs (like me 😄 ).