### PR TITLE
Add support to specify the package.json for no-extraneous-dependencies rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Changed
 - [`no-extraneous-dependencies`]: use `read-pkg-up` to simplify finding + loading `package.json` ([#680], thanks [@wtgtybhertgeghgtwtg])
+- Add support to specify the package.json [`no-extraneous-dependencies`] ([#685], thanks [@ramasilveyra])
 
 ### Fixed
 - attempt to fix crash in [`no-mutable-exports`]. ([#660])
@@ -385,6 +386,7 @@ for info on changes for earlier releases.
 
 [#742]: https://github.com/benmosher/eslint-plugin-import/pull/742
 [#712]: https://github.com/benmosher/eslint-plugin-import/pull/712
+[#685]: https://github.com/benmosher/eslint-plugin-import/pull/685
 [#680]: https://github.com/benmosher/eslint-plugin-import/pull/680
 [#654]: https://github.com/benmosher/eslint-plugin-import/pull/654
 [#639]: https://github.com/benmosher/eslint-plugin-import/pull/639
@@ -574,3 +576,4 @@ for info on changes for earlier releases.
 [@duncanbeevers]: https://github.com/duncanbeevers
 [@giodamelio]: https://github.com/giodamelio
 [@ntdb]: https://github.com/ntdb
+[@ramasilveyra]: https://github.com/ramasilveyra

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -1,7 +1,7 @@
 # Forbid the use of extraneous packages
 
 Forbid the import of external modules that are not declared in the `package.json`'s `dependencies`, `devDependencies`, `optionalDependencies` or `peerDependencies`.
-The closest parent `package.json` will be used. If no `package.json` is found, the rule will not lint anything.
+The closest parent `package.json` will be used. If no `package.json` is found, the rule will not lint anything. This behaviour can be changed with the rule option `packageDir`.
 
 ### Options
 
@@ -26,6 +26,12 @@ You can also use an array of globs instead of literal booleans:
 ```
 
 When using an array of globs, the setting will be activated if the name of the file being linted matches a single glob in the array.
+
+Also there is one more option called `packageDir`, this option is to specify the path to the folder containing package.json and is relative to the current working directory.
+
+```js
+"import/no-extraneous-dependencies": ["error", {"packageDir": './some-dir/'}]
+```
 
 ## Rule Details
 

--- a/tests/files/with-syntax-error/package.json
+++ b/tests/files/with-syntax-error/package.json
@@ -1,0 +1,1 @@
+{{ "name": "with-syntax-error" }


### PR DESCRIPTION
Add support for nested package.json, projects with a folder architecture with internals package.json files (see https://github.com/benmosher/eslint-plugin-import/issues/458).

### Discussion

Actually change the behavior of use the closest package.json to use the root package.json breaks the rule when you _want_ to check the dependencies from an internal package.json, so I have this two paths in mind:

1) Per default get the dependencies from the closest package.json and if the option `getPkgFromRoot` is true get the dependencies from the root package.json file.

2) Add an option like `pkgPath` to the rule to be able to specify the package.json path and if is null just find the closest package.json like the last version. IMHO this looks better, it's more flexible.

**What do you think about this?**

## 12/24/2016 update

I choose the _2._ path, the option is called `packagePath`.


## 01/29/2017 update

Commit name changed to `Add support to specify the package.json` as this solution doesnt fully solve all the cases of #458 Look: https://github.com/benmosher/eslint-plugin-import/pull/685#pullrequestreview-17807295