### PR TITLE
Add React Native Absolute import support to node resolver

### DIFF
--- a/resolvers/node/README.md
+++ b/resolvers/node/README.md
@@ -20,6 +20,9 @@ settings:
         - .es6
         - .coffee
 
+      # This allows to resolve absolute imports in React Native
+      projectName: 'YourAppNameInPackage.json'
+
       paths:
         # an array of absolute paths which will also be searched
         # think NODE_PATH

--- a/resolvers/node/index.js
+++ b/resolvers/node/index.js
@@ -15,6 +15,11 @@ exports.resolve = function (source, file, config) {
   }
 
   try {
+    if (config && config.projectName && source.startsWith(config.projectName)) {
+      source = path.relative(file, source)
+      log('new source is:', source)
+    }
+
     resolvedPath = resolve.sync(source, opts(file, config))
     log('Resolved to:', resolvedPath)
     return { found: true, path: resolvedPath }

--- a/resolvers/node/test/paths.js
+++ b/resolvers/node/test/paths.js
@@ -22,3 +22,12 @@ describe("default options", function () {
       .to.have.property('found', false)
   })
 })
+
+describe("absolute imports", function () {
+  it("handles absolute path", function () {
+    expect(node.resolve('project/app/src/components/TopBar', '/home/map/repos/project/app/src/screens/Detail.js'))
+      .to.have.property('path')
+      .equal(path.resolve(__dirname, '../TopBar'))
+  })
+})
+


### PR DESCRIPTION
Hi there,

First, thanks for eslint-plugin-import it really helps development.

I was having some issues using it with React Native and opened a StackOverflow question that turned into an issue of the project #626. Instead of creating a new resolver for React Native as suggested in this issue I've added a new setting to node resolver that is used to resolve absolute imports. If you prefer it to be a separate resolver, I can refactor it.

This is working in my RN project as expected.

Thanks, cheers
Miguel
