### PR TITLE
Update recommended.js

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -3,6 +3,8 @@
  * @type {Object}
  */
 module.exports = {
+  plugins: ['import'],
+
   rules: {
     // analysis/correctness
     'import/no-unresolved': 'error',


### PR DESCRIPTION
Add missing plugins config. If you use `recommended` without this the rules aren't found?