### PR TITLE
[New] `no-extraneous-dependencies`: check both the absolute and relative filename

### DIFF
--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 import pkgUp from 'pkg-up'
 import minimatch from 'minimatch'
 import importType from '../core/importType'
@@ -78,7 +79,10 @@ function testConfig(config, filename) {
     return config
   }
   // Array of globs.
-  return config.some(c => minimatch(filename, c))
+  return config.some(c => (
+    minimatch(filename, c) ||
+    minimatch(filename, path.join(process.cwd(), c))
+  ))
 }
 
 module.exports = {

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -42,8 +42,18 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
+      options: [{devDependencies: ['*.spec.js']}],
+      filename: path.join(process.cwd(), 'foo.spec.js'),
+    }),
+    test({
+      code: 'import chai from "chai"',
       options: [{devDependencies: ['*.test.js', '*.spec.js']}],
       filename: 'foo.spec.js',
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: ['*.test.js', '*.spec.js']}],
+      filename: path.join(process.cwd(), 'foo.spec.js'),
     }),
     test({ code: 'require(6)' }),
   ],
@@ -111,8 +121,26 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import chai from "chai"',
+      options: [{devDependencies: ['*.test.js']}],
+      filename: path.join(process.cwd(), 'foo.tes.js'),
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
+      }],
+    }),
+    test({
+      code: 'import chai from "chai"',
       options: [{devDependencies: ['*.test.js', '*.spec.js']}],
       filename: 'foo.tes.js',
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
+      }],
+    }),
+    test({
+      code: 'import chai from "chai"',
+      options: [{devDependencies: ['*.test.js', '*.spec.js']}],
+      filename: path.join(process.cwd(), 'foo.tes.js'),
       errors: [{
         ruleId: 'no-extraneous-dependencies',
         message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',


### PR DESCRIPTION
Fixes #602.

This should be semver-minor.
