### PR TITLE
Handle call expressions in the no-anonymous-default-export rule

### DIFF
--- a/docs/rules/no-anonymous-default-export.md
+++ b/docs/rules/no-anonymous-default-export.md
@@ -16,6 +16,7 @@ The complete default configuration looks like this.
   "allowArrowFunction": false,
   "allowAnonymousClass": false,
   "allowAnonymousFunction": false,
+  "allowCallExpression": true, // The true value here is for backward compatibility
   "allowLiteral": false,
   "allowObject": false
 }]
@@ -32,6 +33,9 @@ export default () => {}
 export default class {}
 
 export default function () {}
+
+/* eslint import/no-anonymous-default-export: [2, {"allowCallExpression": false}] */
+export default foo(bar)
 
 export default 123
 
@@ -58,6 +62,8 @@ export default class {}
 
 /* eslint import/no-anonymous-default-export: [2, {"allowAnonymousFunction": true}] */
 export default function () {}
+
+export default foo(bar)
 
 /* eslint import/no-anonymous-default-export: [2, {"allowLiteral": true}] */
 export default 123

--- a/src/rules/no-anonymous-default-export.js
+++ b/src/rules/no-anonymous-default-export.js
@@ -14,6 +14,12 @@ const defs = {
     description: 'If `false`, will report default export of an arrow function',
     message: 'Assign arrow function to a variable before exporting as module default',
   },
+  CallExpression: {
+    option: 'allowCallExpression',
+    description: 'If `false`, will report default export of a function call',
+    message: 'Assign call result to a variable before exporting as module default',
+    default: true,
+  },
   ClassDeclaration: {
     option: 'allowAnonymousClass',
     description: 'If `false`, will report default export of an anonymous class',
@@ -43,15 +49,21 @@ const defs = {
   },
 }
 
-const schemaProperties = Object.keys(defs).
-  map((key) => defs[key]).
-  reduce((acc, def) => {
+const schemaProperties = Object.keys(defs)
+  .map((key) => defs[key])
+  .reduce((acc, def) => {
     acc[def.option] = {
       description: def.description,
       type: 'boolean',
-      default: false,
     }
 
+    return acc
+  }, {})
+
+const defaults = Object.keys(defs)
+  .map((key) => defs[key])
+  .reduce((acc, def) => {
+    acc[def.option] = def.hasOwnProperty('default') ? def.default : false
     return acc
   }, {})
 
@@ -67,7 +79,7 @@ module.exports = {
   },
 
   create: function (context) {
-    const options = Object.assign({}, context.options[0])
+    const options = Object.assign({}, defaults, context.options[0])
 
     return {
       'ExportDefaultDeclaration': (node) => {

--- a/tests/src/rules/no-anonymous-default-export.js
+++ b/tests/src/rules/no-anonymous-default-export.js
@@ -21,6 +21,7 @@ ruleTester.run('no-anonymous-default-export', rule, {
       test({ code: 'export default \'foo\'', options: [{ allowLiteral: true }] }),
       test({ code: 'export default `foo`', options: [{ allowLiteral: true }] }),
       test({ code: 'export default {}', options: [{ allowObject: true }] }),
+      test({ code: 'export default foo(bar)', options: [{ allowCallExpression: true }] }),
 
       // Allow forbidden types with multiple options
       test({ code: 'export default 123', options: [{ allowLiteral: true, allowObject: true }] }),
@@ -30,6 +31,9 @@ ruleTester.run('no-anonymous-default-export', rule, {
       test({ code: 'export * from \'foo\'' }),
       test({ code: 'const foo = 123\nexport { foo }' }),
       test({ code: 'const foo = 123\nexport { foo as default }' }),
+
+      // Allow call expressions by default for backwards compatibility
+      test({ code: 'export default foo(bar)' }),
 
       ...SYNTAX_CASES,
     ],
@@ -43,6 +47,7 @@ ruleTester.run('no-anonymous-default-export', rule, {
       test({ code: 'export default \'foo\'', errors: [{ message: 'Assign literal to a variable before exporting as module default' }] }),
       test({ code: 'export default `foo`', errors: [{ message: 'Assign literal to a variable before exporting as module default' }] }),
       test({ code: 'export default {}', errors: [{ message: 'Assign object to a variable before exporting as module default' }] }),
+      test({ code: 'export default foo(bar)', options: [{ allowCallExpression: false }], errors: [{ message: 'Assign call result to a variable before exporting as module default' }] }),
 
       // Test failure with non-covering exception
       test({ code: 'export default 123', options: [{ allowObject: true }], errors: [{ message: 'Assign literal to a variable before exporting as module default' }] }),


### PR DESCRIPTION
Call expressions are not handled by the `no-anonymous-default-export` rule... not anymore!

Previously:
```js
// No error
export default foo(bar)
```

After the PR:
```js
// Error: Assign call result to a variable before exporting as module default
export default foo(bar)
```