### PR TITLE
Add 'always-and-inside-groups' value to order's newlines-between option to allow newlines inside import groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -386,6 +386,7 @@ for info on changes for earlier releases.
 [#654]: https://github.com/benmosher/eslint-plugin-import/pull/654
 [#639]: https://github.com/benmosher/eslint-plugin-import/pull/639
 [#630]: https://github.com/benmosher/eslint-plugin-import/pull/630
+[#628]: https://github.com/benmosher/eslint-plugin-import/pull/628
 [#596]: https://github.com/benmosher/eslint-plugin-import/pull/596
 [#586]: https://github.com/benmosher/eslint-plugin-import/pull/586
 [#578]: https://github.com/benmosher/eslint-plugin-import/pull/578
@@ -437,7 +438,6 @@ for info on changes for earlier releases.
 
 [#660]: https://github.com/benmosher/eslint-plugin-import/issues/660
 [#653]: https://github.com/benmosher/eslint-plugin-import/issues/653
-[#628]: https://github.com/benmosher/eslint-plugin-import/issues/628
 [#627]: https://github.com/benmosher/eslint-plugin-import/issues/627
 [#609]: https://github.com/benmosher/eslint-plugin-import/issues/609
 [#604]: https://github.com/benmosher/eslint-plugin-import/issues/604

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Added
 - [`no-anonymous-default-export`] rule: report anonymous default exports ([#712], thanks [@duncanbeevers]).
-- Add new value to `order`'s `newlines-between` option to allow newlines inside import groups ([#627], [#628])
+- Add new value to `order`'s `newlines-between` option to allow newlines inside import groups ([#627], [#628], thanks [@giodamelio])
 
 ### Changed
 - [`no-extraneous-dependencies`]: use `read-pkg-up` to simplify finding + loading `package.json` ([#680], thanks [@wtgtybhertgeghgtwtg])
@@ -569,3 +569,4 @@ for info on changes for earlier releases.
 [@jakubsta]: https://github.com/jakubsta
 [@wtgtybhertgeghgtwtg]: https://github.com/wtgtybhertgeghgtwtg
 [@duncanbeevers]: https://github.com/duncanbeevers
+[@giodamelio]: https://github.com/giodamelio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Added
 - [`no-anonymous-default-export`] rule: report anonymous default exports ([#712], thanks [@duncanbeevers]).
+- Add new value to `order`'s `newlines-between` option to allow newlines inside import groups ([#627], [#628])
 
 ### Changed
 - [`no-extraneous-dependencies`]: use `read-pkg-up` to simplify finding + loading `package.json` ([#680], thanks [@wtgtybhertgeghgtwtg])
@@ -436,6 +437,8 @@ for info on changes for earlier releases.
 
 [#660]: https://github.com/benmosher/eslint-plugin-import/issues/660
 [#653]: https://github.com/benmosher/eslint-plugin-import/issues/653
+[#628]: https://github.com/benmosher/eslint-plugin-import/issues/628
+[#627]: https://github.com/benmosher/eslint-plugin-import/issues/627
 [#609]: https://github.com/benmosher/eslint-plugin-import/issues/609
 [#604]: https://github.com/benmosher/eslint-plugin-import/issues/604
 [#602]: https://github.com/benmosher/eslint-plugin-import/issues/602

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -92,13 +92,14 @@ You can set the options like this:
 "import/order": ["error", {"groups": ["index", "sibling", "parent", "internal", "external", "builtin"]}]
 ```
 
-### `newlines-between: [ignore|always|never]`:
+### `newlines-between: [ignore|always|always-and-inside-groups|never]`:
 
 
 Enforces or forbids new lines between import groups:
 
 - If set to `ignore`, no errors related to new lines between import groups will be reported (default).
 - If set to `always`, at least one new line between each group will be enforced, and new lines inside a group will be forbidden. To prevent multiple lines between imports, core `no-multiple-empty-lines` rule can be used.
+- If set to `always-and-inside-groups`, it will act like `always` except newlines are allowed inside import groups.
 - If set to `never`, no new lines are allowed in the entire import section.
 
 With the default group setting, the following will be invalid:
@@ -106,6 +107,15 @@ With the default group setting, the following will be invalid:
 ```js
 /* eslint import/order: ["error", {"newlines-between": "always"}] */
 import fs from 'fs';
+import path from 'path';
+import index from './';
+import sibling from './foo';
+```
+
+```js
+/* eslint import/order: ["error", {"newlines-between": "always-and-inside-groups"}] */
+import fs from 'fs';
+
 import path from 'path';
 import index from './';
 import sibling from './foo';
@@ -126,6 +136,17 @@ while those will be valid:
 ```js
 /* eslint import/order: ["error", {"newlines-between": "always"}] */
 import fs from 'fs';
+import path from 'path';
+
+import index from './';
+
+import sibling from './foo';
+```
+
+```js
+/* eslint import/order: ["error", {"newlines-between": "always-and-inside-groups"}] */
+import fs from 'fs';
+
 import path from 'path';
 
 import index from './';

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -120,22 +120,25 @@ function makeNewlinesBetweenReport (context, imported, newlinesBetweenImports) {
   let previousImport = imported[0]
 
   imported.slice(1).forEach(function(currentImport) {
-    if (newlinesBetweenImports === 'always') {
-      if (currentImport.rank !== previousImport.rank
-        && getNumberOfEmptyLinesBetween(currentImport, previousImport) === 0)
+    const emptyLinesBetween = getNumberOfEmptyLinesBetween(currentImport, previousImport)
+
+    if (newlinesBetweenImports === 'always'
+        || newlinesBetweenImports === 'always-and-inside-groups') {
+      if (currentImport.rank !== previousImport.rank && emptyLinesBetween === 0)
       {
         context.report(
           previousImport.node, 'There should be at least one empty line between import groups'
         )
       } else if (currentImport.rank === previousImport.rank
-        && getNumberOfEmptyLinesBetween(currentImport, previousImport) > 0)
+        && emptyLinesBetween > 0
+        && newlinesBetweenImports !== 'always-and-inside-groups')
       {
         context.report(
           previousImport.node, 'There should be no empty line within import group'
         )
       }
     } else {
-      if (getNumberOfEmptyLinesBetween(currentImport, previousImport) > 0) {
+      if (emptyLinesBetween > 0) {
         context.report(previousImport.node, 'There should be no empty line between import groups')
       }
     }
@@ -156,7 +159,12 @@ module.exports = {
             type: 'array',
           },
           'newlines-between': {
-            enum: [ 'ignore', 'always', 'never' ],
+            enum: [
+              'ignore',
+              'always',
+              'always-and-inside-groups',
+              'never',
+            ],
           },
         },
         additionalProperties: false,

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -376,6 +376,32 @@ ruleTester.run('order', rule, {
       `,
       options: [{ 'newlines-between': 'always' }]
     }),
+    // Option: newlines-between: 'always-and-inside-groups'
+    test({
+      code: `
+        var fs = require('fs');
+        var path = require('path');
+
+        var util = require('util');
+
+        var async = require('async');
+
+        var relParent1 = require('../foo');
+        var relParent2 = require('../');
+
+        var relParent3 = require('../bar');
+
+        var sibling = require('./foo');
+        var sibling2 = require('./bar');
+
+        var sibling3 = require('./foobar');
+      `,
+      options: [
+        {
+          'newlines-between': 'always-and-inside-groups',
+        },
+      ],
+    }),
   ],
   invalid: [
     // builtin before external module (require)


### PR DESCRIPTION
New option to allow newlines inside import groups. See #627.
