### PR TITLE
Remove `es6-set` dependency from max-depdendencies.js

### DIFF
--- a/src/rules/max-dependencies.js
+++ b/src/rules/max-dependencies.js
@@ -1,4 +1,3 @@
-import Set from 'es6-set'
 import isStaticRequire from '../core/staticRequire'
 
 const DEFAULT_MAX = 10


### PR DESCRIPTION
`es6-set` was already removed from the package.json

Fixes #611.