### PR TITLE
Add a .coffee test proving extension resolve order

### DIFF
--- a/tests/files/bar.coffee
+++ b/tests/files/bar.coffee
@@ -1,0 +1,1 @@
+console.log 'bar'

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -183,7 +183,7 @@ ruleTester.run('extensions', rule, {
         },
       ],
     }),
-    // extension resolve order (#965)
+    // extension resolve order (#583/#965)
     test({
       code: [
         'import component from "./bar.jsx"',
@@ -198,6 +198,18 @@ ruleTester.run('extensions', rule, {
             column: 23,
         },
       ],
+    }),
+    test({
+      code: 'import "./bar.coffee"',
+      errors: [
+        {
+          message: 'Unexpected use of file extension "coffee" for "./bar.coffee"',
+          line: 1,
+          column: 8,
+        },
+      ],
+      options: ['never', { js: 'always', jsx: 'always' }],
+      settings: { 'import/resolve': { 'extensions': ['.coffee', '.js'] } },
     }),
 
     test({


### PR DESCRIPTION
Sending this PR just in case it's useful and connects some dots, feel free to close otherwise.

---

Add a test for a more unconventional extension to prove that the `extensions` rule can take anything as long as the extension resolve order is correct, i.e. it can only remove the extension if it would resolve to the correct file.

I was thinking about documenting this behavior, but [it's already documented](https://github.com/benmosher/eslint-plugin-import/blob/bc50394ce45c33f4ee54f86216270700ed329a53/docs/rules/extensions.md#exception).

Ref. #965.
Closes #583.