### PR TITLE
Always include comments when parsing

### DIFF
--- a/tests/src/rules/exports-last.js
+++ b/tests/src/rules/exports-last.js
@@ -53,11 +53,11 @@ ruleTester.run('exports-last', rule, {
     // Multiline export
     test({
       code: `
-        const baz = 'quux'
-        export default function foo () {
+        const foo = 'bar'
+        export default function bar () {
           const very = 'multiline'
         }
-        export const bar = true
+        export const baz = true
       `,
     }),
     // Many exports

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -19,7 +19,8 @@ exports.default = function parse(path, content, context) {
   parserOptions = Object.assign({}, parserOptions)
   parserOptions.ecmaFeatures = Object.assign({}, parserOptions.ecmaFeatures)
 
-  // always attach comments
+  // always include and attach comments
+  parserOptions.comment = true
   parserOptions.attachComment = true
 
   // provide the `filePath` like eslint itself does, in `parserOptions`


### PR DESCRIPTION
See #910 and eslint/typescript-eslint-parser#346.