### PR TITLE
docs: Update obsoleted reference

### DIFF
--- a/docs/rules/no-named-as-default.md
+++ b/docs/rules/no-named-as-default.md
@@ -27,7 +27,7 @@ import foo from './foo.js';
 import bar from './foo.js';
 ```
 
-For [ES7], this also prevents exporting the default from a referenced module as a name within than module, for the same reasons:
+For post-ES2015 `export` extensions, this also prevents exporting the default from a referenced module as a name within than module, for the same reasons:
 
 ```js
 // valid:
@@ -39,8 +39,8 @@ export bar from './foo.js';
 
 ## Further Reading
 
-- ECMAScript Proposal: export ns from
-- ECMAScript Proposal: export default from
+- ECMAScript Proposal: [export ns from]
+- ECMAScript Proposal: [export default from]
 
-[export-ns-from]: https://github.com/leebyron/ecmascript-export-ns-from
-[export-default-from]: https://github.com/leebyron/ecmascript-export-default-from
+[export ns from]: https://github.com/leebyron/ecmascript-export-ns-from
+[export default from]: https://github.com/leebyron/ecmascript-export-default-from

--- a/docs/rules/no-named-as-default.md
+++ b/docs/rules/no-named-as-default.md
@@ -39,6 +39,8 @@ export bar from './foo.js';
 
 ## Further Reading
 
-- Lee Byron's [ES7] export proposal
+- ECMAScript Proposal: export ns from
+- ECMAScript Proposal: export default from
 
-[ES7]: https://github.com/leebyron/ecmascript-more-export-from
+[export-ns-from]: https://github.com/leebyron/ecmascript-export-ns-from
+[export-default-from]: https://github.com/leebyron/ecmascript-export-default-from


### PR DESCRIPTION
Since [Additional export-from statements in ES7](https://github.com/leebyron/ecmascript-more-export-from) has been separated repo in [export-ns-from](https://github.com/leebyron/ecmascript-export-ns-from) and [export-default-from](https://github.com/leebyron/ecmascript-export-default-from), reference link need to update.