### PR TITLE
utils: [Fix] report the error stack on a resolution error

### DIFF
--- a/tests/files/load-error-resolver.js
+++ b/tests/files/load-error-resolver.js
@@ -1,1 +1,1 @@
-throw new Error('TEST ERROR')
+throw new SyntaxError('TEST SYNTAX ERROR')

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -8,6 +8,11 @@ import * as fs from 'fs'
 import * as utils from '../utils'
 
 describe('resolve', function () {
+  // We don't want to test for a specific stack, just that it was there in the error message.
+  function replaceErrorStackForTest(str) {
+    return typeof str === 'string' ? str.replace(/(\n\s+at .+:\d+\)?)+$/, '\n<stack-was-here>') : str
+  }
+
   it('throws on bad parameters', function () {
     expect(resolve.bind(null, null, null)).to.throw(Error)
   })
@@ -60,7 +65,7 @@ describe('resolve', function () {
                       , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } }),
                     )).to.equal(undefined)
     expect(testContextReports[0]).to.be.an('object')
-    expect(testContextReports[0].message).to.equal('Resolve error: foo-bar-resolver-v2 resolve test exception')
+    expect(replaceErrorStackForTest(testContextReports[0].message)).to.equal('Resolve error: foo-bar-resolver-v2 resolve test exception\n<stack-was-here>')
     expect(testContextReports[0].loc).to.eql({ line: 1, column: 0 })
 
     testContextReports.length = 0
@@ -153,7 +158,7 @@ describe('resolve', function () {
                       , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } }),
                     )).to.equal(undefined)
     expect(testContextReports[0]).to.be.an('object')
-    expect(testContextReports[0].message).to.equal('Resolve error: TEST ERROR')
+    expect(replaceErrorStackForTest(testContextReports[0].message)).to.equal('Resolve error: SyntaxError: TEST SYNTAX ERROR\n<stack-was-here>')
     expect(testContextReports[0].loc).to.eql({ line: 1, column: 0 })
   })
 

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - Uses createRequireFromPath to resolve loaders ([#1591], thanks [@arcanis])
+- report the error stack on a resolution error ([#599], thanks [@sompylasar])
 
 ## v2.5.0 - 2019-12-07
 
@@ -72,6 +73,7 @@ Yanked due to critical issue with cache key resulting from #839.
 [#1166]: https://github.com/benmosher/eslint-plugin-import/issues/1166
 [#1160]: https://github.com/benmosher/eslint-plugin-import/pull/1160
 [#1035]: https://github.com/benmosher/eslint-plugin-import/issues/1035
+[#599]: https://github.com/benmosher/eslint-plugin-import/pull/599
 
 [@hulkish]: https://github.com/hulkish
 [@timkraut]: https://github.com/timkraut
@@ -81,3 +83,4 @@ Yanked due to critical issue with cache key resulting from #839.
 [@brettz9]: https://github.com/brettz9
 [@JounQin]: https://github.com/JounQin
 [@arcanis]: https://github.com/arcanis
+[@sompylasar]: https://github.com/sompylasar


### PR DESCRIPTION
Resolve errors are most likely caused by invalid configuration, and the reason is easier to determine with the full details rather than just `err.message`.

See https://github.com/benmosher/eslint-plugin-import/issues/536

With this change, it reports something like:

```
import/no-unresolved: Resolve error: SyntaxError: Unexpected token import
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at module.exports (/__censored__/webpack/configFactory.js:216:3)
    at configProdClient (/__censored__/webpack/configProdClient.js:5:36)
    at Object.<anonymous> (/__censored__/webpack/configForEslintImportResolver.js:1:126)
```
