### PR TITLE
removed install warnings of unmet peer dependency

### DIFF
--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "eslint-plugin-import": ">=1.4.0",
-    "webpack": "^1.11.0 || ^2.1.0-beta || ^2.1.0"
+    "webpack": "^1.11.0 || ^2.2.0-rc || ^2.2.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
When you using webpack 2.2.0-rc.1 I get the below warning the whole time since the incompatibility with 2.2.0 has been solved we should bump the required versions.

`warning Incorrect peer dependency "webpack@^1.11.0 || ^2.1.0-beta || ^2.1.0".`