### PR TITLE
(#609) Make prefer-default-export count re-exported default exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-
+### Fixed
+- [`prefer-default-export`] handles re-exported default exports ([#609])
 
 ## [2.0.1] - 2016-10-06
 ### Fixed
@@ -399,6 +400,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#609]: https://github.com/benmosher/eslint-plugin-import/issues/609
 [#604]: https://github.com/benmosher/eslint-plugin-import/issues/604
 [#577]: https://github.com/benmosher/eslint-plugin-import/issues/577
 [#570]: https://github.com/benmosher/eslint-plugin-import/issues/570

--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -11,7 +11,24 @@ module.exports = {
     let hasStarExport = false
     let namedExportNode = null
 
+    function captureDeclaration(identifierOrPattern) {
+      if (identifierOrPattern.type === 'ObjectPattern') {
+        // recursively capture
+        identifierOrPattern.properties
+          .forEach(function(property) {
+            captureDeclaration(property.value)
+          })
+      } else {
+      // assume it's a single standard identifier
+        specifierExportCount++
+      }
+    }
+
     return {
+      'ExportDefaultSpecifier': function() {
+        specifierExportCount++
+      },
+
       'ExportSpecifier': function(node) {
         if (node.exported.name === 'default') {
           hasDefaultExport = true
@@ -24,19 +41,6 @@ module.exports = {
       'ExportNamedDeclaration': function(node) {
         // if there are specifiers, node.declaration should be null
         if (!node.declaration) return
-
-        function captureDeclaration(identifierOrPattern) {
-          if (identifierOrPattern.type === 'ObjectPattern') {
-            // recursively capture
-            identifierOrPattern.properties
-              .forEach(function(property) {
-                captureDeclaration(property.value)
-              })
-          } else {
-          // assume it's a single standard identifier
-            specifierExportCount++
-          }
-        }
 
         if (node.declaration.declarations) {
           node.declaration.declarations.forEach(function(declaration) {

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -55,6 +55,10 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         export * from './foo';`,
       }),
+    test({
+      code: `export Memory, { MemoryValue } from './Memory'`,
+      parser: 'babel-eslint',
+      }),
 
     // no exports at all
     test({


### PR DESCRIPTION
(#609) Make prefer-default-export count re-exported default exports

The rule didn't count re-exporting default exports, which led to it reporting where it shouldn't have.

I also moved out the `captureDeclaration` function declaration because I easily could and so that it wouldn't get re-declared for every encountered `ExportNamedDeclaration`.