### PR TITLE
#656: Fix crashes that caused when using object-rest properties in `namespace` rule

### DIFF
--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -161,6 +161,9 @@ module.exports = {
           if (pattern.type !== 'ObjectPattern') return
 
           for (let property of pattern.properties) {
+            if (property.type === 'ExperimentalRestProperty') {
+              continue
+            }
 
             if (property.key.type !== 'Identifier') {
               context.report({

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -92,6 +92,20 @@ const valid = [
     options: [{ allowComputed: true }],
   }),
 
+  // #656: should handle object-rest properties
+  test({
+    code: `import * as names from './named-exports'; const {a, b, ...rest} = names;`,
+    parserOptions: {
+      ecmaFeatures: {
+        experimentalObjectRestSpread: true,
+      },
+    },
+  }),
+  test({
+    code: `import * as names from './named-exports'; const {a, b, ...rest} = names;`,
+    parser: 'babel-eslint',
+  }),
+
   ...SYNTAX_CASES,
 ]
 


### PR DESCRIPTION
Fixes #656.

This is the one of long standing issue, where ESLint crashes when you are trying to use object-rest on namespace import:

```js
import * as names from './named-exports';
const {a, b, ...rest} = names; // Cannot read property 'type' of undefined
```

Also, I have noticed that it's only caused on variable declarations (in the other words, it does not crash on assignment expressions):

```js
import * as names from './named-exports';
let a, b, rest;
({a, b, ...rest} = names); // Nothing happens
```

I don't know if this is a right solution, but I think it's going to be okay ever since I found that it does not crash when it's not using variable declarations.

I will add notes to changelog and documents once this has confirmed.