### PR TITLE
(#610): Fix crash when calling require() with a number

### DIFF
--- a/src/core/staticRequire.js
+++ b/src/core/staticRequire.js
@@ -5,5 +5,6 @@ export default function isStaticRequire(node) {
     node.callee.type === 'Identifier' &&
     node.callee.name === 'require' &&
     node.arguments.length === 1 &&
-    node.arguments[0].type === 'Literal'
+    node.arguments[0].type === 'Literal' &&
+    typeof node.arguments[0].value === 'string'
 }

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -45,6 +45,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{devDependencies: ['*.test.js', '*.spec.js']}],
       filename: 'foo.spec.js',
     }),
+    test({ code: 'require(6)' }),
   ],
   invalid: [
     test({


### PR DESCRIPTION
Fixes #610: Fix crash when calling require() with a number