### PR TITLE
Fix #519: Add option `newlines-between: "ignore"` to `order`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
   with some `parserOptions` in the mix. ([#402])
 - `react` shared config: added `jsx: true` to `parserOptions.ecmaFeatures`.
 - Added [`no-webpack-loader-syntax`] rule: forbid custom Webpack loader syntax in imports. ([#586], thanks [@fson]!)
+- Add option `newlines-between: "ignore"` to [`order`] ([#519])
 
 ### Breaking
 - [`import/extensions` setting] defaults to `['.js']`. ([#306])
@@ -392,6 +393,7 @@ for info on changes for earlier releases.
 [#566]: https://github.com/benmosher/eslint-plugin-import/issues/566
 [#545]: https://github.com/benmosher/eslint-plugin-import/issues/545
 [#530]: https://github.com/benmosher/eslint-plugin-import/issues/530
+[#519]: https://github.com/benmosher/eslint-plugin-import/issues/519
 [#507]: https://github.com/benmosher/eslint-plugin-import/issues/507
 [#478]: https://github.com/benmosher/eslint-plugin-import/issues/478
 [#456]: https://github.com/benmosher/eslint-plugin-import/issues/456

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`import/extensions` setting] defaults to `['.js']`. ([#306])
 - [`import/ignore` setting] defaults to nothing, and ambiguous modules are ignored natively. This means importing from CommonJS modules will no longer be reported by [`default`], [`named`], or [`namespace`], regardless of `import/ignore`. ([#270])
 - [`newline-after-import`]: Removed need for an empty line after an inline `require` call ([#570])
+- [`order`]: Default value for `newlines-between` option is now `ignore` ([#519])
 
 ### Changed
 - `imports-first` is renamed to [`first`]. `imports-first` alias will continue to

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -92,13 +92,13 @@ You can set the options like this:
 "import/order": ["error", {"groups": ["index", "sibling", "parent", "internal", "external", "builtin"]}]
 ```
 
-### `newlines-between: [always|never]`:
+### `newlines-between: [always|ignore|never]`:
 
 
 Enforces or forbids new lines between import groups:
 
-- If omitted, assertion messages will be neither enforced nor forbidden.
-- If set to `always`, at least one new line between each group will be enforced, and new lines inside a group will be forbidden. To prevent multiple lines between imports, core `no-multiple-empty-lines` rule can be used.
+- If set to `always`, at least one new line between each group will be enforced, and new lines inside a group will be forbidden. To prevent multiple lines between imports, core `no-multiple-empty-lines` rule can be used (default).
+- If set to `ignore`, no errors related to new lines between import groups will be reported.
 - If set to `never`, no new lines are allowed in the entire import section.
 
 With the default group setting, the following will be invalid:

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -92,13 +92,13 @@ You can set the options like this:
 "import/order": ["error", {"groups": ["index", "sibling", "parent", "internal", "external", "builtin"]}]
 ```
 
-### `newlines-between: [always|ignore|never]`:
+### `newlines-between: [ignore|always|never]`:
 
 
 Enforces or forbids new lines between import groups:
 
-- If set to `always`, at least one new line between each group will be enforced, and new lines inside a group will be forbidden. To prevent multiple lines between imports, core `no-multiple-empty-lines` rule can be used (default).
-- If set to `ignore`, no errors related to new lines between import groups will be reported.
+- If set to `ignore`, no errors related to new lines between import groups will be reported (default).
+- If set to `always`, at least one new line between each group will be enforced, and new lines inside a group will be forbidden. To prevent multiple lines between imports, core `no-multiple-empty-lines` rule can be used.
 - If set to `never`, no new lines are allowed in the entire import section.
 
 With the default group setting, the following will be invalid:

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -157,7 +157,7 @@ module.exports = {
             type: 'array',
           },
           'newlines-between': {
-            enum: [ 'always', 'never' ],
+            enum: [ 'always', 'ignore', 'never' ],
           },
         },
         additionalProperties: false,
@@ -206,7 +206,7 @@ module.exports = {
       'Program:exit': function reportAndReset() {
         makeOutOfOrderReport(context, imported)
 
-        if ('newlines-between' in options) {
+        if ('newlines-between' in options && options['newlines-between'] !== 'ignore') {
           makeNewlinesBetweenReport(context, imported, options['newlines-between'])
         }
 

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -157,7 +157,7 @@ module.exports = {
             type: 'array',
           },
           'newlines-between': {
-            enum: [ 'always', 'ignore', 'never' ],
+            enum: [ 'ignore', 'always', 'never' ],
           },
         },
         additionalProperties: false,
@@ -167,6 +167,7 @@ module.exports = {
 
   create: function importOrderRule (context) {
     const options = context.options[0] || {}
+    const newlinesBetweenImports = options['newlines-between'] || 'ignore'
     let ranks
 
     try {
@@ -206,8 +207,8 @@ module.exports = {
       'Program:exit': function reportAndReset() {
         makeOutOfOrderReport(context, imported)
 
-        if ('newlines-between' in options && options['newlines-between'] !== 'ignore') {
-          makeNewlinesBetweenReport(context, imported, options['newlines-between'])
+        if (newlinesBetweenImports !== 'ignore') {
+          makeNewlinesBetweenReport(context, imported, newlinesBetweenImports)
         }
 
         imported = []

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -209,6 +209,32 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+    // Option: newlines-between: 'ignore'
+    test({
+      code: `
+      var fs = require('fs');
+
+      var index = require('./');
+      var path = require('path');
+      var sibling = require('./foo');
+
+
+      var relParent1 = require('../foo');
+
+      var relParent3 = require('../');
+      var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling'],
+            ['parent', 'external'],
+          ],
+          'newlines-between': 'ignore',
+        },
+      ],
+    }),
     // Option newlines-between: 'always' with multiline imports #1
     test({
       code: `
@@ -299,7 +325,7 @@ ruleTester.run('order', rule, {
           port: 4444,
           runner: {
             server_path: require('runner-binary').path,
-            
+
             cli_args: {
                 'webdriver.chrome.driver': require('browser-binary').path
             }

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -235,6 +235,32 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+    // 'ignore' should be the default value for `newlines-between`
+    test({
+      code: `
+      var fs = require('fs');
+
+      var index = require('./');
+      var path = require('path');
+      var sibling = require('./foo');
+
+
+      var relParent1 = require('../foo');
+
+      var relParent3 = require('../');
+
+      var async = require('async');
+      `,
+      options: [
+        {
+          groups: [
+            ['builtin', 'index'],
+            ['sibling'],
+            ['parent', 'external'],
+          ],
+        },
+      ],
+    }),
     // Option newlines-between: 'always' with multiline imports #1
     test({
       code: `


### PR DESCRIPTION
Fix #519: Add option `newlines-between: "ignore"` to `order`

I haven't yet changed the default option, which I think we should, as I have not yet see any comments from others. That can be done in a second time, but should it be done, it should be done before the v2 release