### PR TITLE
`no-commonjs`: Fix false positive when `exports` is in scope

### DIFF
--- a/src/rules/no-commonjs.js
+++ b/src/rules/no-commonjs.js
@@ -36,7 +36,12 @@ module.exports = {
 
         // exports.
         if (node.object.name === 'exports') {
-          context.report({ node, message: EXPORT_MESSAGE })
+          const isInScope = context.getScope()
+            .variables
+            .some(variable => variable.name === 'exports')
+          if (! isInScope) {
+            context.report({ node, message: EXPORT_MESSAGE })
+          }
         }
 
       },

--- a/tests/src/rules/no-commonjs.js
+++ b/tests/src/rules/no-commonjs.js
@@ -17,6 +17,15 @@ ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
     // exports
     { code: 'export default "x"', parserOptions: { sourceType: 'module' } },
     { code: 'export function house() {}', parserOptions: { sourceType: 'module' } },
+    {
+      code:
+      'function someFunc() {\n'+
+      '  const exports = someComputation();\n'+
+      '\n'+
+      '  expect(exports.someProp).toEqual({ a: \'value\' });\n'+
+      '}',
+      parserOptions: { sourceType: 'module' },
+    },
 
     // allowed requires
     { code: 'function a() { var x = require("y"); }' }, // nested requires allowed


### PR DESCRIPTION
I've added a fix for false positives for no-commonjs when `exports` is in scope.

Fixes #940.