### PR TITLE
Fix Unambiguous JavaScript Grammar link

### DIFF
--- a/docs/rules/unambiguous.md
+++ b/docs/rules/unambiguous.md
@@ -51,4 +51,4 @@ a `module`.
 - [node-eps#13](https://github.com/nodejs/node-eps/issues/13)
 
 [`parserOptions.sourceType`]: http://eslint.org/docs/user-guide/configuring#specifying-parser-options
-[Unambiguous JavaScript Grammar]: https://github.com/nodejs/node-eps/blob/master/002-es6-modules.md#51-determining-if-source-is-an-es-module
+[Unambiguous JavaScript Grammar]: https://github.com/nodejs/node-eps/blob/master/002-es-modules.md#32-determining-if-source-is-an-es-module


### PR DESCRIPTION
The old link was a dead link. 