### PR TITLE
newline-after-import: update error message in case multiple empty lines are expected

### DIFF
--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -84,7 +84,8 @@ module.exports = {
             line: node.loc.end.line,
             column,
           },
-          message: `Expected empty line after ${type} statement not followed by another ${type}.`,
+          message: `Expected ${options.count} empty line${options.count > 1 ? 's' : ''} \
+after ${type} statement not followed by another ${type}.`,
           fix: fixer => fixer.insertTextAfter(
             node,
             '\n'.repeat(EXPECTED_LINE_DIFFERENCE - lineDifference)

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -1,7 +1,10 @@
 import { RuleTester } from 'eslint'
 
-const IMPORT_ERROR_MESSAGE = 'Expected empty line after import statement not followed by another import.'
-const REQUIRE_ERROR_MESSAGE = 'Expected empty line after require statement not followed by another require.'
+const IMPORT_ERROR_MESSAGE = 'Expected 1 empty line after import statement not followed by another import.'
+const IMPORT_ERROR_MESSAGE_MULTIPLE = function(count) {
+    return `Expected ${count} empty lines after import statement not followed by another import.`
+}
+const REQUIRE_ERROR_MESSAGE = 'Expected 1 empty line after require statement not followed by another require.'
 
 const ruleTester = new RuleTester()
 
@@ -181,7 +184,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       errors: [ {
         line: 1,
         column: 1,
-        message: IMPORT_ERROR_MESSAGE,
+        message: IMPORT_ERROR_MESSAGE_MULTIPLE(2),
       } ],
       parserOptions: { sourceType: 'module' },
     },
@@ -347,4 +350,4 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parser: 'babel-eslint',
     },
   ],
-});
+})

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -1,7 +1,7 @@
 import { RuleTester } from 'eslint'
 
 const IMPORT_ERROR_MESSAGE = 'Expected 1 empty line after import statement not followed by another import.'
-const IMPORT_ERROR_MESSAGE_MULTIPLE = function(count) {
+const IMPORT_ERROR_MESSAGE_MULTIPLE = (count) => {
     return `Expected ${count} empty lines after import statement not followed by another import.`
 }
 const REQUIRE_ERROR_MESSAGE = 'Expected 1 empty line after require statement not followed by another require.'


### PR DESCRIPTION
This PR simply updates the `newline-after-import` error message which was misleading when `count` was set to anything other than 1.