### PR TITLE
Header-ify rule categories for easy linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 
 ## Rules
 
-**Static analysis:**
+### Static analysis
 
 * Ensure imports point to a file/module that can be resolved. ([`no-unresolved`])
 * Ensure named imports correspond to a named export in the remote file. ([`named`])
@@ -36,7 +36,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 [`no-webpack-loader-syntax`]: ./docs/rules/no-webpack-loader-syntax.md
 [`no-self-import`]: ./docs/rules/no-self-import.md
 
-**Helpful warnings:**
+### Helpful warnings
 
 
 * Report any invalid exports, i.e. re-export of the same name ([`export`])
@@ -53,7 +53,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 [`no-extraneous-dependencies`]: ./docs/rules/no-extraneous-dependencies.md
 [`no-mutable-exports`]: ./docs/rules/no-mutable-exports.md
 
-**Module systems:**
+### Module systems
 
 * Report potentially ambiguous parse goal (`script` vs. `module`) ([`unambiguous`])
 * Report CommonJS `require` calls and `module.exports` or `exports.*`. ([`no-commonjs`])
@@ -66,7 +66,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 [`no-nodejs-modules`]: ./docs/rules/no-nodejs-modules.md
 
 
-**Style guide:**
+### Style guide
 
 * Ensure all imports appear before other statements ([`first`])
 * Ensure all exports appear after other statements ([`exports-last`])


### PR DESCRIPTION
It's often pretty helpful to link to rule categories in eslint configuration files.  This lets one link to specific categories, too