### PR TITLE
fixes #954 - strip out webpack loaders for no-extraneous-dependencies

### DIFF
--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -55,11 +55,11 @@ function optDepErrorMessage(packageName) {
 }
 
 function stripWebpackLoaders(name) {
-  return name.split('!').pop();
+  return name.split('!').pop()
 }
 
 function reportIfMissing(context, deps, depsOptions, node, name) {
-  name = stripWebpackLoaders(name);
+  name = stripWebpackLoaders(name)
   if (importType(name, context) !== 'external') {
     return
   }

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -54,7 +54,12 @@ function optDepErrorMessage(packageName) {
     `not optionalDependencies.`
 }
 
+function stripWebpackLoaders(name) {
+  return name.split('!').pop();
+}
+
 function reportIfMissing(context, deps, depsOptions, node, name) {
+  name = stripWebpackLoaders(name);
   if (importType(name, context) !== 'external') {
     return
   }

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -29,6 +29,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({ code: 'var foo = require("pkg-up")'}),
     test({ code: 'import "fs"'}),
     test({ code: 'import "./foo"'}),
+    test({ code: 'import "raw-loader!./foo"'}),
     test({ code: 'import "lodash.isarray"'}),
     test({ code: 'import "@org/package"'}),
 
@@ -73,6 +74,13 @@ ruleTester.run('no-extraneous-dependencies', rule, {
   invalid: [
     test({
       code: 'import "not-a-dependency"',
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+      }],
+    }),
+    test({
+      code: 'import "raw-loader!not-a-dependency"',
       errors: [{
         ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',


### PR DESCRIPTION
Hi everyone!

A small attempt to fix https://github.com/benmosher/eslint-plugin-import/issues/954. I'm not that familiar with eslint-plugin-import so I wasn't sure how "resolvers" should help here or not (https://github.com/benmosher/eslint-plugin-import/issues/954#issuecomment-338195344).

However this could be an intermediate solution.