### PR TITLE
Register TypeScript nodes as exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-import-resolver-webpack": "file:./resolvers/webpack",
     "eslint-module-utils": "file:./utils",
     "eslint-plugin-import": "2.x",
+    "eslint-plugin-typescript": "^0.8.1",
     "gulp": "^3.9.0",
     "gulp-babel": "6.1.2",
     "istanbul": "^0.4.0",
@@ -71,7 +72,7 @@
     "rimraf": "2.5.2",
     "sinon": "^2.3.2",
     "typescript": "^2.0.3",
-    "typescript-eslint-parser": "^2.1.0"
+    "typescript-eslint-parser": "^8.0.0"
   },
   "peerDependencies": {
     "eslint": "2.x - 4.x"

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -409,6 +409,9 @@ ExportMap.parse = function (path, content, context) {
           case 'ClassDeclaration':
           case 'TypeAlias': // flowtype with babel-eslint parser
           case 'InterfaceDeclaration':
+          case 'TSEnumDeclaration':
+          case 'TSInterfaceDeclaration':
+          case 'TSAbstractClassDeclaration':
             m.namespace.set(n.declaration.id.name, captureDoc(docStyleParsers, n))
             break
           case 'VariableDeclaration':

--- a/tests/files/typescript.ts
+++ b/tests/files/typescript.ts
@@ -1,5 +1,23 @@
-type X = string
+export type MyType = string
+export enum MyEnum {
+  Foo,
+  Bar,
+  Baz
+}
+export interface Foo {
+  native: string | number
+  typedef: MyType
+  enum: MyEnum
+}
 
-export function getFoo() : X {
+export abstract class Bar {
+  abstract foo(): Foo
+
+  method() {
+    return "foo"
+  }
+}
+
+export function getFoo() : MyType {
   return "foo"
 }

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -337,8 +337,24 @@ describe('ExportMap', function () {
           expect(imports).property('errors').to.be.empty
         })
 
-        it('has export (getFoo)', function () {
+        it('has exported function', function () {
           expect(imports.has('getFoo')).to.be.true
+        })
+
+        it('has exported typedef', function () {
+          expect(imports.has('MyType')).to.be.true
+        })
+
+        it('has exported enum', function () {
+          expect(imports.has('MyEnum')).to.be.true
+        })
+
+        it('has exported interface', function () {
+          expect(imports.has('Foo')).to.be.true
+        })
+
+        it('has exported abstract class', function () {
+          expect(imports.has('Bar')).to.be.true
         })
       })
     })


### PR DESCRIPTION
This ensures that code using `export enum Foo {}` or `export abstract class Bar {}` registers those as exports that can be imported in other files.