### PR TITLE
Don't respect config setting if in a node_module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
 !tests/**/node_modules/
+!resolvers/**/test/**/node_modules
 
 # Users Environment Variables
 .lock-wscript

--- a/resolvers/webpack/CHANGELOG.md
+++ b/resolvers/webpack/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## Unreleased
+- Fix [#666] - only respect config and configIndex settings if not in a node_module
 
 ## 0.8.3 - 2017-06-23
 ### Changed

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -16,12 +16,17 @@ var log = require('debug')('eslint-plugin-import:resolver:webpack')
 exports.interfaceVersion = 2
 
 /**
+ * Settings object
+ * @typedef {Object} settings
+ * @property {string} configPath the path to the webpack config
+ */
+/**
  * Find the full path to 'source', given 'file' as a full reference path.
  *
  * resolveImport('./foo', '/Users/ben/bar.js') => '/Users/ben/foo.js'
  * @param  {string} source - the module to resolve; i.e './some-module'
  * @param  {string} file - the importing file's full path; i.e. '/usr/local/bin/file.js'
- * TODO: take options as a third param, with webpack config file name
+ * @param  {settings} settings - settings object
  * @return {string?} the resolved path to source, undefined if not resolved, or null
  *                   if resolved to a non-FS resource (i.e. script tag at page load)
  */

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -44,12 +44,16 @@ exports.resolve = function (source, file, settings) {
   }
 
   var webpackConfig
-
-  var configPath = get(settings, 'config')
-    , configIndex = get(settings, 'config-index')
+    , configPath
+    , configIndex
     , packageDir
 
-  log('Config path from settings:', configPath)
+  // Only respect webpackConfig settings if not in a node_module
+  if (!~file.indexOf('/node_modules/')) {
+    configPath = get(settings, 'config')
+    configIndex = get(settings, 'config-index')
+    log('Config path from settings:', configPath)
+  }
 
   // see if we've got a config path, a config object, an array of config objects or a config function
   if (!configPath || typeof configPath === 'string') {

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -96,7 +96,7 @@ describe("config", function () {
     const npmModuleFile = path.resolve(npmModulePath, 'foo.js')
 
     // Repeat of test against foo alias, for a control
-    // (If the alias is changed, this test could silently regress without this)
+    // (Without this, if the alias was changed, this test would silently regress)
     expect(resolve('foo', file, absoluteSettings)).to.have.property('path')
         .and.equal(path.join(__dirname, 'files', 'some', 'absolutely', 'goofy', 'path', 'foo.js'))
     // Actual test

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -91,4 +91,16 @@ describe("config", function () {
         .and.equal(path.join(__dirname, 'files', 'some', 'goofy', 'path', 'foo.js'))
   })
 
+  it("ignores config setting when resolving inside a dependency", function () {
+    const npmModulePath = path.resolve(__dirname, 'files', 'node_modules', 'some-module')
+    const npmModuleFile = path.resolve(npmModulePath, 'foo.js')
+
+    // Repeat of test against foo alias, for a control
+    // (If the alias is changed, this test could silently regress without this)
+    expect(resolve('foo', file, absoluteSettings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'some', 'absolutely', 'goofy', 'path', 'foo.js'))
+    // Actual test
+    expect(resolve('foo', npmModuleFile, absoluteSettings)).to.have.property('found')
+        .and.equal(false)
+  })
 })


### PR DESCRIPTION
Fixes #666.

This has made the `resolve.moduleDirectories finds a node module` test to fail - it was the creation of the `package.json` in the fake node_module that prompted it. I have spent quite some time looking at this test alone already, and it appears that resolveSync is not finding it, and I cannot for the life of me work out why this happens...

All I can say is that I have verified that it's not my code that caused it (`checkout master`, create `package.json` in `some-module`, then run tests), just the creation of the package.json (which, of course, is expected of an npm module..)

It is 3:20AM now for me, think I'm going to call it a night. :sleeping: 