### PR TITLE
Update webpack resolver to allow passing a config object rather than filename

### DIFF
--- a/resolvers/webpack/README.md
+++ b/resolvers/webpack/README.md
@@ -52,3 +52,17 @@ settings:
       config: 'webpack.multiple.config.js'
       config-index: 1   # take the config at index 1
 ```
+
+or with explicit config object:
+
+```yaml
+---
+settings:
+  import/resolver:
+    webpack:
+      config:
+        resolve:
+          extensions:
+            - .js
+            - .jsx
+```

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -63,4 +63,32 @@ describe("config", function () {
     }
     expect(function () { resolve('foo', file, settings) }).to.throw(Error)
   })
+
+  it("finds config object when config is an object", function () {
+    var settings = {
+      config: require(path.join(__dirname, 'files', 'some', 'absolute.path.webpack.config.js')),
+    }
+    expect(resolve('foo', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'some', 'absolutely', 'goofy', 'path', 'foo.js'))
+  })
+
+  it("finds the first config with a resolve section when config is an array of config objects", function () {
+    var settings = {
+      config: require(path.join(__dirname, './files/webpack.config.multiple.js')),
+    }
+
+    expect(resolve('main-module', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
+  })
+
+  it("finds the config at option config-index when config is an array of config objects", function () {
+    var settings = {
+      config: require(path.join(__dirname, './files/webpack.config.multiple.js')),
+      'config-index': 2,
+    }
+
+    expect(resolve('foo', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'some', 'goofy', 'path', 'foo.js'))
+  })
+
 })


### PR DESCRIPTION
...because my Webpack config is generated by an API (and not written to disk) and `.eslintrc.js` allows us to use complex JavaScript objects.