### PR TITLE
Flow types support in the `order` rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 # generated output
 lib/
 **/.nyc_output/
+yarn.lock

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -20,6 +20,8 @@ import bar from './bar';
 import baz from './bar/baz';
 // 6. "index" of the current directory
 import main from './';
+// 7. Flow types
+import type { Element } from 'react';
 ```
 
 Unassigned imports are ignored, as the order they are imported in may be important.
@@ -75,7 +77,7 @@ This rule supports the following options:
 
 ### `groups: [array]`:
 
-How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are: `"builtin"`, `"external"`, `"internal"`, `"parent"`, `"sibling"`, `"index"`. The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
+How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are: `"builtin"`, `"external"`, `"internal"`, `"parent"`, `"sibling"`, `"index"`, `"flow"`. The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
 ```js
 [
   'builtin', // Built-in types are first
@@ -84,7 +86,7 @@ How groups are defined, and the order to respect. `groups` must be an array of `
   // Then the rest: internal and external type
 ]
 ```
-The default value is `["builtin", "external", "parent", "sibling", "index"]`.
+The default value is `["builtin", "external", "parent", "sibling", "index", "flow"]`.
 
 You can set the options like this:
 

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -3,7 +3,7 @@
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
-const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
+const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index', 'flow']
 
 // REPORTING
 
@@ -58,13 +58,19 @@ function makeOutOfOrderReport(context, imported) {
 
 // DETECTING
 
-function computeRank(context, ranks, name, type) {
-  return ranks[importType(name, context)] +
+function computeRank(context, ranks, node, name, type) {
+  let rankType
+  if (type === 'import' && node.importKind === 'type') {
+    rankType = 'flow'
+  } else {
+    rankType = importType(name, context)
+  }
+  return ranks[rankType] +
     (type === 'import' ? 0 : 100)
 }
 
 function registerNode(context, node, name, type, ranks, imported) {
-  const rank = computeRank(context, ranks, name, type)
+  const rank = computeRank(context, ranks, node, name, type)
   if (rank !== -1) {
     imported.push({name, rank, node})
   }
@@ -75,7 +81,7 @@ function isInVariableDeclarator(node) {
     (node.type === 'VariableDeclarator' || isInVariableDeclarator(node.parent))
 }
 
-const types = ['builtin', 'external', 'internal', 'parent', 'sibling', 'index']
+const types = ['builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'flow']
 
 // Creates an object with type-rank pairs.
 // Example: { index: 0, sibling: 1, parent: 1, external: 1, builtin: 2, internal: 2 }

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -402,6 +402,18 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+    // Flow imports
+    test({
+      code: `
+        import foo from 'foo';
+        import type { bar } from 'bar';
+      `,
+      parser: 'babel-eslint',
+      options: [{groups: [
+        'external',
+        'flow',
+      ]}],
+    }),
   ],
   invalid: [
     // builtin before external module (require)
@@ -783,6 +795,24 @@ ruleTester.run('order', rule, {
         {
           line: 2,
           message: 'There should be at least one empty line between import groups',
+        },
+      ],
+    }),
+    // Flow imports
+    test({
+      code: `
+        import type { bar } from 'bar';
+        import foo from 'foo';
+      `,
+      parser: 'babel-eslint',
+      options: [{groups: [
+        'external',
+        'flow',
+      ]}],
+      errors: [
+        {
+          line: 3,
+          message: '`foo` import should occur before import of `bar`',
         },
       ],
     }),


### PR DESCRIPTION
Closes #645

~~PS: I also included a `yarn.lock` file: https://yarnpkg.com/en/docs/version-control~~

Please autosquash my fixup commits before merging. :smile: 