### PR TITLE
add-missing-env-variable-in-webpack-config

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -47,6 +47,7 @@ exports.resolve = function (source, file, settings) {
 
   var configPath = get(settings, 'config')
     , configIndex = get(settings, 'config-index')
+    , env = get(settings, 'env')
     , packageDir
 
   log('Config path from settings:', configPath)
@@ -82,7 +83,7 @@ exports.resolve = function (source, file, settings) {
   }
 
   if (typeof webpackConfig === 'function') {
-    webpackConfig = webpackConfig()
+    webpackConfig = webpackConfig(env)
   }
 
   if (Array.isArray(webpackConfig)) {

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -91,4 +91,16 @@ describe("config", function () {
         .and.equal(path.join(__dirname, 'files', 'some', 'goofy', 'path', 'foo.js'))
   })
 
+  it('finds the config at option env when config is a function', function() {
+    var settings = {
+      config: require(path.join(__dirname, './files/webpack.function.config.js')),
+      env: {
+        dummy: true,
+      },
+    }
+
+    expect(resolve('bar', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'some', 'goofy', 'path', 'bar.js'))
+  })
+
 })

--- a/resolvers/webpack/test/files/webpack.function.config.js
+++ b/resolvers/webpack/test/files/webpack.function.config.js
@@ -1,11 +1,12 @@
 var path = require('path')
 var pluginsTest = require('webpack-resolver-plugin-test')
 
-module.exports = function() {
+module.exports = function(env) {
   return {
     resolve: {
       alias: {
         'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
+        'bar': env ? path.join(__dirname, 'some', 'goofy', 'path', 'bar.js') : undefined,
         'some-alias': path.join(__dirname, 'some'),
       },
       modules: [


### PR DESCRIPTION
Following https://github.com/benmosher/eslint-plugin-import/pull/938, I am facing a problem where my project is composed of a several applications and each them might define a "custom" webpack configuration which extends a common configuration which is defined in the root of the project.
```
/
apps/
- app1/
  webpackConfig.js  <-- specific to app1
  .eslintrc
- app2/
  webpackConfig.js  <-- specific to app2
  .eslintrc
- app3/
  webpackConfig.js <-- specific to app3
  .eslintrc
webpack.config.js <-- common configuration
```
A custom webpack configuration looks like so:
__apps/app1/webpackConfig.js__
```JS
export function (baseConfig) => {
 newConfig = baseConfig
 // Some custom manipulation
 ....
 return newConfig
}
```

**Note that the common webpack configuration is responsible for determining which webpack configuration to load based on the application name**.
So for instance, to run the `app1`, we execute the following command :
```SH
webpack-dev-server  --config webpack.config.js --env app1
```

The problem is that the 'env' variable is being ignored, So I can't do something like that:
__apps/app1/.eslintrc__
```JS
const path = require('path');
module.exports = {
  settings: {
    'import/resolver': {
      webpack: {
        config: path.resolve(__dirname, '../../webpack.config.js'),
        env: 'app1'
      }
    }
  },
};
```
The solution is to grab the env from the settings and to pass it to the webpackConfig in the webpack resolver:
__resolvers/webpack/index.js__
```JS
var env = get(settings, 'env')
if (typeof webpackConfig === 'function') {
   webpackConfig = webpackConfig(env)
}
```
