### PR TITLE
Fix eslint-import-resolver-webpack with pnpm

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -122,8 +122,8 @@ function createResolveSync(configPath, webpackConfig) {
   }
 
   try {
-    var webpackFilename = resolve.sync('webpack', { basedir })
-    var webpackResolveOpts = { basedir: path.dirname(webpackFilename) }
+    var webpackFilename = resolve.sync('webpack', { basedir, preserveSymlinks: false })
+    var webpackResolveOpts = { basedir: path.dirname(webpackFilename), preserveSymlinks: false }
 
     webpackRequire = function (id) {
       return require(resolve.sync(id, webpackResolveOpts))

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -38,7 +38,7 @@
     "is-absolute": "^0.2.3",
     "lodash.get": "^3.7.0",
     "node-libs-browser": "^1.0.0 || ^2.0.0",
-    "resolve": "^1.2.0",
+    "resolve": "^1.4.0",
     "semver": "^5.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updated resolve to ^1.4.0, where it introduced option to not preserve
symlinks when resolving, matching node's behavior.