### PR TITLE
Update no-nodejs-modules rule to allow ignored files

### DIFF
--- a/docs/rules/no-nodejs-modules.md
+++ b/docs/rules/no-nodejs-modules.md
@@ -7,6 +7,7 @@ Forbid the use of Node.js builtin modules. Can be useful for client-side web pro
 This rule supports the following options:
 
 - `allow`: Array of names of allowed modules. Defaults to an empty array.
+- `ignore`: Array of filenames to disable this check on. Useful if some of your files, like config, run in node.js.
 
 ## Rule Details
 
@@ -32,6 +33,10 @@ var foo = require('foo');
 var foo = require('./foo');
 
 /* eslint import/no-nodejs-modules: ["error", {"allow": ["path"]}] */
+import path from 'path';
+
+// in `config.js`
+/* eslint import/no-nodejs-modules: ["error", {"ignore": ["**\/config*"]}] */
 import path from 'path';
 ```
 

--- a/src/rules/no-nodejs-modules.js
+++ b/src/rules/no-nodejs-modules.js
@@ -39,6 +39,7 @@ module.exports = {
           }],
         },
       },
+      additionalProperties: false,
     }],
   },
 

--- a/src/rules/no-nodejs-modules.js
+++ b/src/rules/no-nodejs-modules.js
@@ -19,6 +19,27 @@ function isIgnored(ignored, filename) {
 module.exports = {
   meta: {
     docs: {},
+    schema: [{
+      type: 'object',
+      properties: {
+        allow: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+        },
+        ignore: {
+          oneOf: [{
+            type: 'string',
+          }, {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          }],
+        },
+      },
+    }],
   },
 
   create: function (context) {

--- a/src/rules/no-nodejs-modules.js
+++ b/src/rules/no-nodejs-modules.js
@@ -16,16 +16,6 @@ function isIgnored(ignored, filename) {
   ))
 }
 
-function guaranteeArray(item) {
-  if (item instanceof Array) {
-    return item
-  }
-  if (item) {
-    return [item]
-  }
-  return []
-}
-
 module.exports = {
   meta: {
     docs: {},
@@ -34,7 +24,7 @@ module.exports = {
   create: function (context) {
     const options = context.options[0] || {}
     const allowed = options.allow || []
-    const ignored = guaranteeArray(options.ignore)
+    const ignored = [].concat(options.ignore || [])
     const filename = context.getFilename()
 
     return {

--- a/tests/src/rules/no-nodejs-modules.js
+++ b/tests/src/rules/no-nodejs-modules.js
@@ -1,3 +1,4 @@
+import * as path from 'path'
 import { test } from '../utils'
 
 import { RuleTester } from 'eslint'
@@ -56,6 +57,26 @@ ruleTester.run('no-nodejs-modules', rule, {
         allow: ['path', 'events'],
       }],
     }),
+    test({
+      code: 'import path from "path"',
+      options: [{ignore: 'ignored.js'}],
+      filename: 'ignored.js',
+    }),
+    test({
+      code: 'import {readFile} from "fs"',
+      options: [{ignore: 'webpack*'}],
+      filename: 'webpack.config.js',
+    }),
+    test({
+      code: 'var events = require("events")',
+      options: [{ignore: 'ignored.js'}],
+      filename: 'ignored.js',
+    }),
+    test({
+      code: 'var events = require("events")',
+      options: [{ignore: '**/ignore*'}],
+      filename: path.join(process.cwd(), 'ignore.js'),
+    }),
   ],
   invalid: [
     test({
@@ -81,5 +102,11 @@ ruleTester.run('no-nodejs-modules', rule, {
       }],
       errors: [error('Do not import Node.js builtin module "fs"')],
     }),
+    test({
+      code: 'import {readFile} from "fs"',
+      options: [{ignore: 'ignored.js'}],
+      filename: 'webpack.config.js',
+      errors: [error('Do not import Node.js builtin module "fs"')],
+    })
   ],
 })

--- a/tests/src/rules/no-nodejs-modules.js
+++ b/tests/src/rules/no-nodejs-modules.js
@@ -77,6 +77,11 @@ ruleTester.run('no-nodejs-modules', rule, {
       options: [{ignore: '**/ignore*'}],
       filename: path.join(process.cwd(), 'ignore.js'),
     }),
+    test({
+      code: 'const {readFile} = require("fs")',
+      options: [{ignore: ['**/ignore*']}],
+      filename: 'ignored.js',
+    })
   ],
   invalid: [
     test({


### PR DESCRIPTION
I have a primarily web-based project, however in my config files, etc, I have access to the node runtime and sometimes need it (to read files, etc).

I want to be able to use node modules in these files, but not anywhere else in the project.

This extension to the rule does that.