### PR TITLE
Support scoped modules containing hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Yanked due to critical issue in eslint-module-utils with cache key resulting fro
 ### Fixed
 - attempt to fix crash in [`no-mutable-exports`]. ([#660])
 - "default is a reserved keyword" in no-maned-default tests by locking down babylon to 6.15.0 (#756, thanks @gmathieu)
+- support scoped modules containing non word characters
 
 
 ## [2.2.0] - 2016-11-07

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -27,7 +27,7 @@ function isExternalModule(name, settings, path) {
   return externalModuleRegExp.test(name) && isExternalPath(path, name, settings)
 }
 
-const scopedRegExp = /^@\w+\/\w+/
+const scopedRegExp = /^@[^\/]+\/[^\/]+/
 function isScoped(name) {
   return scopedRegExp.test(name)
 }

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -31,6 +31,9 @@ describe('importType(name)', function () {
   it("should return 'external' for scopes packages", function() {
     expect(importType('@cycle/core', context)).to.equal('external')
     expect(importType('@cycle/dom', context)).to.equal('external')
+    expect(importType('@some-thing/something', context)).to.equal('external')
+    expect(importType('@some-thing/something/some-module', context)).to.equal('external')
+    expect(importType('@some-thing/something/some-directory/someModule.js', context)).to.equal('external')
   })
 
   it("should return 'internal' for non-builtins resolved outside of node_modules", function () {


### PR DESCRIPTION
I was having problems with the order rule and scoped modules. It was returning NaN for the rank. I discovered the regex was not matching our scope name which contained hyphens.

This regex should match the full range of scoped module names I think. Please check it though.