### PR TITLE
use main lodash package

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-import-resolver-node": "^0.3.1",
     "eslint-module-utils": "^2.1.1",
     "has": "^1.0.1",
-    "lodash.cond": "^4.3.0",
+    "lodash": "^4.17.4",
     "minimatch": "^3.0.3",
     "read-pkg-up": "^2.0.0"
   },

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -1,4 +1,4 @@
-import cond from 'lodash.cond'
+import cond from 'lodash/cond'
 import builtinModules from 'builtin-modules'
 import { join } from 'path'
 


### PR DESCRIPTION
many libraries use main lodash package and a few use module-separated package, the pr is to reduce size of `node_modules` folder a bit

i was going to change to `lodash@^4.3.0`, but i just notice `eslint` use the latest version, it'll got resolved to that version anyway, so i think we can safely use that version