### PR TITLE
Allow core modules to resolve files inside declared modules

### DIFF
--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -8,14 +8,23 @@ function constant(value) {
   return () => value
 }
 
+function baseModule(name) {
+  if (isScoped(name)) {
+    const [scope, pkg] = name.split('/')
+    return `${scope}/${pkg}`
+  }
+  const [pkg] = name.split('/')
+  return pkg
+}
+
 export function isAbsolute(name) {
   return name.indexOf('/') === 0
 }
 
 export function isBuiltIn(name, settings) {
-  const baseModule = name.split('/')[0]
+  const base = baseModule(name)
   const extras = (settings && settings['import/core-modules']) || []
-  return builtinModules.indexOf(baseModule) !== -1 || extras.indexOf(baseModule) > -1
+  return builtinModules.indexOf(base) !== -1 || extras.indexOf(base) > -1
 }
 
 function isExternalPath(path, name, settings) {

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -13,8 +13,9 @@ export function isAbsolute(name) {
 }
 
 export function isBuiltIn(name, settings) {
+  const baseModule = name.split('/')[0]
   const extras = (settings && settings['import/core-modules']) || []
-  return builtinModules.indexOf(name) !== -1 || extras.indexOf(name) > -1
+  return builtinModules.indexOf(baseModule) !== -1 || extras.indexOf(baseModule) > -1
 }
 
 function isExternalPath(path, name, settings) {

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -5,7 +5,7 @@ import importType from 'core/importType'
 
 import { testContext } from '../utils'
 
-describe.only('importType(name)', function () {
+describe('importType(name)', function () {
   const context = testContext()
 
   it("should return 'absolute' for paths starting with a /", function() {

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -5,7 +5,7 @@ import importType from 'core/importType'
 
 import { testContext } from '../utils'
 
-describe('importType(name)', function () {
+describe.only('importType(name)', function () {
   const context = testContext()
 
   it("should return 'absolute' for paths starting with a /", function() {
@@ -72,6 +72,11 @@ describe('importType(name)', function () {
 
     const electronContext = testContext({ 'import/core-modules': ['electron'] })
     expect(importType('electron', electronContext)).to.equal('builtin')
+  })
+
+  it("should return 'builtin' for resources inside additional core modules", function() {
+    const electronContext = testContext({ 'import/core-modules': ['electron'] })
+    expect(importType('electron/some/path/to/resource.json', electronContext)).to.equal('builtin')
   })
 
   it("should return 'external' for module from 'node_modules' with default config", function() {

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -5,7 +5,7 @@ import importType from 'core/importType'
 
 import { testContext } from '../utils'
 
-describe('importType(name)', function () {
+describe.only('importType(name)', function () {
   const context = testContext()
 
   it("should return 'absolute' for paths starting with a /", function() {
@@ -69,14 +69,21 @@ describe('importType(name)', function () {
   it("should return 'builtin' for additional core modules", function() {
     // without extra config, should be marked external
     expect(importType('electron', context)).to.equal('external')
+    expect(importType('@org/foobar', context)).to.equal('external')
 
     const electronContext = testContext({ 'import/core-modules': ['electron'] })
     expect(importType('electron', electronContext)).to.equal('builtin')
+
+    const scopedContext = testContext({ 'import/core-modules': ['@org/foobar'] })
+    expect(importType('@org/foobar', scopedContext)).to.equal('builtin')
   })
 
   it("should return 'builtin' for resources inside additional core modules", function() {
     const electronContext = testContext({ 'import/core-modules': ['electron'] })
     expect(importType('electron/some/path/to/resource.json', electronContext)).to.equal('builtin')
+
+    const scopedContext = testContext({ 'import/core-modules': ['@org/foobar'] })
+    expect(importType('@org/foobar/some/path/to/resource.json', scopedContext)).to.equal('builtin')
   })
 
   it("should return 'external' for module from 'node_modules' with default config", function() {


### PR DESCRIPTION
Closes #886.

Lets users add packages to `core-modules` such as `electron`, then import resources from paths such as `electron/some/path/to/resource.json` without encountering lint errors.

You have edit access to this branch – let me know if there is anything else you're looking for. Thanks!