### PR TITLE
fix unambiguous regex

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -286,7 +286,8 @@ ExportMap.for = function (path, context) {
   const content = fs.readFileSync(path, { encoding: 'utf8' })
 
   // check for and cache ignore
-  if (isIgnored(path, context) && !unambiguous.potentialModulePattern.test(content)) {
+  if (isIgnored(path, context) || !unambiguous.test(content)) {
+    log('ignored path due to unambiguous regex or ignore settings:', path)
     exportCache.set(cacheKey, null)
     return null
   }

--- a/tests/files/malformed.js
+++ b/tests/files/malformed.js
@@ -1,1 +1,3 @@
 return foo from fnuction () {
+
+export {}

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -4,6 +4,7 @@ import ExportMap from '../../../src/ExportMap'
 import * as fs from 'fs'
 
 import { getFilename } from '../utils'
+import * as unambiguous from 'eslint-module-utils/unambiguous'
 
 describe('ExportMap', function () {
   const fakeContext = {
@@ -341,6 +342,25 @@ describe('ExportMap', function () {
         })
       })
     })
+
+  })
+
+  // todo: move to utils
+  describe('unambigous regex', function () {
+
+    const testFiles = [
+      ['deep/b.js', true],
+      ['bar.js', true],
+      ['deep-es7/b.js', true],
+      ['common.js', false],
+    ]
+
+    for (let [testFile, expectedRegexResult] of testFiles) {
+      it(`works for ${testFile} (${expectedRegexResult})`, function () {
+        const content = fs.readFileSync('./tests/files/' + testFile, 'utf8')
+        expect(unambiguous.test(content)).to.equal(expectedRegexResult)
+      })
+    }
 
   })
 

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -346,7 +346,7 @@ describe('ExportMap', function () {
   })
 
   // todo: move to utils
-  describe('unambigous regex', function () {
+  describe('unambiguous regex', function () {
 
     const testFiles = [
       ['deep/b.js', true],

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -163,14 +163,14 @@ ruleTester.run('named', rule, {
     }),
 
     // parse errors
-    test({
-      code: "import { a } from './test.coffee';",
-      settings: { 'import/extensions': ['.js', '.coffee'] },
-      errors: [{
-        message: "Parse errors in imported module './test.coffee': Unexpected token > (1:20)",
-        type: 'Literal',
-      }],
-    }),
+    // test({
+    //   code: "import { a } from './test.coffee';",
+    //   settings: { 'import/extensions': ['.js', '.coffee'] },
+    //   errors: [{
+    //     message: "Parse errors in imported module './test.coffee': Unexpected token > (1:20)",
+    //     type: 'Literal',
+    //   }],
+    // }),
 
     // flow types
     test({

--- a/utils/unambiguous.js
+++ b/utils/unambiguous.js
@@ -1,10 +1,10 @@
 'use strict'
 exports.__esModule = true
 
+
+const pattern = /(^|;)\s*(export|import)((\s+\w)|(\s*[{*]))/m
 /**
  * detect possible imports/exports without a full parse.
- * used primarily to ignore the import/ignore setting, iif it looks like
- * there might be something there (i.e., jsnext:main is set).
  *
  * A negative test means that a file is definitely _not_ a module.
  * A positive test means it _could_ be.
@@ -13,8 +13,9 @@ exports.__esModule = true
  * avoid a parse.
  * @type {RegExp}
  */
-exports.potentialModulePattern =
-  new RegExp(`(?:^|;)\s*(?:export|import)(?:(?:\s+\w)|(?:\s*[{*]))`)
+exports.test = function isMaybeUnambiguousModule(content) {
+  return pattern.test(content)
+}
 
 // future-/Babel-proof at the expense of being a little loose
 const unambiguousNodeType = /^(Exp|Imp)ort.*Declaration$/


### PR DESCRIPTION
Key notes:
- used a `&&` instead of `||` for the auto-ignore (fail) so it wasn't even used unless the file is ignored anyway, and then it would ignore the ignore if the regex passed
- did not set regex to `multiline` mode, so it would fail on files unless `import`/`export` is the first line (double fail)

I also had to comment out a parser error test for CoffeeScript that should never have passed in v2 if I had implemented this correctly to begin with.

To publish this, need to bump+publish `eslint-module-utils`, then bump the dep in the plugin and publish it too.

I'm thinking this should be semver-minor since it's a large enough fix that it's nearly a feature.

Technically a breaking change to `eslint-module-utils`, but that's [not a big deal](https://www.npmjs.com/browse/depended/eslint-module-utils).

fixes #615
fixes #634
fixes #649