### PR TITLE
loosen the version of `rimraf` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mocha": "^3.1.2",
     "nyc": "^8.3.0",
     "redux": "^3.0.4",
-    "rimraf": "2.5.2",
+    "rimraf": "^2.6.2",
     "sinon": "^2.3.2",
     "typescript": "^2.0.3",
     "typescript-eslint-parser": "^8.0.0"


### PR DESCRIPTION
I think there is no reason to pin the `rimraf` version to `2.5.2` strictly.
