### PR TITLE
Add no-commonjs-exports-with-import rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 
 * Report potentially ambiguous parse goal (`script` vs. `module`) ([`unambiguous`])
 * Report CommonJS `require` calls and `module.exports` or `exports.*`. ([`no-commonjs`])
+* Report `import` used in the same file as CommonJS `module.exports` or `exports.*`. ([`no-commonjs-exports-with-import`])
 * Report AMD `require` and `define` calls. ([`no-amd`])
 * No Node.js builtin modules. ([`no-nodejs-modules`])
 
 [`unambiguous`]: ./docs/rules/unambiguous.md
 [`no-commonjs`]: ./docs/rules/no-commonjs.md
+[`no-commonjs-exports-with-import`]: ./docs/rules/no-commonjs-exports-with-import.md
 [`no-amd`]: ./docs/rules/no-amd.md
 [`no-nodejs-modules`]: ./docs/rules/no-nodejs-modules.md
 

--- a/docs/rules/no-commonjs-exports-with-import.md
+++ b/docs/rules/no-commonjs-exports-with-import.md
@@ -1,0 +1,52 @@
+# no-commonjs-exports-with-import
+
+Reports if you use `import` in the same file that `module.exports` or
+`exports.*` is used.
+
+webpack will break the bundle if you use `import` in the same file that
+`module.exports` is used, but it will appear to build pretty alright. When this
+happens, webpack outputs a warning like:
+
+```
+WARNING in ./foo.js
+4:12-13 "export 'default' (imported as 'bar') was not found in './bar'
+```
+
+And when the JS is run in the browser, an error like the following is
+logged:
+
+```
+Uncaught TypeError: Cannot assign to read only property 'exports' of
+object '#<Object>'
+```
+
+This rule makes webpack safer to use in this way.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+import foo from './foo';
+module.exports = foo;
+```
+
+The following patterns are not warnings:
+
+```js
+// best
+import foo from './foo';
+export default foo;
+```
+
+```js
+// ok
+const foo = require('./foo');
+module.exports = foo;
+```
+
+```js
+// weird
+const foo = require('./foo');
+export default foo;
+```

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export const rules = {
   'no-anonymous-default-export': require('./rules/no-anonymous-default-export'),
 
   'no-commonjs': require('./rules/no-commonjs'),
+  'no-commonjs-exports-with-import': require('./rules/no-commonjs-exports-with-import'),
   'no-amd': require('./rules/no-amd'),
   'no-duplicates': require('./rules/no-duplicates'),
   'first': require('./rules/first'),

--- a/src/rules/no-commonjs-exports-with-import.js
+++ b/src/rules/no-commonjs-exports-with-import.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Prevent CommonJS exports and import from being used in the same
+ *   file.
+ * @author Joe Lencioni
+ */
+
+const MESSAGE = 'Cannot use CommonJS exports in the same file as `import`'
+
+module.exports = {
+  meta: {
+    docs: {},
+  },
+
+  create: function rule(context) {
+    let usesImport = false
+    let usesCommonJSExports = false
+
+    function flagModuleExports(node) {
+      usesCommonJSExports = true
+
+      if (!usesImport) {
+        return
+      }
+
+      context.report(node, MESSAGE)
+    }
+
+    return {
+      ImportDeclaration(node) {
+        usesImport = true
+
+        if (usesCommonJSExports) {
+          context.report(node, MESSAGE)
+        }
+      },
+
+      AssignmentExpression(node) {
+        if (node.left.type === 'MemberExpression') {
+          // foo.bar = baz;
+          const memberExpression = node.left
+          if (memberExpression.object.name !== 'module') {
+            return
+          }
+          if (memberExpression.property.name !== 'exports') {
+            return
+          }
+
+          flagModuleExports(node)
+        } else {
+          // foo = bar;
+          if (node.left.name !== 'exports') {
+            return
+          }
+
+          flagModuleExports(node)
+        }
+      },
+
+      CallExpression(node) {
+        if (node.callee.type !== 'MemberExpression') {
+          return
+        }
+
+        const memberExpression = node.callee
+        if (memberExpression.object.name !== 'exports') {
+          return
+        }
+
+        flagModuleExports(node)
+      },
+    }
+  },
+}

--- a/tests/src/rules/no-commonjs-exports-with-import.js
+++ b/tests/src/rules/no-commonjs-exports-with-import.js
@@ -1,0 +1,103 @@
+import { RuleTester } from 'eslint'
+
+const ruleTester = new RuleTester()
+const rule = require('rules/no-commonjs-exports-with-import')
+
+const parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module',
+}
+
+ruleTester.run('no-commonjs-exports-with-import', rule, {
+  valid: [
+    {
+      code: `
+        import foo from './foo';
+        export default foo;
+      `,
+      parserOptions,
+    },
+
+    {
+      code: `
+        const foo = require('./foo');
+        export default foo;
+      `,
+      parserOptions,
+    },
+
+    {
+      code: `
+        const foo = require('./foo');
+        module.exports = foo;
+      `,
+      parserOptions,
+    },
+
+    {
+      code: `
+        const foo = require('./foo');
+        exports.foo = foo;
+      `,
+      parserOptions,
+    },
+
+    {
+      code: `
+        const foo = require('./foo');
+        exports.use(foo);
+      `,
+      parserOptions,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `
+        import foo from './foo';
+        module.exports = foo;
+      `,
+      errors: [{
+        message: 'Cannot use CommonJS exports in the same file as `import`',
+        type: 'AssignmentExpression',
+      }],
+      parserOptions,
+    },
+
+    {
+      code: `
+        import foo from './foo';
+        exports = foo;
+      `,
+      errors: [{
+        message: 'Cannot use CommonJS exports in the same file as `import`',
+        type: 'AssignmentExpression',
+      }],
+      parserOptions,
+    },
+
+    {
+      code: `
+        import foo from './foo';
+        exports.use(foo);
+      `,
+      errors: [{
+        message: 'Cannot use CommonJS exports in the same file as `import`',
+        type: 'CallExpression',
+      }],
+      parserOptions,
+    },
+
+    {
+      code: `
+        module.exports = {};
+        import foo from './foo';
+      `,
+      errors: [{
+        message: 'Cannot use CommonJS exports in the same file as `import`',
+        type: 'ImportDeclaration',
+      }],
+      parserOptions,
+    },
+  ],
+})


### PR DESCRIPTION
We want to start using Webpack to resolve imports instead of Babel. One
key difference is that Webpack will break the bundle if you use `import`
in the same file that `module.exports` is used, but it will appear to
build pretty alright. When this happens, webpack outputs a warning like:

```
WARNING in ./foo.js
4:12-13 "export 'default' (imported as 'bar') was not found in './bar'
```

And when the JS is run in the browser, an error like the following is
logged:

```
Uncaught TypeError: Cannot assign to read only property 'exports' of
object '#<Object>'
```

To make this safer to turn on, I am adding this
no-commonjs-exports-with-import rule which reports when it encounters an
`import` in the same file as a CommonJS `module.exports` or `exports.*`.