### PR TITLE
newline-after-import with decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Fixed
 - [`prefer-default-export`] handles re-exported default exports ([#609])
+- Fix crash when using `newline-after-import` with decorators ([#592])
+- Properly report `newline-after-import` when next line is a decorator
 
 ## [2.0.1] - 2016-10-06
 ### Fixed
@@ -402,6 +404,7 @@ for info on changes for earlier releases.
 
 [#609]: https://github.com/benmosher/eslint-plugin-import/issues/609
 [#604]: https://github.com/benmosher/eslint-plugin-import/issues/604
+[#592]: https://github.com/benmosher/eslint-plugin-import/issues/592
 [#577]: https://github.com/benmosher/eslint-plugin-import/issues/577
 [#570]: https://github.com/benmosher/eslint-plugin-import/issues/570
 [#567]: https://github.com/benmosher/eslint-plugin-import/issues/567

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -38,6 +38,9 @@ function getLineDifference(node, nextNode) {
   return nextNode.loc.start.line - node.loc.end.line
 }
 
+function isClassWithDecorator(node) {
+  return node.type === 'ClassDeclaration' && node.decorators && node.decorators.length
+}
 
 module.exports = {
   meta: {
@@ -48,6 +51,10 @@ module.exports = {
     const requireCalls = []
 
     function checkForNewLine(node, nextNode, type) {
+      if (isClassWithDecorator(nextNode)) {
+        nextNode = nextNode.decorators[0]
+      }
+
       if (getLineDifference(node, nextNode) < 2) {
         let column = node.loc.start.column
 

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -116,11 +116,13 @@ module.exports = {
       ArrowFunctionExpression: incrementLevel,
       BlockStatement: incrementLevel,
       ObjectExpression: incrementLevel,
+      Decorator: incrementLevel,
       'FunctionDeclaration:exit': decrementLevel,
       'FunctionExpression:exit': decrementLevel,
       'ArrowFunctionExpression:exit': decrementLevel,
       'BlockStatement:exit': decrementLevel,
       'ObjectExpression:exit': decrementLevel,
+      'Decorator:exit': decrementLevel,
     }
   },
 }

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -128,6 +128,14 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       `,
       parserOptions: { sourceType: 'module' },
     },
+    {
+      code: `//issue 592
+        @SomeDecorator(require('./some-file'))
+        export default class App {}
+      `,
+      parserOptions: { sourceType: 'module' },
+      parser: 'babel-eslint',
+    },
   ],
 
   invalid: [

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -136,6 +136,11 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { sourceType: 'module' },
       parser: 'babel-eslint',
     },
+    {
+      code: "var foo = require('foo');\n\n@SomeDecorator(foo)\nclass Foo {}",
+      parserOptions: { sourceType: 'module' },
+      parser: 'babel-eslint',
+    },
   ],
 
   invalid: [
@@ -255,6 +260,26 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         message: IMPORT_ERROR_MESSAGE,
       } ],
       parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: "import foo from 'foo';\n@SomeDecorator(foo)\nclass Foo {}",
+      errors: [ {
+        line: 1,
+        column: 1,
+        message: IMPORT_ERROR_MESSAGE,
+      } ],
+      parserOptions: { sourceType: 'module' },
+      parser: 'babel-eslint',
+    },
+    {
+      code: "var foo = require('foo');\n@SomeDecorator(foo)\nclass Foo {}",
+      errors: [ {
+        line: 1,
+        column: 1,
+        message: REQUIRE_ERROR_MESSAGE,
+      } ],
+      parserOptions: { sourceType: 'module' },
+      parser: 'babel-eslint',
     },
   ],
 })


### PR DESCRIPTION
This fixes the crash outlined in #592, when using a `require` statement inside a decorator.

While I was in there I also noticed that `newline-after-import` wasn't properly reporting if the next line was a decorator. I added this so it would be properly reported, but I can remove that if decorator support isn't something you want to add (I know it's still experimental).