### PR TITLE
Change 1st order's example's label to valid value

### DIFF
--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -3,7 +3,7 @@
 Enforce a convention in the order of `require()` / `import` statements. The order is as shown in the following example:
 
 ```js
-// 1. node "builtins"
+// 1. node "builtin" modules
 import fs from 'fs';
 import path from 'path';
 // 2. "external" modules


### PR DESCRIPTION
This change allow copy-paste value from 1st example into eslintrc. 
It's impossible now cause valid value is `builtin` but not `buildins`.