### PR TITLE
Fix #570: No newline after inline require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Breaking
 - [`import/extensions` setting] defaults to `['.js']`. ([#306])
 - [`import/ignore` setting] defaults to nothing, and ambiguous modules are ignored natively. This means importing from CommonJS modules will no longer be reported by [`default`], [`named`], or [`namespace`], regardless of `import/ignore`. ([#270])
+- [`newline-after-import`]: Removed need for an empty line after an inline `require` call ([#570])
 
 ### Changed
 - `imports-first` is renamed to [`first`]. `imports-first` alias will continue to
@@ -378,6 +379,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#570]: https://github.com/benmosher/eslint-plugin-import/issues/570
 [#567]: https://github.com/benmosher/eslint-plugin-import/issues/567
 [#566]: https://github.com/benmosher/eslint-plugin-import/issues/566
 [#545]: https://github.com/benmosher/eslint-plugin-import/issues/545

--- a/docs/rules/newline-after-import.md
+++ b/docs/rules/newline-after-import.md
@@ -1,10 +1,8 @@
 # newline-after-import
 
-Reports if there's no new line after last import/require in group.
+Enforces having an empty line after the last top-level import statement or require call.
 
 ## Rule Details
-
-**NOTE**: In each of those examples you can replace `import` call with `require`.
 
 Valid:
 
@@ -21,6 +19,13 @@ import { bar }  from 'bar-lib'
 const FOO = 'BAR'
 ```
 
+```js
+const FOO = require('./foo')
+const BAR = require('./bar')
+
+const BAZ = 1
+```
+
 ...whereas here imports will be reported:
 
 ```js
@@ -33,6 +38,12 @@ import * as foo from 'foo'
 const FOO = 'BAR'
 
 import { bar }  from 'bar-lib'
+```
+
+```js
+const FOO = require('./foo')
+const BAZ = 1
+const BAR = require('./bar')
 ```
 
 ## When Not To Use It

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -68,6 +68,14 @@ module.exports = {
       }
     }
 
+    let level = 0
+    function incrementLevel() {
+      level++
+    }
+    function decrementLevel() {
+      level--
+    }
+
     return {
       ImportDeclaration: function (node) {
         const { parent } = node
@@ -83,7 +91,7 @@ module.exports = {
       },
       CallExpression: function(node) {
         const scope = context.getScope()
-        if (isStaticRequire(node)) {
+        if (isStaticRequire(node) && level === 0) {
           const currentScope = scopes[scopeIndex]
 
           if (scope === currentScope.scope) {
@@ -127,6 +135,16 @@ module.exports = {
           })
         })
       },
+      FunctionDeclaration: incrementLevel,
+      FunctionExpression: incrementLevel,
+      ArrowFunctionExpression: incrementLevel,
+      BlockStatement: incrementLevel,
+      ObjectExpression: incrementLevel,
+      'FunctionDeclaration:exit': decrementLevel,
+      'FunctionExpression:exit': decrementLevel,
+      'ArrowFunctionExpression:exit': decrementLevel,
+      'BlockStatement:exit': decrementLevel,
+      'ObjectExpression:exit': decrementLevel,
     }
   },
 }

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -45,10 +45,9 @@ module.exports = {
   meta: {
     docs: {},
   },
-
   create: function (context) {
-    const scopes = []
-    let scopeIndex = 0
+    let level = 0
+    const requireCalls = []
 
     function checkForNewLine(node, nextNode, type) {
       if (getLineDifference(node, nextNode) < 2) {
@@ -68,7 +67,6 @@ module.exports = {
       }
     }
 
-    let level = 0
     function incrementLevel() {
       level++
     }
@@ -86,53 +84,33 @@ module.exports = {
           checkForNewLine(node, nextNode, 'import')
         }
       },
-      Program: function () {
-        scopes.push({ scope: context.getScope(), requireCalls: [] })
-      },
       CallExpression: function(node) {
-        const scope = context.getScope()
         if (isStaticRequire(node) && level === 0) {
-          const currentScope = scopes[scopeIndex]
-
-          if (scope === currentScope.scope) {
-            currentScope.requireCalls.push(node)
-          } else {
-            scopes.push({ scope, requireCalls: [ node ] })
-            scopeIndex += 1
-          }
+          requireCalls.push(node)
         }
       },
       'Program:exit': function () {
         log('exit processing for', context.getFilename())
-        scopes.forEach(function ({ scope, requireCalls }) {
-          const scopeBody = getScopeBody(scope)
+        const scopeBody = getScopeBody(context.getScope())
+        log('got scope:', scopeBody)
 
-          // skip non-array scopes (i.e. arrow function expressions)
-          if (!scopeBody || !(scopeBody instanceof Array)) {
-            log('invalid scope:', scopeBody)
+        requireCalls.forEach(function (node, index) {
+          const nodePosition = findNodeIndexInScopeBody(scopeBody, node)
+          log('node position in scope:', nodePosition)
+
+          const statementWithRequireCall = scopeBody[nodePosition]
+          const nextStatement = scopeBody[nodePosition + 1]
+          const nextRequireCall = requireCalls[index + 1]
+
+          if (nextRequireCall && containsNodeOrEqual(statementWithRequireCall, nextRequireCall)) {
             return
           }
 
-          log('got scope:', scopeBody)
+          if (nextStatement &&
+             (!nextRequireCall || !containsNodeOrEqual(nextStatement, nextRequireCall))) {
 
-          requireCalls.forEach(function (node, index) {
-            const nodePosition = findNodeIndexInScopeBody(scopeBody, node)
-            log('node position in scope:', nodePosition)
-
-            const statementWithRequireCall = scopeBody[nodePosition]
-            const nextStatement = scopeBody[nodePosition + 1]
-            const nextRequireCall = requireCalls[index + 1]
-
-            if (nextRequireCall && containsNodeOrEqual(statementWithRequireCall, nextRequireCall)) {
-              return
-            }
-
-            if (nextStatement &&
-               (!nextRequireCall || !containsNodeOrEqual(nextStatement, nextRequireCall))) {
-
-              checkForNewLine(statementWithRequireCall, nextStatement, 'require')
-            }
-          })
+            checkForNewLine(statementWithRequireCall, nextStatement, 'require')
+          }
         })
       },
       FunctionDeclaration: incrementLevel,

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -1,7 +1,7 @@
 import { RuleTester } from 'eslint'
 
-const IMPORT_ERROR_MESSAGE = 'Expected empty line after import statement not followed by another import.';
-const REQUIRE_ERROR_MESSAGE = 'Expected empty line after require statement not followed by another require.';
+const IMPORT_ERROR_MESSAGE = 'Expected empty line after import statement not followed by another import.'
+const REQUIRE_ERROR_MESSAGE = 'Expected empty line after require statement not followed by another require.'
 
 const ruleTester = new RuleTester()
 
@@ -21,7 +21,6 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { ecmaVersion: 6 } ,
     },
     "function x(){ require('baz'); }",
-
     "a(require('b'), require('c'), require('d'));",
     `function foo() {
       switch (renderData.modalViewKey) {
@@ -100,7 +99,35 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
     {
       code: "var foo = require('foo-module');\n\nvar a = 123;\n\nvar bar = require('bar-lib');",
       parserOptions: { sourceType: 'module' }
-    }
+    },
+    {
+      code: `
+        function foo() {
+          var foo = require('foo');
+          foo();
+        }
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: `
+        if (true) {
+          var foo = require('foo');
+          foo();
+        }
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: `
+        function a() {
+          var assign = Object.assign || require('object-assign');
+          var foo = require('foo');
+          var bar = 42;
+        }
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
   ],
 
   invalid: [
@@ -179,14 +206,6 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       code: "var assign = Object.assign || require('object-assign');\nvar foo = require('foo');\nvar bar = 42;",
       errors: [ {
         line: 2,
-        column: 1,
-        message: REQUIRE_ERROR_MESSAGE,
-      } ]
-    },
-    {
-      code: "function a() {\nvar assign = Object.assign || require('object-assign');\nvar foo = require('foo');\nvar bar = 42; }",
-      errors: [ {
-        line: 3,
         column: 1,
         message: REQUIRE_ERROR_MESSAGE,
       } ]


### PR DESCRIPTION
Breaking change - newline-after-import: Do not require empty line after inline `require` (fixes #570).

cc @singles @sindresorhus

I made two commits:
- One applying the change and making the new tests pass
- One simplifying the implementation by removing the whole usage of scopes (redundant with the level system I picked from the order rule, and a bit more complex IMO)