### PR TITLE
#601: Fixed default order for the order rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Fixed
 - Fixed code that relied on removed dependencies. ([#604])
+- Fixed default order for the [`order`] rule ([#601])
 
 ## [2.0.0]! - 2016-09-30
 ### Added
@@ -397,6 +398,7 @@ for info on changes for earlier releases.
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
 [#604]: https://github.com/benmosher/eslint-plugin-import/issues/604
+[#601]: https://github.com/benmosher/eslint-plugin-import/issues/601
 [#577]: https://github.com/benmosher/eslint-plugin-import/issues/577
 [#570]: https://github.com/benmosher/eslint-plugin-import/issues/570
 [#567]: https://github.com/benmosher/eslint-plugin-import/issues/567

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -3,7 +3,7 @@
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
-const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
+const defaultGroups = ['builtin', 'external', 'internal', 'parent', 'sibling', 'index']
 
 // REPORTING
 


### PR DESCRIPTION
Fixes #601.
This fixes the default order to be the one described by the documentation, and they have been inconsistent ever since the rule was introduced.

Though it fixes the implementation to correspond to what the documentation says, this is a fix that can create new linting errors for users that use internal modules and have not overridden the order. In this case, I think that can be accepted as a fix/patch, and not a breaking change/major, but wanted to have some confirmation.

Fortunately, I think that the use of internal modules is relatively low, so it should not break anything for most people.

cc @ljharb who I know is very passionnate about respecting semver and might have more experience with this kind of situation.
