### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/src/docsUrl.js
+++ b/src/docsUrl.js
@@ -1,10 +1,5 @@
 const repoUrl = 'https://github.com/benmosher/eslint-plugin-import'
 
-export default function docsUrl(ruleName, commitHash) {
-  let baseUrl = `${repoUrl}/tree/master/docs/rules`
-  if (commitHash) {
-    baseUrl = `${repoUrl}/blob/${commitHash}/docs/rules`
-  }
-
-  return `${baseUrl}/${ruleName}.md`
+export default function docsUrl(ruleName, commitHash = 'master') {
+  return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`
 }

--- a/src/docsUrl.js
+++ b/src/docsUrl.js
@@ -1,5 +1,10 @@
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+const repoUrl = 'https://github.com/benmosher/eslint-plugin-import'
 
-export default function docsUrl(ruleName) {
-  return `${ruleDocsUrl}/${ruleName}.md`
+export default function docsUrl(ruleName, commitHash) {
+  let baseUrl = `${repoUrl}/tree/master/docs/rules`
+  if (commitHash) {
+    baseUrl = `${repoUrl}/blob/${commitHash}/docs/rules`
+  }
+
+  return `${baseUrl}/${ruleName}.md`
 }

--- a/src/docsUrl.js
+++ b/src/docsUrl.js
@@ -1,0 +1,5 @@
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
+export default function docsUrl(ruleName) {
+  return `${ruleDocsUrl}/${ruleName}.md`
+}

--- a/src/rules/default.js
+++ b/src/rules/default.js
@@ -1,8 +1,12 @@
 import Exports from '../ExportMap'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/default.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/default.js
+++ b/src/rules/default.js
@@ -1,11 +1,10 @@
 import Exports from '../ExportMap'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/default.md`,
+      url: docsUrl('default'),
     },
   },
 

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -1,8 +1,12 @@
 import ExportMap, { recursivePatternCapture } from '../ExportMap'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/export.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -1,11 +1,10 @@
 import ExportMap, { recursivePatternCapture } from '../ExportMap'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/export.md`,
+      url: docsUrl('export'),
     },
   },
 

--- a/src/rules/exports-last.js
+++ b/src/rules/exports-last.js
@@ -4,7 +4,15 @@ function isNonExportStatement({ type }) {
     type !== 'ExportAllDeclaration'
 }
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
+  meta: {
+    docs: {
+      url: `${ruleDocsUrl}/exports-last.md`,
+    },
+  },
+
   create: function (context) {
     return {
       Program: function ({ body }) {

--- a/src/rules/exports-last.js
+++ b/src/rules/exports-last.js
@@ -1,15 +1,15 @@
+import docsUrl from '../docsUrl'
+
 function isNonExportStatement({ type }) {
   return type !== 'ExportDefaultDeclaration' &&
     type !== 'ExportNamedDeclaration' &&
     type !== 'ExportAllDeclaration'
 }
 
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
-
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/exports-last.md`,
+      url: docsUrl('exports-last'),
     },
   },
 

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -10,11 +10,12 @@ const patternProperties = {
 }
 const properties = {
   type: 'object',
-  properties: { 
+  properties: {
     'pattern': patternProperties,
     'ignorePackages': { type: 'boolean' },
   },
 }
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 function buildProperties(context) {
 
@@ -46,7 +47,7 @@ function buildProperties(context) {
       // If ignorePackages is provided, transfer it to result
       if (obj.ignorePackages !== undefined) {
         result.ignorePackages = obj.ignorePackages
-      }      
+      }
     })
 
     return result
@@ -54,7 +55,9 @@ function buildProperties(context) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/extensions.md`,
+    },
 
     schema: {
       anyOf: [
@@ -66,7 +69,7 @@ module.exports = {
         {
           type: 'array',
           items: [
-            enumValues, 
+            enumValues,
             properties,
           ],
           additionalItems: false,
@@ -75,7 +78,7 @@ module.exports = {
           type: 'array',
           items: [properties],
           additionalItems: false,
-        },                
+        },
         {
           type: 'array',
           items: [patternProperties],

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -2,6 +2,7 @@ import path from 'path'
 
 import resolve from 'eslint-module-utils/resolve'
 import { isBuiltIn, isExternalModuleMain, isScopedMain } from '../core/importType'
+import docsUrl from '../docsUrl'
 
 const enumValues = { enum: [ 'always', 'ignorePackages', 'never' ] }
 const patternProperties = {
@@ -15,7 +16,6 @@ const properties = {
     'ignorePackages': { type: 'boolean' },
   },
 }
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 function buildProperties(context) {
 
@@ -56,7 +56,7 @@ function buildProperties(context) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/extensions.md`,
+      url: docsUrl('extensions'),
     },
 
     schema: {

--- a/src/rules/first.js
+++ b/src/rules/first.js
@@ -1,6 +1,10 @@
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/first.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/first.js
+++ b/src/rules/first.js
@@ -1,9 +1,9 @@
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/first.md`,
+      url: docsUrl('first'),
     },
   },
 

--- a/src/rules/group-exports.js
+++ b/src/rules/group-exports.js
@@ -1,7 +1,8 @@
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
+
 const meta = {
   docs: {
-    url: `${ruleDocsUrl}/group-exports.md`,
+    url: docsUrl('group-exports'),
   },
 }
 /* eslint-disable max-len */

--- a/src/rules/group-exports.js
+++ b/src/rules/group-exports.js
@@ -1,4 +1,9 @@
-const meta = {}
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+const meta = {
+  docs: {
+    url: `${ruleDocsUrl}/group-exports.md`,
+  },
+}
 /* eslint-disable max-len */
 const errors = {
   ExportNamedDeclaration: 'Multiple named export declarations; consolidate all named exports into a single export declaration',

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -1,5 +1,12 @@
 import first from './first'
 
-const newMeta = Object.assign({}, first.meta, { deprecated: true })
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/blob'
+
+const newMeta = Object.assign({}, first.meta, {
+  deprecated: true,
+  docs: {
+    url: `${ruleDocsUrl}/7b25c1cb95ee18acc1531002fd343e1e6031f9ed/docs/rules/imports-first.md`,
+  },
+})
 
 module.exports = Object.assign({}, first, { meta: newMeta })

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -1,11 +1,10 @@
 import first from './first'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/blob'
+import docsUrl from '../docsUrl'
 
 const newMeta = Object.assign({}, first.meta, {
   deprecated: true,
   docs: {
-    url: `${ruleDocsUrl}/7b25c1cb95ee18acc1531002fd343e1e6031f9ed/docs/rules/imports-first.md`,
+    url: docsUrl('imports-first', '7b25c1cb95ee18acc1531002fd343e1e6031f9ed'),
   },
 })
 

--- a/src/rules/imports-first.js
+++ b/src/rules/imports-first.js
@@ -1,5 +1,6 @@
-import first from './first'
 import docsUrl from '../docsUrl'
+
+const first = require('./first')
 
 const newMeta = Object.assign({}, first.meta, {
   deprecated: true,

--- a/src/rules/max-dependencies.js
+++ b/src/rules/max-dependencies.js
@@ -12,10 +12,13 @@ const countDependencies = (dependencies, lastNode, context) => {
     )
   }
 }
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/max-dependencies.md`,
+    },
 
     schema: [
       {

--- a/src/rules/max-dependencies.js
+++ b/src/rules/max-dependencies.js
@@ -1,4 +1,5 @@
 import isStaticRequire from '../core/staticRequire'
+import docsUrl from '../docsUrl'
 
 const DEFAULT_MAX = 10
 
@@ -12,12 +13,11 @@ const countDependencies = (dependencies, lastNode, context) => {
     )
   }
 }
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/max-dependencies.md`,
+      url: docsUrl('max-dependencies'),
     },
 
     schema: [

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -1,9 +1,13 @@
 import * as path from 'path'
 import Exports from '../ExportMap'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/named.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -1,12 +1,11 @@
 import * as path from 'path'
 import Exports from '../ExportMap'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/named.md`,
+      url: docsUrl('named'),
     },
   },
 

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -1,13 +1,12 @@
+import declaredScope from 'eslint-module-utils/declaredScope'
 import Exports from '../ExportMap'
 import importDeclaration from '../importDeclaration'
-import declaredScope from 'eslint-module-utils/declaredScope'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/namespace.md`,
+      url: docsUrl('namespace'),
     },
 
     schema: [

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -2,8 +2,14 @@ import Exports from '../ExportMap'
 import importDeclaration from '../importDeclaration'
 import declaredScope from 'eslint-module-utils/declaredScope'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
+    docs: {
+      url: `${ruleDocsUrl}/namespace.md`,
+    },
+
     schema: [
       {
         'type': 'object',

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -4,10 +4,10 @@
  */
 
 import isStaticRequire from '../core/staticRequire'
+import docsUrl from '../docsUrl'
 
 import debug from 'debug'
 const log = debug('eslint-plugin-import:rules:newline-after-import')
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -46,7 +46,7 @@ function isClassWithDecorator(node) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/newline-after-import.md`,
+      url: docsUrl('newline-after-import'),
     },
     schema: [
       {

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -7,6 +7,7 @@ import isStaticRequire from '../core/staticRequire'
 
 import debug from 'debug'
 const log = debug('eslint-plugin-import:rules:newline-after-import')
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -44,7 +45,9 @@ function isClassWithDecorator(node) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/newline-after-import.md`,
+    },
     schema: [
       {
         'type': 'object',

--- a/src/rules/no-absolute-path.js
+++ b/src/rules/no-absolute-path.js
@@ -1,9 +1,13 @@
 import { isAbsolute } from '../core/importType'
 import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-absolute-path.md`,
+    },
     schema: [ makeOptionsSchema() ],
   },
 

--- a/src/rules/no-absolute-path.js
+++ b/src/rules/no-absolute-path.js
@@ -1,12 +1,11 @@
-import { isAbsolute } from '../core/importType'
 import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import { isAbsolute } from '../core/importType'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-absolute-path.md`,
+      url: docsUrl('no-absolute-path'),
     },
     schema: [ makeOptionsSchema() ],
   },

--- a/src/rules/no-amd.js
+++ b/src/rules/no-amd.js
@@ -3,7 +3,7 @@
  * @author Jamund Ferguson
  */
 
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -12,7 +12,7 @@ const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/mast
 module.exports = {
     meta: {
         docs: {
-            url: `${ruleDocsUrl}/no-amd.md`,
+            url: docsUrl('no-amd'),
         },
     },
 

--- a/src/rules/no-amd.js
+++ b/src/rules/no-amd.js
@@ -3,13 +3,17 @@
  * @author Jamund Ferguson
  */
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = {
     meta: {
-        docs: {},
+        docs: {
+            url: `${ruleDocsUrl}/no-amd.md`,
+        },
     },
 
     create: function (context) {

--- a/src/rules/no-anonymous-default-export.js
+++ b/src/rules/no-anonymous-default-export.js
@@ -3,6 +3,8 @@
  * @author Duncan Beevers
  */
 
+import docsUrl from '../docsUrl'
+
 const defs = {
   ArrayExpression: {
     option: 'allowArray',
@@ -67,12 +69,10 @@ const defaults = Object.keys(defs)
     return acc
   }, {})
 
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
-
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-anonymous-default-export.md`,
+      url: docsUrl('no-anonymous-default-export'),
     },
 
     schema: [

--- a/src/rules/no-anonymous-default-export.js
+++ b/src/rules/no-anonymous-default-export.js
@@ -67,8 +67,14 @@ const defaults = Object.keys(defs)
     return acc
   }, {})
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
+    docs: {
+      url: `${ruleDocsUrl}/no-anonymous-default-export.md`,
+    },
+
     schema: [
       {
         type: 'object',

--- a/src/rules/no-commonjs.js
+++ b/src/rules/no-commonjs.js
@@ -5,6 +5,7 @@
 
 const EXPORT_MESSAGE = 'Expected "export" or "export default"'
     , IMPORT_MESSAGE = 'Expected "import" instead of "require()"'
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 function allowPrimitive(node, context) {
   if (context.options.indexOf('allow-primitive-modules') < 0) return false
@@ -19,7 +20,9 @@ function allowPrimitive(node, context) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-commonjs.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-commonjs.js
+++ b/src/rules/no-commonjs.js
@@ -3,9 +3,10 @@
  * @author Jamund Ferguson
  */
 
+import docsUrl from '../docsUrl'
+
 const EXPORT_MESSAGE = 'Expected "export" or "export default"'
     , IMPORT_MESSAGE = 'Expected "import" instead of "require()"'
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 function allowPrimitive(node, context) {
   if (context.options.indexOf('allow-primitive-modules') < 0) return false
@@ -21,7 +22,7 @@ function allowPrimitive(node, context) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-commonjs.md`,
+      url: docsUrl('no-commonjs'),
     },
   },
 

--- a/src/rules/no-deprecated.js
+++ b/src/rules/no-deprecated.js
@@ -1,7 +1,6 @@
-import Exports from '../ExportMap'
 import declaredScope from 'eslint-module-utils/declaredScope'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import Exports from '../ExportMap'
+import docsUrl from '../docsUrl'
 
 function message(deprecation) {
   return 'Deprecated' + (deprecation.description ? ': ' + deprecation.description : '.')
@@ -19,7 +18,7 @@ function getDeprecation(metadata) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-deprecated.md`,
+      url: docsUrl('no-deprecated'),
     },
   },
 

--- a/src/rules/no-deprecated.js
+++ b/src/rules/no-deprecated.js
@@ -1,6 +1,8 @@
 import Exports from '../ExportMap'
 import declaredScope from 'eslint-module-utils/declaredScope'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function message(deprecation) {
   return 'Deprecated' + (deprecation.description ? ': ' + deprecation.description : '.')
 }
@@ -16,7 +18,9 @@ function getDeprecation(metadata) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-deprecated.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -1,5 +1,7 @@
 import resolve from 'eslint-module-utils/resolve'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function checkImports(imported, context) {
   for (let [module, nodes] of imported.entries()) {
     if (nodes.size > 1) {
@@ -12,7 +14,9 @@ function checkImports(imported, context) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-duplicates.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -1,6 +1,5 @@
 import resolve from 'eslint-module-utils/resolve'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 function checkImports(imported, context) {
   for (let [module, nodes] of imported.entries()) {
@@ -15,7 +14,7 @@ function checkImports(imported, context) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-duplicates.md`,
+      url: docsUrl('no-duplicates'),
     },
   },
 

--- a/src/rules/no-dynamic-require.js
+++ b/src/rules/no-dynamic-require.js
@@ -1,3 +1,5 @@
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function isRequire(node) {
   return node &&
     node.callee &&
@@ -13,7 +15,9 @@ function isStaticValue(arg) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-dynamic-require.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-dynamic-require.js
+++ b/src/rules/no-dynamic-require.js
@@ -1,4 +1,4 @@
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 function isRequire(node) {
   return node &&
@@ -16,7 +16,7 @@ function isStaticValue(arg) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-dynamic-require.md`,
+      url: docsUrl('no-dynamic-require'),
     },
   },
 

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -6,6 +6,8 @@ import resolve from 'eslint-module-utils/resolve'
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function getDependencies(context, packageDir) {
   try {
     const packageContent = packageDir
@@ -112,7 +114,9 @@ function testConfig(config, filename) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-extraneous-dependencies.md`,
+    },
 
     schema: [
       {

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -5,8 +5,7 @@ import minimatch from 'minimatch'
 import resolve from 'eslint-module-utils/resolve'
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 function getDependencies(context, packageDir) {
   try {
@@ -115,7 +114,7 @@ function testConfig(config, filename) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-extraneous-dependencies.md`,
+      url: docsUrl('no-extraneous-dependencies'),
     },
 
     schema: [

--- a/src/rules/no-internal-modules.js
+++ b/src/rules/no-internal-modules.js
@@ -3,13 +3,12 @@ import minimatch from 'minimatch'
 import resolve from 'eslint-module-utils/resolve'
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-internal-modules.md`,
+      url: docsUrl('no-internal-modules'),
     },
 
     schema: [

--- a/src/rules/no-internal-modules.js
+++ b/src/rules/no-internal-modules.js
@@ -4,9 +4,13 @@ import resolve from 'eslint-module-utils/resolve'
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-internal-modules.md`,
+    },
 
     schema: [
       {

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -1,9 +1,9 @@
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-mutable-exports.md`,
+      url: docsUrl('no-mutable-exports'),
     },
   },
 

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -1,6 +1,10 @@
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-mutable-exports.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-named-as-default-member.js
+++ b/src/rules/no-named-as-default-member.js
@@ -6,8 +6,7 @@
  */
 import Exports from '../ExportMap'
 import importDeclaration from '../importDeclaration'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -16,7 +15,7 @@ const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/mast
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-named-as-default-member.md`,
+      url: docsUrl('no-named-as-default-member'),
     },
   },
 

--- a/src/rules/no-named-as-default-member.js
+++ b/src/rules/no-named-as-default-member.js
@@ -7,13 +7,17 @@
 import Exports from '../ExportMap'
 import importDeclaration from '../importDeclaration'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-named-as-default-member.md`,
+    },
   },
 
   create: function(context) {

--- a/src/rules/no-named-as-default.js
+++ b/src/rules/no-named-as-default.js
@@ -1,12 +1,11 @@
 import Exports from '../ExportMap'
 import importDeclaration from '../importDeclaration'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-named-as-default.md`,
+      url: docsUrl('no-named-as-default'),
     },
   },
 

--- a/src/rules/no-named-as-default.js
+++ b/src/rules/no-named-as-default.js
@@ -1,9 +1,13 @@
 import Exports from '../ExportMap'
 import importDeclaration from '../importDeclaration'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-named-as-default.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-named-default.js
+++ b/src/rules/no-named-default.js
@@ -1,9 +1,9 @@
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-named-default.md`,
+      url: docsUrl('no-named-default'),
     },
   },
 

--- a/src/rules/no-named-default.js
+++ b/src/rules/no-named-default.js
@@ -1,6 +1,10 @@
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-named-default.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-namespace.js
+++ b/src/rules/no-namespace.js
@@ -3,7 +3,7 @@
  * @author Radek Benkel
  */
 
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -13,7 +13,7 @@ const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/mast
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-namespace.md`,
+      url: docsUrl('no-namespace'),
     },
   },
 

--- a/src/rules/no-namespace.js
+++ b/src/rules/no-namespace.js
@@ -3,6 +3,8 @@
  * @author Radek Benkel
  */
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -10,7 +12,9 @@
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-namespace.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-nodejs-modules.js
+++ b/src/rules/no-nodejs-modules.js
@@ -1,6 +1,8 @@
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function reportIfMissing(context, node, allowed, name) {
   if (allowed.indexOf(name) === -1 && importType(name, context) === 'builtin') {
     context.report(node, 'Do not import Node.js builtin module "' + name + '"')
@@ -9,7 +11,9 @@ function reportIfMissing(context, node, allowed, name) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-nodejs-modules.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-nodejs-modules.js
+++ b/src/rules/no-nodejs-modules.js
@@ -1,7 +1,6 @@
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 function reportIfMissing(context, node, allowed, name) {
   if (allowed.indexOf(name) === -1 && importType(name, context) === 'builtin') {
@@ -12,7 +11,7 @@ function reportIfMissing(context, node, allowed, name) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-nodejs-modules.md`,
+      url: docsUrl('no-nodejs-modules'),
     },
   },
 

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -4,9 +4,13 @@ import path from 'path'
 import resolve from 'eslint-module-utils/resolve'
 import isStaticRequire from '../core/staticRequire'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-restricted-paths.md`,
+    },
 
     schema: [
       {

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -3,13 +3,12 @@ import path from 'path'
 
 import resolve from 'eslint-module-utils/resolve'
 import isStaticRequire from '../core/staticRequire'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-restricted-paths.md`,
+      url: docsUrl('no-restricted-paths'),
     },
 
     schema: [

--- a/src/rules/no-self-import.js
+++ b/src/rules/no-self-import.js
@@ -5,8 +5,7 @@
 
 import resolve from 'eslint-module-utils/resolve'
 import isStaticRequire from '../core/staticRequire'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 function isImportingSelf(context, node, requireName) {
   const filePath = context.getFilename()
@@ -25,7 +24,7 @@ module.exports = {
     docs: {
       description: 'Forbid a module from importing itself',
       recommended: true,
-      url: `${ruleDocsUrl}/no-self-import.md`,
+      url: docsUrl('no-self-import'),
     },
 
     schema: [],

--- a/src/rules/no-self-import.js
+++ b/src/rules/no-self-import.js
@@ -6,6 +6,8 @@
 import resolve from 'eslint-module-utils/resolve'
 import isStaticRequire from '../core/staticRequire'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function isImportingSelf(context, node, requireName) {
   const filePath = context.getFilename()
 
@@ -20,10 +22,12 @@ function isImportingSelf(context, node, requireName) {
 
 module.exports = {
   meta: {
-    doc: {
+    docs: {
       description: 'Forbid a module from importing itself',
       recommended: true,
+      url: `${ruleDocsUrl}/no-self-import.md`,
     },
+
     schema: [],
   },
   create: function (context) {

--- a/src/rules/no-unassigned-import.js
+++ b/src/rules/no-unassigned-import.js
@@ -1,8 +1,8 @@
-import isStaticRequire from '../core/staticRequire'
 import path from 'path'
 import minimatch from 'minimatch'
 
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import isStaticRequire from '../core/staticRequire'
+import docsUrl from '../docsUrl'
 
 function report(context, node) {
   context.report({
@@ -55,7 +55,7 @@ module.exports = {
   create,
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-unassigned-import.md`,
+      url: docsUrl('no-unassigned-import'),
     },
     schema: [
       {

--- a/src/rules/no-unassigned-import.js
+++ b/src/rules/no-unassigned-import.js
@@ -2,6 +2,8 @@ import isStaticRequire from '../core/staticRequire'
 import path from 'path'
 import minimatch from 'minimatch'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function report(context, node) {
   context.report({
     node,
@@ -52,7 +54,9 @@ function create(context) {
 module.exports = {
   create,
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-unassigned-import.md`,
+    },
     schema: [
       {
         'type': 'object',

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -7,10 +7,14 @@ import resolve, { CASE_SENSITIVE_FS, fileExistsWithCaseSync } from 'eslint-modul
 import ModuleCache from 'eslint-module-utils/ModuleCache'
 import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor'
 
-
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 module.exports = {
   meta: {
+    docs: {
+      url: `${ruleDocsUrl}/no-unresolved.md`,
+    },
+
     schema: [ makeOptionsSchema({
       caseSensitive: { type: 'boolean', default: true },
     })],
@@ -43,4 +47,3 @@ module.exports = {
 
   },
 }
-

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -6,13 +6,12 @@
 import resolve, { CASE_SENSITIVE_FS, fileExistsWithCaseSync } from 'eslint-module-utils/resolve'
 import ModuleCache from 'eslint-module-utils/ModuleCache'
 import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-unresolved.md`,
+      url: docsUrl('no-unresolved'),
     },
 
     schema: [ makeOptionsSchema({

--- a/src/rules/no-useless-path-segments.js
+++ b/src/rules/no-useless-path-segments.js
@@ -7,8 +7,7 @@ import path from 'path'
 import sumBy from 'lodash/sumBy'
 import resolve from 'eslint-module-utils/resolve'
 import moduleVisitor from 'eslint-module-utils/moduleVisitor'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 /**
  * convert a potentially relative path from node utils into a true
@@ -37,7 +36,7 @@ const countRelParent = x => sumBy(x, v => v === '..')
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-useless-path-segments.md`,
+      url: docsUrl('no-useless-path-segments'),
     },
 
     fixable: 'code',

--- a/src/rules/no-useless-path-segments.js
+++ b/src/rules/no-useless-path-segments.js
@@ -8,6 +8,8 @@ import sumBy from 'lodash/sumBy'
 import resolve from 'eslint-module-utils/resolve'
 import moduleVisitor from 'eslint-module-utils/moduleVisitor'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 /**
  * convert a potentially relative path from node utils into a true
  * relative path.
@@ -33,7 +35,13 @@ function normalize(fn) {
 const countRelParent = x => sumBy(x, v => v === '..')
 
 module.exports = {
-  meta: { fixable: 'code' },
+  meta: {
+    docs: {
+      url: `${ruleDocsUrl}/no-useless-path-segments.md`,
+    },
+
+    fixable: 'code',
+  },
 
   create: function (context) {
     const currentDir = path.dirname(context.getFilename())

--- a/src/rules/no-webpack-loader-syntax.js
+++ b/src/rules/no-webpack-loader-syntax.js
@@ -1,5 +1,7 @@
 import isStaticRequire from '../core/staticRequire'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 function reportIfNonStandard(context, node, name) {
   if (name.indexOf('!') !== -1) {
     context.report(node, `Unexpected '!' in '${name}'. ` +
@@ -10,7 +12,9 @@ function reportIfNonStandard(context, node, name) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/no-webpack-loader-syntax.md`,
+    },
   },
 
   create: function (context) {

--- a/src/rules/no-webpack-loader-syntax.js
+++ b/src/rules/no-webpack-loader-syntax.js
@@ -1,6 +1,5 @@
 import isStaticRequire from '../core/staticRequire'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 function reportIfNonStandard(context, node, name) {
   if (name.indexOf('!') !== -1) {
@@ -13,7 +12,7 @@ function reportIfNonStandard(context, node, name) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/no-webpack-loader-syntax.md`,
+      url: docsUrl('no-webpack-loader-syntax'),
     },
   },
 

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -4,6 +4,7 @@ import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 
 const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 // REPORTING
 
@@ -149,7 +150,9 @@ function makeNewlinesBetweenReport (context, imported, newlinesBetweenImports) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/order.md`,
+    },
 
     schema: [
       {

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -2,9 +2,9 @@
 
 import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
+import docsUrl from '../docsUrl'
 
 const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
 
 // REPORTING
 
@@ -151,7 +151,7 @@ function makeNewlinesBetweenReport (context, imported, newlinesBetweenImports) {
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/order.md`,
+      url: docsUrl('order'),
     },
 
     schema: [

--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -1,8 +1,12 @@
 'use strict'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: `${ruleDocsUrl}/prefer-default-export.md`,
+    },
   },
 
   create: function(context) {

--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -1,11 +1,11 @@
 'use strict'
 
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/prefer-default-export.md`,
+      url: docsUrl('prefer-default-export'),
     },
   },
 

--- a/src/rules/unambiguous.js
+++ b/src/rules/unambiguous.js
@@ -5,8 +5,14 @@
 
 import { isModule } from 'eslint-module-utils/unambiguous'
 
+const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+
 module.exports = {
-  meta: {},
+  meta: {
+    docs: {
+      url: `${ruleDocsUrl}/unambiguous.md`,
+    },
+  },
 
   create: function (context) {
     // ignore non-modules

--- a/src/rules/unambiguous.js
+++ b/src/rules/unambiguous.js
@@ -4,13 +4,12 @@
  */
 
 import { isModule } from 'eslint-module-utils/unambiguous'
-
-const ruleDocsUrl = 'https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules'
+import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
     docs: {
-      url: `${ruleDocsUrl}/unambiguous.md`,
+      url: docsUrl('unambiguous'),
     },
   },
 

--- a/tests/src/core/docsUrl.js
+++ b/tests/src/core/docsUrl.js
@@ -1,0 +1,13 @@
+import { expect } from 'chai'
+
+import docsUrl from '../../../src/docsUrl'
+
+describe('docsUrl', function () {
+  it('returns the rule documentation URL when given a rule name', function () {
+    expect(docsUrl('foo')).to.equal('https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules/foo.md')
+  })
+
+  it('supports an optional commit hash parameter', function () {
+    expect(docsUrl('foo', 'bar')).to.equal('https://github.com/benmosher/eslint-plugin-import/blob/bar/docs/rules/foo.md')
+  })
+})

--- a/tests/src/core/docsUrl.js
+++ b/tests/src/core/docsUrl.js
@@ -4,7 +4,7 @@ import docsUrl from '../../../src/docsUrl'
 
 describe('docsUrl', function () {
   it('returns the rule documentation URL when given a rule name', function () {
-    expect(docsUrl('foo')).to.equal('https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules/foo.md')
+    expect(docsUrl('foo')).to.equal('https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/foo.md')
   })
 
   it('supports an optional commit hash parameter', function () {


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.

This also fixes the `docs` property of `no-self-import`, which was previously `doc`.

I'm not sure I like how the URL's are being defined here to fit within the 99 character line length limit, if you would like me to move the `ruleDocsUrl` to a single file that they all import, or alternatively do something like https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/commit/eb207d0ef650e9f91f7f7ca3be2ab8cbe762f0d3, just let me know!

Note: `imports-first` has a slightly different format since the documentation for this deprecated rule was removed. If you want that to instead point to `first`'s documentation that can be changed.
  
  