### PR TITLE
Imports that are resolvable should not be reported as builtins

### DIFF
--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -21,10 +21,11 @@ export function isAbsolute(name) {
   return name.indexOf('/') === 0
 }
 
-export function isBuiltIn(name, settings) {
+export function isBuiltIn(name, settings, path) {
   const base = baseModule(name)
   const extras = (settings && settings['import/core-modules']) || []
-  return builtinModules.indexOf(base) !== -1 || extras.indexOf(base) > -1
+  const isInternal = isInternalModule(name, settings, path)
+  return !isInternal && (builtinModules.indexOf(base) !== -1 || extras.indexOf(base) > -1)
 }
 
 function isExternalPath(path, name, settings) {

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -41,6 +41,11 @@ describe('importType(name)', function () {
     expect(importType('importType', pathContext)).to.equal('internal')
   })
 
+  it("should return 'internal' for files resolved outside of node_modules that share a name with a builtin", function () {
+    const pathContext = testContext({ "import/resolver": { node: { paths: [ path.join(__dirname, '..', '..', 'files') ] } } })
+    expect(importType('constants/foo', pathContext)).to.equal('internal')
+  })
+
   it("should return 'parent' for internal modules that go through the parent", function() {
     expect(importType('../foo', context)).to.equal('parent')
     expect(importType('../../foo', context)).to.equal('parent')


### PR DESCRIPTION
`constants` is a builtin (apparently) in node. however, if we can resolve the module name, we should assume that it is _not_ a builtin.

Perhaps we could create a second rule that enforces not clobbering builtin names, but that behaviour shouldn't be part of this rule which is to enforce _ordering_.