### PR TITLE
Recommended a method of handling Webpack function config arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,19 @@ settings:
 [`eslint_d`]: https://www.npmjs.com/package/eslint_d
 [`eslint-loader`]: https://www.npmjs.com/package/eslint-loader
 
+## Webpack configuration arguments
+
+This plugin doesn't pass arguments to [Webpack configuration functions](https://webpack.js.org/configuration/configuration-types/#exporting-a-function). If a Webpack configuration function uses the `env` or `argv` arguments, values must be supplied to avoid `argument undefined` errors. On Node 6.4 or greater we recommend [default parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters):
+
+```js
+// webpack.config.js
+const defaultEnv = { NODE_ENV: 'development' };
+
+module.exports = (env = defaultEnv) => {
+  // ...configuration
+}
+```
+
 ## SublimeLinter-eslint
 
 SublimeLinter-eslint introduced a change to support `.eslintignore` files


### PR DESCRIPTION
I ran into the undefined `env` issue with webpack function configuration, and noticed while searching that plenty of others have had the same problem. Example issues:

https://github.com/benmosher/eslint-plugin-import/issues/398
https://github.com/AtomLinter/linter-eslint/issues/625

The Vue and React boilerplates I've used recently both use function configuration, so I think this is probably a common issue. Adding a recommended way of handling this issue to the documentation could be helpful for webpack users, and save them the time I spent looking for the cause of the problem and a solution. 

Here's a draft of what I believe is the simplest way to handle the issue. Feedback welcome; I'm happy to revise.