### PR TITLE
no-common-js: allow conditional requires

### DIFF
--- a/src/rules/no-commonjs.js
+++ b/src/rules/no-commonjs.js
@@ -47,6 +47,10 @@ module.exports = {
       },
       'CallExpression': function (call) {
         if (context.getScope().type !== 'module') return
+        if (
+          call.parent.type !== 'ExpressionStatement'
+          && call.parent.type !== 'VariableDeclarator'
+        ) return
 
         if (call.callee.type !== 'Identifier') return
         if (call.callee.name !== 'require') return

--- a/tests/src/rules/no-commonjs.js
+++ b/tests/src/rules/no-commonjs.js
@@ -29,6 +29,7 @@ ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
 
     // allowed requires
     { code: 'function a() { var x = require("y"); }' }, // nested requires allowed
+    { code: 'var a = c && require("b")' }, // conditional requires allowed
     { code: 'require.resolve("help")' }, // methods of require are allowed
     { code: 'require.ensure([])' }, // webpack specific require.ensure is allowed
     { code: 'require([], function(a, b, c) {})' }, // AMD require is allowed


### PR DESCRIPTION
IMO, `a && require('a')` should be allowed.