### PR TITLE
fix #939 by adding `.mjs` to stock Node resolver

### DIFF
--- a/resolvers/node/CHANGELOG.md
+++ b/resolvers/node/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## Unreleased
-
+### Added
+- `.mjs` extension detected by default to support `experimental-modules` (#939)
 
 ## v0.3.1 - 2017-06-23
 ### Changed
@@ -36,6 +37,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 [#438]: https://github.com/benmosher/eslint-plugin-import/pull/438
 
+[#939]: https://github.com/benmosher/eslint-plugin-import/issues/939
 [#531]: https://github.com/benmosher/eslint-plugin-import/issues/531
 [#437]: https://github.com/benmosher/eslint-plugin-import/issues/437
 

--- a/resolvers/node/index.js
+++ b/resolvers/node/index.js
@@ -27,7 +27,8 @@ exports.resolve = function (source, file, config) {
 function opts(file, config) {
   return Object.assign({
       // more closely matches Node (#333)
-      extensions: ['.js', '.json'],
+      // plus 'mjs' for native modules! (#939)
+      extensions: ['.mjs', '.js', '.json'],
     },
     config,
     {

--- a/resolvers/node/package.json
+++ b/resolvers/node/package.json
@@ -3,7 +3,9 @@
   "version": "0.3.1",
   "description": "Node default behavior import resolution plugin for eslint-plugin-import.",
   "main": "index.js",
-  "files": ["index.js"],
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "nyc mocha"
   },

--- a/resolvers/node/test/native.js
+++ b/resolvers/node/test/native.js
@@ -1,0 +1,1 @@
+exports.natively = function () { return "but where do we feature?" }

--- a/resolvers/node/test/native.mjs
+++ b/resolvers/node/test/native.mjs
@@ -1,0 +1,1 @@
+export function natively() { return "a shining new era is tiptoeing nearer" }

--- a/resolvers/node/test/paths.js
+++ b/resolvers/node/test/paths.js
@@ -11,14 +11,39 @@ describe("paths", function () {
   })
 })
 
+
+describe("core", function () {
+  it("returns found, but null path, for core Node modules", function () {
+    var resolved = node.resolve('fs', "./test/file.js")
+    expect(resolved).has.property("found", true)
+    expect(resolved).has.property("path", null)
+  })
+})
+
+
 describe("default options", function () {
+
   it("finds .json files", function () {
-        expect(node.resolve('./data', './test/file.js'))
+    expect(node.resolve('./data', './test/file.js'))
       .to.have.property('path')
       .equal(path.resolve(__dirname, './data.json'))
   })
+
   it("ignores .json files if 'extensions' is redefined", function () {
-        expect(node.resolve('./data', './test/file.js', { extensions: ['.js'] }))
+    expect(node.resolve('./data', './test/file.js', { extensions: ['.js'] }))
       .to.have.property('found', false)
   })
+
+  it("finds mjs modules, with precedence over .js", function () {
+    expect(node.resolve('./native', './test/file.js'))
+      .to.have.property('path')
+      .equal(path.resolve(__dirname, './native.mjs'))
+  })
+
+  it("still finds .js if explicit", function () {
+    expect(node.resolve('./native.js', './test/file.js'))
+      .to.have.property('path')
+      .equal(path.resolve(__dirname, './native.js'))
+  })
+
 })


### PR DESCRIPTION
I'm assuming this is not controversial but thought it'd be good to run it through CI and get feedback just in case.