### PR TITLE
Updated eslint-import-resolver-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "contains-path": "^0.1.0",
     "debug": "^2.2.0",
     "doctrine": "1.5.0",
-    "eslint-import-resolver-node": "^0.2.0",
+    "eslint-import-resolver-node": "^0.3.0",
     "eslint-module-utils": "^2.0.0",
     "has": "^1.0.1",
     "lodash.cond": "^4.3.0",


### PR DESCRIPTION
This fixes issues with linting related using an old `node-resolve` version that is in the 0.2.x. See: https://github.com/substack/node-resolve/issues/117#issuecomment-279299735