### PR TITLE
Add test for flow type export

### DIFF
--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -28,6 +28,10 @@ ruleTester.run('no-mutable-exports', rule, {
       parser: 'babel-eslint',
       code: 'export Something from "./something";',
     }),
+    test({
+      parser: 'babel-eslint',
+      code: 'type Foo = {}\nexport type {Foo}',
+    }),
   ],
   invalid: [
     test({


### PR DESCRIPTION
This adds a test for the bug reported in issue #758 and #660, which was already fixed by https://github.com/benmosher/eslint-plugin-import/commit/bfdc2bbfa16c2d27fa24ee0665ffb41040ef696c. :)

If I revert that commit, the test fails with this error:

```
  1) no-mutable-exports valid type Foo = {}
export type {Foo}:
     TypeError: Cannot read property 'kind' of null
      at checkDeclaration (src/rules/no-mutable-exports.js:7:37)
      at checkDeclarationsInScope (src/rules/no-mutable-exports.js:19:15)
      at EventEmitter.handleExportNamed (src/rules/no-mutable-exports.js:41:11)
      at NodeEventGenerator.applySelector (node_modules/eslint/lib/util/node-event-generator.js:265:26)
      at NodeEventGenerator.applySelectors (node_modules/eslint/lib/util/node-event-generator.js:294:22)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/util/node-event-generator.js:308:14)
      at CodePathAnalyzer.enterNode (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:602:23)
      at CommentEventGenerator.enterNode (node_modules/eslint/lib/util/comment-event-generator.js:98:23)
      at Traverser.enter (node_modules/eslint/lib/eslint.js:929:36)
      at Traverser.__execute (node_modules/estraverse/estraverse.js:397:31)
      at Traverser.traverse (node_modules/estraverse/estraverse.js:501:28)
      at Traverser.traverse (node_modules/eslint/lib/util/traverser.js:31:22)
      at EventEmitter.module.exports.api.verify (node_modules/eslint/lib/eslint.js:926:23)
      at runRuleForItem (node_modules/eslint/lib/testers/rule-tester.js:387:38)
      at testValidTemplate (node_modules/eslint/lib/testers/rule-tester.js:420:28)
      at Context.RuleTester.it (node_modules/eslint/lib/testers/rule-tester.js:548:25)
```