### PR TITLE
resolve configs for webpack2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
   ([#566], thanks [@preco21])
 - [`default`]: allow re-export of values from ignored files as default
   ([#545], thanks [@skyrpex])
+- Added `resolve.modules` to configs for webpack2 support ([#569])
 
 ## [1.15.0] - 2016-09-12
 ### Added

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -191,7 +191,8 @@ function createWebpack1ResolveSync(webpackRequire, resolveConfig, plugins) {
     new ModuleAsFilePlugin('module'),
     new ModuleAsDirectoryPlugin('module'),
     new DirectoryDescriptionFilePlugin(
-      'package.json', ['module', 'jsnext:main'].concat(resolveConfig.packageMains || webpack1DefaultMains)
+      'package.json',
+      ['module', 'jsnext:main'].concat(resolveConfig.packageMains || webpack1DefaultMains)
     ),
     new DirectoryDefaultFilePlugin(['index']),
     new FileAppendPlugin(resolveConfig.extensions || ['', '.webpack.js', '.web.js', '.js']),

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -185,7 +185,8 @@ function createWebpack1ResolveSync(webpackRequire, resolveConfig, plugins) {
     new ModuleAliasPlugin(resolveConfig.alias || {}),
     makeRootPlugin(ModulesInRootPlugin, 'module', resolveConfig.root),
     new ModulesInDirectoriesPlugin(
-      'module', resolveConfig.modulesDirectories || ['web_modules', 'node_modules']
+      'module',
+      resolveConfig.modulesDirectories || resolveConfig.modules || ['web_modules', 'node_modules']
     ),
     makeRootPlugin(ModulesInRootPlugin, 'module', resolveConfig.fallback),
     new ModuleAsFilePlugin('module'),

--- a/resolvers/webpack/test/config-extensions/webpack.config.babel.js
+++ b/resolvers/webpack/test/config-extensions/webpack.config.babel.js
@@ -5,6 +5,12 @@ export default {
     alias: {
       'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
     },
+    modules: [
+      path.join(__dirname, 'src'),
+      path.join(__dirname, 'fallback'),
+      'node_modules',
+      'bower_components',
+    ],
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),
     fallback: path.join(__dirname, 'fallback'),

--- a/resolvers/webpack/test/files/some/absolute.path.webpack.config.js
+++ b/resolvers/webpack/test/files/some/absolute.path.webpack.config.js
@@ -5,6 +5,11 @@ module.exports = {
     alias: {
       'foo': path.join(__dirname, 'absolutely', 'goofy', 'path', 'foo.js'),
     },
+    modules: [
+      path.join(__dirname, 'src'),
+      'node_modules',
+      'bower_components',
+    ],
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),
   },

--- a/resolvers/webpack/test/files/webpack.config.babel.js
+++ b/resolvers/webpack/test/files/webpack.config.babel.js
@@ -5,6 +5,12 @@ export default {
     alias: {
       'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
     },
+    modules: [
+      path.join(__dirname, 'src'),
+      path.join(__dirname, 'fallback'),
+      'node_modules',
+      'bower_components',
+    ],
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),
     fallback: path.join(__dirname, 'fallback'),

--- a/resolvers/webpack/test/files/webpack.config.js
+++ b/resolvers/webpack/test/files/webpack.config.js
@@ -7,6 +7,12 @@ module.exports = {
       'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
       'some-alias': path.join(__dirname, 'some'),
     },
+    modules: [
+      path.join(__dirname, 'src'),
+      path.join(__dirname, 'fallback'),
+      'node_modules',
+      'bower_components',
+    ],
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),
     fallback: path.join(__dirname, 'fallback'),

--- a/resolvers/webpack/test/files/webpack.config.js
+++ b/resolvers/webpack/test/files/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   resolve: {
     alias: {
       'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
-      'some-alias': path.join(__dirname, 'some')
+      'some-alias': path.join(__dirname, 'some'),
     },
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),

--- a/resolvers/webpack/test/files/webpack.config.multiple.js
+++ b/resolvers/webpack/test/files/webpack.config.multiple.js
@@ -14,6 +14,11 @@ module.exports = [{
     alias: {
       'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
     },
+    modules: [
+      path.join(__dirname, 'src'),
+      'node_modules',
+      'bower_components',
+    ],
     modulesDirectories: ['node_modules', 'bower_components'],
     root: path.join(__dirname, 'src'),
   },

--- a/resolvers/webpack/test/files/webpack.function.config.js
+++ b/resolvers/webpack/test/files/webpack.function.config.js
@@ -8,6 +8,12 @@ module.exports = function() {
         'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
         'some-alias': path.join(__dirname, 'some'),
       },
+      modules: [
+        path.join(__dirname, 'src'),
+        path.join(__dirname, 'fallback'),
+        'node_modules',
+        'bower_components',
+      ],
       modulesDirectories: ['node_modules', 'bower_components'],
       root: path.join(__dirname, 'src'),
       fallback: path.join(__dirname, 'fallback'),


### PR DESCRIPTION
Added configs for webpack2 (since version 2.1.0-beta.23)
`modulesDirectories` now [change](https://github.com/webpack/webpack.js.org/blob/develop/content/how-to/upgrade-from-webpack-1.md#resolveroot-resolvefallback-resolvemodulesdirectories) to `modules`  
