### PR TITLE
Release 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+
+
+## [2.4.0] - 2017-06-02
 ### Added
 - Add `filePath` into `parserOptions` passed to `parser` ([#839], thanks [@sompylasar])
 - Add `allow` option to [`no-unassigned-import`] to allow for files that match the globs ([#671], [#737], thanks [@kevin940726]).
@@ -448,6 +451,7 @@ for info on changes for earlier releases.
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
 [#314]: https://github.com/benmosher/eslint-plugin-import/pull/314
 
+[#839]: https://github.com/benmosher/eslint-plugin-import/issues/839
 [#671]: https://github.com/benmosher/eslint-plugin-import/issues/671
 [#660]: https://github.com/benmosher/eslint-plugin-import/issues/660
 [#653]: https://github.com/benmosher/eslint-plugin-import/issues/653
@@ -506,7 +510,8 @@ for info on changes for earlier releases.
 [#119]: https://github.com/benmosher/eslint-plugin-import/issues/119
 [#89]: https://github.com/benmosher/eslint-plugin-import/issues/89
 
-[Unreleased]: https://github.com/benmosher/eslint-plugin-import/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/benmosher/eslint-plugin-import/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/benmosher/eslint-plugin-import/compare/v2.0.1...v2.1.0
@@ -586,4 +591,5 @@ for info on changes for earlier releases.
 [@giodamelio]: https://github.com/giodamelio
 [@ntdb]: https://github.com/ntdb
 [@ramasilveyra]: https://github.com/ramasilveyra
+[@sompylasar]: https://github.com/sompylasar
 [@kevin940726]: https://github.com/kevin940726

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "debug": "^2.2.0",
     "doctrine": "1.5.0",
     "eslint-import-resolver-node": "^0.2.0",
-    "eslint-module-utils": "^2.0.0",
+    "eslint-module-utils": "^2.1.0",
     "has": "^1.0.1",
     "lodash.cond": "^4.3.0",
     "minimatch": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Import with sanity.",
   "engines": {
     "node": ">=4"

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-module-utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Core utilities to support eslint-plugin-import and other module-related plugins.",
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
need to move eslint-module-utils@v2.1.0 to the `latest` tag before publishing