### PR TITLE
no-extraneous-dependencies allow array of globs option

### DIFF
--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -113,9 +113,15 @@ module.exports.schema = [
   {
     'type': 'object',
     'properties': {
-      'devDependencies': { 'type': ['boolean', 'array'] },
-      'optionalDependencies': { 'type': ['boolean', 'array'] },
-      'peerDependencies': { 'type': ['boolean', 'array'] },
+      'devDependencies': {
+        'anyOf': [{ 'type': 'boolean' }, { 'type': 'array' }],
+      },
+      'optionalDependencies': {
+        'anyOf': [{ 'type': 'boolean' }, { 'type': 'array' }],
+      },
+      'peerDependencies': {
+        'anyOf': [{ 'type': 'boolean' }, { 'type': 'array' }],
+      },
     },
     'additionalProperties': false,
   },


### PR DESCRIPTION
`no-extraneous-dependencies` rule options `devDependencies`, `peerDependencies` and `optionalDependencies` should allow boolean and array values.

See docs: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md