### PR TITLE
hotfix bump to v2.2.1 to allow install of node resolver 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 
 
+## [2.2.1] - 2016-12-15
+### Changed
+- bump `eslint-import-resolver-node` dependency range to allow install of bugfix in `v0.3.0`
+
 ## [2.2.0] - 2016-11-07
 ### Fixed
 - Corrected a few gaffs in the auto-ignore logic to fix major performance issues
@@ -479,7 +483,8 @@ for info on changes for earlier releases.
 [#119]: https://github.com/benmosher/eslint-plugin-import/issues/119
 [#89]: https://github.com/benmosher/eslint-plugin-import/issues/89
 
-[Unreleased]: https://github.com/benmosher/eslint-plugin-import/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/benmosher/eslint-plugin-import/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/benmosher/eslint-plugin-import/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/benmosher/eslint-plugin-import/compare/v2.0.0...v2.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Import with sanity.",
   "engines": {
     "node": ">=4"
@@ -79,7 +79,7 @@
     "contains-path": "^0.1.0",
     "debug": "^2.2.0",
     "doctrine": "1.5.0",
-    "eslint-import-resolver-node": "^0.2.0",
+    "eslint-import-resolver-node": "^0.2.0 || ^0.3.0",
     "eslint-module-utils": "^2.0.0",
     "has": "^1.0.1",
     "lodash.cond": "^4.3.0",


### PR DESCRIPTION
branched from tag and just updated `package.json`.

@ljharb: would love your 👀 on my semver 😅 want to make sure I didn't screw up before publishing

todo:
- [ ] tag after merge
- [ ] merge `release` back into `master`