### PR TITLE
Performance increase for no-absolute-path

### DIFF
--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -8,10 +8,6 @@ function constant(value) {
   return () => value
 }
 
-function isAbsolute(name) {
-  return name.indexOf('/') === 0
-}
-
 export function isBuiltIn(name, settings) {
   const extras = (settings && settings['import/core-modules']) || []
   return builtinModules.indexOf(name) !== -1 || extras.indexOf(name) > -1
@@ -50,7 +46,6 @@ function isRelativeToSibling(name) {
 }
 
 const typeTest = cond([
-  [isAbsolute, constant('absolute')],
   [isBuiltIn, constant('builtin')],
   [isExternalModule, constant('external')],
   [isScoped, constant('external')],

--- a/src/rules/no-absolute-path.js
+++ b/src/rules/no-absolute-path.js
@@ -1,10 +1,13 @@
-import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
 function reportIfMissing(context, node, name) {
-  if (importType(name, context) === 'absolute') {
+  if (isAbsolute(name)) {
     context.report(node, 'Do not import modules using an absolute path')
   }
+}
+
+function isAbsolute(name) {
+  return name.indexOf('/') === 0
 }
 
 module.exports = {

--- a/src/rules/no-absolute-path.js
+++ b/src/rules/no-absolute-path.js
@@ -1,6 +1,6 @@
 import isStaticRequire from '../core/staticRequire'
 
-function reportIfMissing(context, node, name) {
+function reportIfAbsolute(context, node, name) {
   if (isAbsolute(name)) {
     context.report(node, 'Do not import modules using an absolute path')
   }
@@ -18,11 +18,11 @@ module.exports = {
   create: function (context) {
     return {
       ImportDeclaration: function handleImports(node) {
-        reportIfMissing(context, node, node.source.value)
+        reportIfAbsolute(context, node, node.source.value)
       },
       CallExpression: function handleRequires(node) {
         if (isStaticRequire(node)) {
-          reportIfMissing(context, node, node.arguments[0].value)
+          reportIfAbsolute(context, node, node.arguments[0].value)
         }
       },
     }

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -8,12 +8,6 @@ import { testContext } from '../utils'
 describe('importType(name)', function () {
   const context = testContext()
 
-  it("should return 'absolute' for paths starting with a /", function() {
-    expect(importType('/', context)).to.equal('absolute')
-    expect(importType('/path', context)).to.equal('absolute')
-    expect(importType('/some/path', context)).to.equal('absolute')
-  })
-
   it("should return 'builtin' for node.js modules", function() {
     expect(importType('fs', context)).to.equal('builtin')
     expect(importType('path', context)).to.equal('builtin')


### PR DESCRIPTION
See my reply here for a detailed analysis on why I made this change: https://github.com/benmosher/eslint-plugin-import/issues/803#issuecomment-303754437

I remove the call to `resolve()` in `no-absolute-path` rule. That should make this rule faster when it is used as a standalone rule or with other rules that are not dependent on having to resolve file paths.

As I currently see no reason to have to call `resolve()` for this rule at all. However, I am new to the code, so I may be wrong. :)