### PR TITLE
Use link to tagged version for rule docs

### DIFF
--- a/src/docsUrl.js
+++ b/src/docsUrl.js
@@ -1,5 +1,7 @@
+import pkg from '../package.json'
+
 const repoUrl = 'https://github.com/benmosher/eslint-plugin-import'
 
-export default function docsUrl(ruleName, commitHash = 'master') {
-  return `${repoUrl}/blob/${commitHash}/docs/rules/${ruleName}.md`
+export default function docsUrl(ruleName, commitish = `v${pkg.version}`) {
+  return `${repoUrl}/blob/${commitish}/docs/rules/${ruleName}.md`
 }

--- a/tests/src/core/docsUrl.js
+++ b/tests/src/core/docsUrl.js
@@ -1,13 +1,14 @@
 import { expect } from 'chai'
 
+import pkg from '../../../package.json'
 import docsUrl from '../../../src/docsUrl'
 
 describe('docsUrl', function () {
   it('returns the rule documentation URL when given a rule name', function () {
-    expect(docsUrl('foo')).to.equal('https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/foo.md')
+    expect(docsUrl('foo')).to.equal(`https://github.com/benmosher/eslint-plugin-import/blob/v${pkg.version}/docs/rules/foo.md`)
   })
 
-  it('supports an optional commit hash parameter', function () {
+  it('supports an optional commit-ish parameter', function () {
     expect(docsUrl('foo', 'bar')).to.equal('https://github.com/benmosher/eslint-plugin-import/blob/bar/docs/rules/foo.md')
   })
 })


### PR DESCRIPTION
This uses the version present in package.json for generating the URL to rule documentation if no [commit-ish](https://stackoverflow.com/questions/23303549/what-are-commit-ish-and-tree-ish-in-git) value is passed. I think this is good because the documentation will match the version the user has installed. This way, even if a rule is changed or removed in the future, the user can find the documentation with ease.