### PR TITLE
allow newer version of node-libs-browser

### DIFF
--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -37,7 +37,7 @@
     "interpret": "^1.0.0",
     "is-absolute": "^0.2.3",
     "lodash.get": "^3.7.0",
-    "node-libs-browser": "^1.0.0",
+    "node-libs-browser": "^1.0.0 || ^2.0.0",
     "resolve": "^1.2.0",
     "semver": "^5.3.0"
   },


### PR DESCRIPTION
this change allows `node-libs-browser@^2.0.0` in  `eslint-import-resolver-webpack`'s deps since that's the version `webpack@^3.0.0` is using (otherwise one ends up with ^1.0.0 and ^2.0.0 installed)
