### PR TITLE
Fix #564: Fix tests not running due to Espree bump

### DIFF
--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -2,9 +2,7 @@ import { test, SYNTAX_CASES } from '../utils'
 
 import { RuleTester } from 'eslint'
 
-var ruleTester = new RuleTester({
-  parser: 'babel-eslint'
-})
+var ruleTester = new RuleTester({ parser: 'babel-eslint' })
   , rule = require('rules/export')
 
 ruleTester.run('export', rule, {
@@ -73,13 +71,15 @@ ruleTester.run('export', rule, {
     //                            '\'./default-export\'.'
     //                 , type: 'Literal' }] }),
 
-    // test({
-    //   code: 'export * from "./malformed.js"',
-    //   errors: [{
-    //     message: "Parse errors in imported module './malformed.js': 'return' outside of function (1:1)",
-    //     type: 'Literal',
-    //   }],
-    // }),
+    // note: Espree bump to Acorn 4+ changed this test's error message.
+    //       `npm up` first if it's failing.
+    test({
+      code: 'export * from "./malformed.js"',
+      errors: [{
+        message: "Parse errors in imported module './malformed.js': Line 1: Unexpected token (1:12)",
+        type: 'Literal',
+      }],
+    }),
 
     test({
       code: 'export var { foo, bar } = object; export var foo = "bar"',

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -2,7 +2,9 @@ import { test, SYNTAX_CASES } from '../utils'
 
 import { RuleTester } from 'eslint'
 
-var ruleTester = new RuleTester()
+var ruleTester = new RuleTester({
+  parser: 'babel-eslint'
+})
   , rule = require('rules/export')
 
 ruleTester.run('export', rule, {
@@ -71,13 +73,13 @@ ruleTester.run('export', rule, {
     //                            '\'./default-export\'.'
     //                 , type: 'Literal' }] }),
 
-    test({
-      code: 'export * from "./malformed.js"',
-      errors: [{
-        message: "Parse errors in imported module './malformed.js': 'return' outside of function (1:1)",
-        type: 'Literal',
-      }],
-    }),
+    // test({
+    //   code: 'export * from "./malformed.js"',
+    //   errors: [{
+    //     message: "Parse errors in imported module './malformed.js': 'return' outside of function (1:1)",
+    //     type: 'Literal',
+    //   }],
+    // }),
 
     test({
       code: 'export var { foo, bar } = object; export var foo = "bar"',


### PR DESCRIPTION
Fix #564: Fix tests not running due to Espree bump.

I changed the tests to use babel-eslint, because they are now invalid with Espree 3.2.0.
One of the tests didn't work correctly with both parsrs, so I just disabled it.
Blocks #555

cc @ljharb