### PR TITLE
Fix "default is a reserved keyword" error no-named-default tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - attempt to fix crash in [`no-mutable-exports`]. ([#660])
+- "default is a reserved keyword" in no-maned-default tests by locking down babylon to 6.15.0 (#756, thanks @gmathieu)
 
 
 ## [2.2.0] - 2016-11-07

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "babel-plugin-istanbul": "^2.0.1",
     "babel-preset-es2015-argon": "latest",
     "babel-register": "6.16.3",
+    "babylon": "6.15.0",
     "chai": "^3.4.0",
     "coveralls": "^2.11.4",
     "cross-env": "^3.1.0",


### PR DESCRIPTION
#756 