### PR TITLE
log a useful error in a module bug arises

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -65,7 +65,12 @@ exports.resolve = function (source, file, settings) {
 
       log('Config path resolved to:', configPath)
       if (configPath) {
-        webpackConfig = require(configPath)
+        try {
+          webpackConfig = require(configPath)
+        } catch(e) {
+          console.log('Error resolving webpackConfig', e)
+          throw e
+        }
       } else {
         log("No config path found relative to", file, "; using {}")
         webpackConfig = {}


### PR DESCRIPTION
is not the root cause of #767, but it at least makes it possible for folks to figure out real fast what is causing the error (use log because eslint swallows thrown errors)
fix #767