### PR TITLE
Add deprecated flags to imports-first metadata

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export const rules = {
   'no-deprecated': require('./rules/no-deprecated'),
 
   // deprecated aliases to rules
-  'imports-first': require('./rules/first'),
+  'imports-first': require('./rules/imports-first'),
 }
 
 export const configs = {

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -1,0 +1,5 @@
+import first from './first'
+
+const newMeta = Object.assign({}, first.meta, { deprecated: true })
+
+module.exports = Object.assign({}, first, { meta: newMeta })

--- a/tests/src/package.js
+++ b/tests/src/package.js
@@ -53,5 +53,9 @@ describe('package', function () {
     }
   })
 
-})
+  it('marks deprecated rules in their metadata', function () {
+    expect(module.rules['imports-first'].meta.deprecated).to.be.true
+    expect(module.rules['first'].meta.deprecated).not.to.be.true
+  })
 
+})


### PR DESCRIPTION
Over on [eslint-find-rules](https://github.com/sarbbottam/eslint-find-rules), there has been some discussion about being able to detect deprecated rules in order to [not report them as unused](https://github.com/sarbbottam/eslint-find-rules/issues/172) and to [report when they are still being used](https://github.com/sarbbottam/eslint-find-rules/issues/188).

In order to implement those features, there needs to be a way to detect that a rule has been deprecated.  Core ESLint rules that are deprecated are marked as such in their metadata.

This PR adds the same `deprecated` flag to the metadata of the deprecated rule in this plugin.

I added a very specific spec for this rule to make sure that `imports-first` is marked as deprecated, but `first` (which is its new name) is not.  There might be a better way to write a more generic test, but when there’s only a single deprecated rule, it’s hard to know what the right direction is.
