### PR TITLE
Clarify docs for glob arrays

### DIFF
--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -25,7 +25,7 @@ You can also use an array of globs instead of literal booleans:
 "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js"]}]
 ```
 
-When using an array of globs, the setting will be activated if the name of the file being linted matches a single glob in the array.
+When using an array of globs, the setting will be set to `true` (no errors reported) if the name of the file being linted matches a single glob in the array, and `false` otherwise.
 
 ## Rule Details
 


### PR DESCRIPTION
Docs required a close reading to realize that the glob array actually *disables* errors for the config option for matching files. This changes the description to be more explicit about what "activation" means for matching files.