### PR TITLE
Ignore root external modules when checking for extensions

### DIFF
--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -84,6 +84,10 @@ function typeTest(name, settings, path) {
   return 'unknown'
 }
 
+export function isScopedModule(name) {
+  return name.indexOf('@') === 0
+}
+
 export default function resolveImportType(name, context) {
   return typeTest(name, context.settings, resolve(name, context))
 }

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -117,6 +117,16 @@ ruleTester.run('extensions', rule, {
       options: [ 'never' ],
     }),
 
+    // Root packages should be ignored and they are names not files
+    test({
+      code: [
+        'import lib from "pkg.js"',
+        'import lib2 from "pgk/package"',
+        'import lib3 from "@name/pkg.js"',
+      ].join('\n'),
+      options: [ 'never' ],
+    }),
+
     // Query strings.
     test({
       code: 'import bare from "./foo?a=True.ext"',
@@ -126,6 +136,15 @@ ruleTester.run('extensions', rule, {
       code: 'import bare from "./foo.js?a=True"',
       options: [ 'always' ],
     }),
+
+    test({
+      code: [
+        'import lib from "pkg"',
+        'import lib2 from "pgk/package.js"',
+        'import lib3 from "@name/pkg"',
+      ].join('\n'),
+      options: [ 'always' ],
+    }),
   ],
 
   invalid: [
@@ -133,15 +152,6 @@ ruleTester.run('extensions', rule, {
       code: 'import a from "a/index.js"',
       errors: [ {
         message: 'Unexpected use of file extension "js" for "a/index.js"',
-        line: 1,
-        column: 15,
-      } ],
-    }),
-    test({
-      code: 'import a from "a"',
-      options: [ 'always' ],
-      errors: [ {
-        message: 'Missing file extension "js" for "a"',
         line: 1,
         column: 15,
       } ],
@@ -285,11 +295,35 @@ ruleTester.run('extensions', rule, {
       ],
     }),
     test({
-      code: 'import thing from "non-package"',
+      code: 'import thing from "non-package/test"',
       options: [ 'always' ],
       errors: [
         {
-            message: 'Missing file extension for "non-package"',
+            message: 'Missing file extension for "non-package/test"',
+            line: 1,
+            column: 19,
+        },
+      ],
+    }),
+
+    test({
+      code: 'import thing from "@name/pkg/test"',
+      options: [ 'always' ],
+      errors: [
+        {
+            message: 'Missing file extension for "@name/pkg/test"',
+            line: 1,
+            column: 19,
+        },
+      ],
+    }),
+
+    test({
+      code: 'import thing from "@name/pkg/test.js"',
+      options: [ 'never' ],
+      errors: [
+        {
+            message: 'Unexpected use of file extension "js" for "@name/pkg/test.js"',
             line: 1,
             column: 19,
         },


### PR DESCRIPTION
When checking for extensions we got a bunch of error dues to the linter checking the name of packages like ‘import Decimal from “decimal.js”’ because we are using ‘never’. The opposite is true too, as seen in #414, when using ‘always’ will trigger linting is you do ‘import query form “query”’.

So what this does is change the ‘checkExtension’ method to check if a file is an external module and if it is then check if its a root one, in which case it is ignored. In that ticket there was a conversation about adding different options but I actually think that this behaviour makes more sense. Naming of packages is a bit weird and will always be so its probably safer just ignore them completely in this case.

A ton of things may be wrong as I’m not familiar with eslint and there may be a better way of checking if the package is root or not that I’m don’t know.