### PR TITLE
Added order rule to support regexs

### DIFF
--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -7,6 +7,10 @@ const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
 
 // REPORTING
 
+function isRegex(str) {
+  return /\/.+\//.test(str)
+}
+
 function reverse(array) {
   return array.map(function (v) {
     return {
@@ -59,8 +63,24 @@ function makeOutOfOrderReport(context, imported) {
 // DETECTING
 
 function computeRank(context, ranks, name, type) {
-  return ranks[importType(name, context)] +
-    (type === 'import' ? 0 : 100)
+  let rankValue
+
+  Object
+    .keys(ranks)
+    .reverse()
+    .forEach(rank => {
+      if (isRegex(rank)) {
+        const regex = new RegExp(rank.slice(1, rank.length - 1))
+
+        if (regex.test(name)) {
+          rankValue = ranks[rank] + (type === 'import' ? 0 : 100)
+        }
+      } else {
+        rankValue = ranks[importType(name, context)]
+      }
+    })
+
+  return rankValue + (type === 'import' ? 0 : 100)
 }
 
 function registerNode(context, node, name, type, ranks, imported) {
@@ -87,8 +107,10 @@ function convertGroupsToRanks(groups) {
     }
     group.forEach(function(groupItem) {
       if (types.indexOf(groupItem) === -1) {
-        throw new Error('Incorrect configuration of the rule: Unknown type `' +
-          JSON.stringify(groupItem) + '`')
+        if (!isRegex(groupItem)) {
+          throw new Error('Incorrect configuration of the rule: Unknown type `' +
+            JSON.stringify(groupItem) + '`')
+        }
       }
       if (res[groupItem] !== undefined) {
         throw new Error('Incorrect configuration of the rule: `' + groupItem + '` is duplicated')

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -376,6 +376,53 @@ ruleTester.run('order', rule, {
       `,
       options: [{ 'newlines-between': 'always' }]
     }),
+    // Option groups should accept a regex and sort it correctly
+    test({
+      code: `
+        import path from 'path';
+        import { Meteor } from 'meteor/meteor';
+      `,
+      options: [{
+        'groups': [
+          'builtin',
+          '/^meteor/.+$/'
+        ]
+      }]
+    }),
+    // Option groups should accept a regex and have newlines-between: 'always' correctly handled
+    test({
+      code: `
+        import path from 'path';
+        
+        import { Meteor } from 'meteor/meteor';
+      `,
+      options: [{
+        'newlines-between': 'always',
+        'groups': [
+          'builtin',
+          '/^meteor/.+$/'
+        ]
+      }]
+    }),
+
+    // Option groups should accept a regex and handle it correctly when it's between an import type
+    test({
+      code: `
+        import path from 'path';
+        
+        import { Meteor } from 'meteor/meteor';
+        
+        import Foo from './foo';
+      `,
+      options: [{
+        'newlines-between': 'always',
+        'groups': [
+          'builtin',
+          '/^meteor/.+$/',
+          'external'
+        ]
+      }]
+    }),
   ],
   invalid: [
     // builtin before external module (require)
@@ -757,6 +804,21 @@ ruleTester.run('order', rule, {
         {
           line: 2,
           message: 'There should be at least one empty line between import groups',
+        },
+      ],
+    }),
+
+    test({
+      code: `
+        import fs from 'fs';
+        import { Meteor } from 'meteor/meteor';
+        import path from 'path';
+      `,
+      options: [{ 'groups': ['builtin', '/^meteor/.+$/'] }],
+      errors: [
+        {
+          line: 4,
+          message: '`path` import should occur before import of `meteor/meteor`',
         },
       ],
     }),


### PR DESCRIPTION
This will make the order rule more configurable especially when you want to have exact control over the order of the imports.

I have already added some tests if you need more I will be glad to add them.

I will add the documentation and the changelog probably tomorrow when I will have time.