### PR TITLE
#604: Fixed code that relied on removed dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-
+### Fixed
+- Fixed code that relied on removed dependencies. ([#604])
 
 ## [2.0.0]! - 2016-09-30
 ### Added
@@ -25,7 +26,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Changed
 - `imports-first` is renamed to [`first`]. `imports-first` alias will continue to
   exist, but may be removed in a future major release.
-- Case-sensitivity: now specifically (and optionally) reported by [`no-unresolved`]. 
+- Case-sensitivity: now specifically (and optionally) reported by [`no-unresolved`].
   Other rules will ignore case-mismatches on paths on case-insensitive filesystems. ([#311])
 
 ### Fixed
@@ -395,6 +396,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#604]: https://github.com/benmosher/eslint-plugin-import/issues/604
 [#577]: https://github.com/benmosher/eslint-plugin-import/issues/577
 [#570]: https://github.com/benmosher/eslint-plugin-import/issues/570
 [#567]: https://github.com/benmosher/eslint-plugin-import/issues/567

--- a/resolvers/node/index.js
+++ b/resolvers/node/index.js
@@ -1,6 +1,5 @@
 var resolve = require('resolve')
   , path = require('path')
-  , assign = require('object-assign')
 
 var log = require('debug')('eslint-plugin-import:resolver:node')
 
@@ -26,7 +25,7 @@ exports.resolve = function (source, file, config) {
 }
 
 function opts(file, config) {
-  return assign({
+  return Object.assign({
       // more closely matches Node (#333)
       extensions: ['.js', '.json'],
     },

--- a/resolvers/node/package.json
+++ b/resolvers/node/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/benmosher/eslint-plugin-import",
   "dependencies": {
     "debug": "^2.2.0",
-    "object-assign": "^4.0.1",
     "resolve": "^1.1.6"
   },
   "devDependencies": {

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -7,7 +7,6 @@ var findRoot = require('find-root')
   , isAbsolute = path.isAbsolute || require('is-absolute')
   , fs = require('fs')
   , coreLibs = require('node-libs-browser')
-  , assign = require('object-assign')
   , resolve = require('resolve')
   , semver = require('semver')
   , has = require('has')
@@ -139,7 +138,7 @@ function createResolveSync(configPath, webpackConfig) {
 function createWebpack2ResolveSync(webpackRequire, resolveConfig) {
   var EnhancedResolve = webpackRequire('enhanced-resolve')
 
-  return EnhancedResolve.create.sync(assign({}, webpack2DefaultResolveConfig, resolveConfig))
+  return EnhancedResolve.create.sync(Object.assign({}, webpack2DefaultResolveConfig, resolveConfig))
 }
 
 /**

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -37,7 +37,6 @@
     "is-absolute": "^0.2.3",
     "lodash.get": "^3.7.0",
     "node-libs-browser": "^1.0.0",
-    "object-assign": "^4.1.0",
     "resolve": "^1.1.7",
     "semver": "^5.3.0"
   },

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -1,6 +1,5 @@
 import path from 'path'
 import has from 'has'
-import assign from 'object-assign'
 
 import resolve from 'eslint-module-utils/resolve'
 import { isBuiltIn } from '../core/importType'
@@ -42,7 +41,7 @@ module.exports = {
   create: function (context) {
     const configuration = context.options[0] || 'never'
     const defaultConfig = typeof configuration === 'string' ? configuration : null
-    const modifiers = assign(
+    const modifiers = Object.assign(
       {},
       typeof configuration === 'object' ? configuration : context.options[1]
     )

--- a/src/rules/max-dependencies.js
+++ b/src/rules/max-dependencies.js
@@ -1,4 +1,3 @@
-import Set from 'es6-set'
 import isStaticRequire from '../core/staticRequire'
 
 const DEFAULT_MAX = 10


### PR DESCRIPTION
Fixes #604.
I replaced `object-assign` and `es6-set` by native `Objct.assign` and `Set`. Since we dropped support for Node < v4, this should not break anything.