### PR TITLE
Fix flow interface imports giving false-negative with `named` rule

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -155,7 +155,7 @@ export default class ExportMap {
       const d = dep()
       // CJS / ignored dependencies won't exist (#717)
       if (d == null) return
-      
+
       d.forEach((v, n) =>
         n !== 'default' && callback.call(thisArg, v, n, this))
     })
@@ -406,6 +406,7 @@ ExportMap.parse = function (path, content, context) {
           case 'FunctionDeclaration':
           case 'ClassDeclaration':
           case 'TypeAlias': // flowtype with babel-eslint parser
+          case 'InterfaceDeclaration':
             m.namespace.set(n.declaration.id.name, captureDoc(docStyleParsers, n))
             break
           case 'VariableDeclaration':

--- a/tests/files/flowtypes.js
+++ b/tests/files/flowtypes.js
@@ -6,3 +6,7 @@ export type MyType = {
   firstName: string,
   lastName: string
 };
+
+export interface MyInterface {}
+
+export class MyClass {}

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -72,6 +72,14 @@ ruleTester.run('named', rule, {
       code: 'import type { MyType } from "./flowtypes"',
       'parser': 'babel-eslint',
     }),
+    test({
+      code: 'import type { MyInterface } from "./flowtypes"',
+      'parser': 'babel-eslint',
+    }),
+    test({
+      code: 'import type { MyClass } from "./flowtypes"',
+      'parser': 'babel-eslint',
+    }),
 
     // jsnext
     test({


### PR DESCRIPTION
This fixes #708 without ignoring all type imports.