### PR TITLE
Es6modules only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 
 - Add [`group-exports`] rule: style-guide rule to report use of multiple named exports ([#721], thanks [@robertrossmann])
+- Add [`es6modules-only`] rule: module-systems rule to detect import of non-es6 modules ([#971], thanks [@dominiktilp])
 
 ## [2.8.0] - 2017-10-18
 ### Added
@@ -433,6 +434,7 @@ for info on changes for earlier releases.
 [`no-anonymous-default-export`]: ./docs/rules/no-anonymous-default-export.md
 [`exports-last`]: ./docs/rules/exports-last.md
 [`group-exports`]: ./docs/rules/group-exports.md
+[`es6modules-only`]: ./docs/rules/es6modules-only.md
 
 [`memo-parser`]: ./memo-parser/README.md
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 * Report CommonJS `require` calls and `module.exports` or `exports.*`. ([`no-commonjs`])
 * Report AMD `require` and `define` calls. ([`no-amd`])
 * No Node.js builtin modules. ([`no-nodejs-modules`])
+* No non-ES6 module import. ([`es6modules-only`])
 
 [`unambiguous`]: ./docs/rules/unambiguous.md
 [`no-commonjs`]: ./docs/rules/no-commonjs.md
 [`no-amd`]: ./docs/rules/no-amd.md
 [`no-nodejs-modules`]: ./docs/rules/no-nodejs-modules.md
+[`es6modules-only`]: ./docs/rules/es6modules-only.md
 
 
 **Style guide:**

--- a/docs/rules/es6modules-only.md
+++ b/docs/rules/es6modules-only.md
@@ -1,0 +1,49 @@
+# es6modules-only
+
+Ensures that the imported file is an ES6 modules / use ES6 export statement.
+
+It's good to use it together with [no-unresolved](./no-unresolved.md)
+
+By default it parse only ES6 import statement, but it is possible to enable it for commonjs / amd (if it make sense to someone) by setting `{ commonjs: true/false, amd: true/false }` as a rule option.
+
+## Rule Details
+
+### Options
+
+By default, only ES6 imports will be resolved:
+
+```js
+/*eslint import/es6modules-only: 2*/
+import x from './foo' // reports if './foo' is not an es6 module
+
+const y = require './bar' // will not report even if './bar' is not an es6 module
+```
+
+#### `ignore`
+
+This rule has its own ignore list, separate from [`import/ignore`]. This is because you may want to ignore some external modules which do not provide es6 version.
+
+```js
+/*eslint import/es6modules-only: "import/es6modules-only": [2, { "ignore": ["react"] }]*/
+
+import react from 'react' // will not be reported, even if not and es6 module
+
+import lodash from 'lodash' // will be reported (if not and es6 module)
+```
+
+```js
+/*eslint import/es6modules-only: "import/es6modules-only": [2, { "ignore": [".styl"] }]*/
+
+import 'basicStyles.styl' // will not be reported
+
+```
+
+## When To Use It
+
+If you want to have es6 only project, and mainly if you want to use tree shaking and other optiomizations. Because it is often hard or even imposible to use it with commonjs / amd modules.
+
+## Further Reading
+
+- [Webpack treeshaking](https://webpack.js.org/guides/tree-shaking/)
+- [Webpack harmony-unused example](https://github.com/webpack/webpack/tree/master/examples/harmony-unused)
+- [ES6 modules chapter in Exploring JS](http://exploringjs.com/es6/ch_modules.html)

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "doctrine": "1.5.0",
     "eslint-import-resolver-node": "^0.3.1",
     "eslint-module-utils": "^2.1.1",
+    "espree": "^3.5.2",
     "has": "^1.0.1",
     "lodash.cond": "^4.3.0",
     "minimatch": "^3.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export const rules = {
+  'es6modules-only': require('./rules/es6modules-only'),
   'no-unresolved': require('./rules/no-unresolved'),
   'named': require('./rules/named'),
   'default': require('./rules/default'),

--- a/src/rules/es6modules-only.js
+++ b/src/rules/es6modules-only.js
@@ -1,0 +1,71 @@
+/**
+ * Ensure that the imported file is an ES6 module (use ES6 export).
+ */
+
+import fs from 'fs'
+import espree from 'espree'
+
+import resolve from 'eslint-module-utils/resolve'
+import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor'
+
+function containES6export(ast) {
+  if (!ast.body) {
+    return {es6: false, err: 'unkown AST'}
+  }
+  const es6export = ast.body.find(
+    node => node.type ? 
+    [
+      'ExportDefaultDeclaration',
+      'ExportNamedDeclaration',
+      'ExportAllDeclaration',
+      'ExportSpecifier',
+    ].includes(node.type) :
+    false
+  )
+
+  return {es6: es6export, err: null}
+}
+
+module.exports = {
+  meta: {
+    schema: [ makeOptionsSchema({
+      espreeConfiguration: { 
+        type: 'object',
+        default: { ecmaVersion: 9, sourceType: 'module', ecmaFeatures: { jsx: true } } ,
+      },
+    })],
+  },
+
+  create: function (context) {
+    const espreeConfiguration = Object.assign(
+      { ecmaVersion: 9, sourceType: 'module', ecmaFeatures: { jsx: true } },
+      context.options[0] ? context.options[0].espreeConfiguration || {} : {}
+    )
+    function checkSourceValue(source) {
+      const resolvedPath = resolve(source.value, context)
+
+      if (resolvedPath !== undefined) {
+        const code = fs.readFileSync(resolvedPath)
+        
+        const ast = espree.parse(code, espreeConfiguration)
+        const result = containES6export(ast)
+        if (!result.es6) {
+          if (result.err) {
+            context.report(source,
+              `Not possible to check '${source.value}'.`)
+          }
+          context.report(source,
+            `Not an ES6 module '${source.value}'.`)
+        }
+      } else {
+        context.report(source,
+          `Not possible to check '${source.value}'.`)
+      }
+
+    }
+
+    return moduleVisitor(checkSourceValue, context.options[0])
+
+  },
+}
+

--- a/tests/src/rules/es6modules-only.js
+++ b/tests/src/rules/es6modules-only.js
@@ -1,0 +1,93 @@
+import * as path from 'path'
+
+import { test, SYNTAX_CASES } from '../utils'
+
+import { CASE_SENSITIVE_FS } from 'eslint-module-utils/resolve'
+
+import { RuleTester } from 'eslint'
+
+var ruleTester = new RuleTester()
+  , rule = require('rules/es6modules-only')
+  , settings = {
+    'import/resolve': {
+      'paths': [path.join( process.cwd(), 'tests', 'files')],
+    },
+  }
+
+  ruleTester.run('es6modules-only', rule, {
+    valid: [
+      test({ code: 'import defaultExport from "./default-export"', settings }),
+      test({ code: 'import defaultClass from "./default-class"', settings }),
+      test({ code: 'import {ExportedClass} from "./named-exports"', settings }),
+      test({ code: 'import all from "./export-all"', settings }),
+
+      test({ 
+        code: 'import common from "./common-module"',
+        settings,
+        options: [ { ignore: ['./common-module'] } ],
+      }),
+
+      test({ 
+        code: 'const defaultExport = require("./default-export")',
+        settings,
+        options: [{ commonjs: true }],
+      }),
+      test({
+        code: 'const defaultClass = require("./default-class")',
+        settings,
+        options: [{ commonjs: true }],
+      }),
+      test({
+        code: 'const {ExportedClass} = require("./named-exports")',
+        settings,
+        options: [{ commonjs: true }],
+      }),
+      test({ 
+        code: 'const all = require("./export-all")',
+        settings,
+        options: [{ commonjs: true }],
+      }),
+    ],
+    invalid: [
+      test({ 
+        code: 'import umd from "./umd"', 
+        settings,
+        errors: [{ message: 'Not an ES6 module \'./umd\'.'
+        , type: 'Literal' }],
+      }),
+      test({ 
+        code: 'import common from "./common-module"', 
+        settings,
+        errors: [{ message: 'Not an ES6 module \'./common-module\'.'
+        , type: 'Literal' }],
+      }),
+      test({ 
+        code: 'import common from "./nonexisted-module"', 
+        settings,
+        errors: [{ message: 'Not possible to check \'./nonexisted-module\'.'
+        , type: 'Literal' }],
+      }),
+
+      test({ 
+        code: 'const umd = require("./umd")', 
+        settings,
+        options: [{ commonjs: true }],
+        errors: [{ message: 'Not an ES6 module \'./umd\'.'
+        , type: 'Literal' }],
+      }),
+      test({ 
+        code: 'const common = require("./common-module")', 
+        settings,
+        options: [{ commonjs: true }],
+        errors: [{ message: 'Not an ES6 module \'./common-module\'.'
+        , type: 'Literal' }],
+      }),
+      test({ 
+        code: 'const common = require("./nonexisted-module")', 
+        settings,
+        options: [{ commonjs: true }],
+        errors: [{ message: 'Not possible to check \'./nonexisted-module\'.'
+        , type: 'Literal' }],
+      }),
+    ],
+  })


### PR DESCRIPTION
It's really basic implementation. It only checks if AST of imported file contains one of these nodes types
[ 
  'ExportDefaultDeclaration',
  'ExportNamedDeclaration',
  'ExportAllDeclaration',
  'ExportSpecifier',
]