### PR TITLE
[docs] Fix `newline-after-import` example

### DIFF
--- a/docs/rules/newline-after-import.md
+++ b/docs/rules/newline-after-import.md
@@ -73,9 +73,8 @@ const FOO = 'BAR'
 
 
 ## Example options usage
-```
+```json
 {
-  ...
   "rules": {
     "import/newline-after-import": ["error", { "count": 2 }]
   }


### PR DESCRIPTION
Fix missing error level in “Example options usage” and add JS highlighting.