### PR TITLE
Add internal to default order groups to match docs

### DIFF
--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -3,7 +3,7 @@
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
-const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
+const defaultGroups = ['builtin', 'external', 'internal', 'parent', 'sibling', 'index']
 
 // REPORTING
 


### PR DESCRIPTION
Quick little bug fix we ran across recently. The docs list the [default value](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#groups-array) for order groups as : ["builtin", "external", "internal", "parent", "sibling", "index"].

But that wasn't matched in [the code](https://github.com/benmosher/eslint-plugin-import/blob/master/src/rules/order.js#L6) This simply makes it match..

fixes #601 