### PR TITLE
Add test case for import/resolve extensions order

### DIFF
--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -183,6 +183,22 @@ ruleTester.run('extensions', rule, {
         },
       ],
     }),
+    // extension resolve order (#965)
+    test({
+      code: [
+        'import component from "./bar.jsx"',
+        'import data from "./bar.json"',
+      ].join('\n'),
+      options: [ { json: 'always', js: 'never', jsx: 'never' } ],
+      settings: { 'import/resolve': { 'extensions': [ '.jsx', '.json', '.js' ] } },
+      errors: [
+        {
+            message: 'Unexpected use of file extension "jsx" for "./bar.jsx"',
+            line: 1,
+            column: 23,
+        },
+      ],
+    }),
 
     test({
       code: [


### PR DESCRIPTION
When there are multiple files with same names and different extensions, the resolver will go by extensions in the order specified in `import/resolve` settings.

This test case ensures that the `extensions` rule is correctly forcing the extension when omitting it would cause it to resolve to the wrong file.

Closes #965.