### PR TITLE
[Docs] fixes problem with weird highlighting

### DIFF
--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -8,13 +8,13 @@ In order to provide a consistent use of file extensions across your code base, t
 
 This rule either takes one string option, one object option, or a string and an object option. If it is the string `"never"` (the default value), then the rule forbids the use for any extension. If it is the string `"always"`, then the rule enforces the use of extensions for all import statements. If it is the string `"ignorePackages"`, then the rule enforces the use of extensions for all import statements except package imports.
 
-```json
+```
 "import/extensions": [<severity>, "never" | "always" | "ignorePackages"]
 ```
 
 By providing an object you can configure each extension separately.
 
-```json
+```
 "import/extensions": [<severity>, {
   <extension>: "never" | "always" | "ignorePackages"
 }]
@@ -24,7 +24,7 @@ By providing an object you can configure each extension separately.
 
 By providing both a string and an object, the string will set the default setting for all extensions, and the object can be used to set granular overrides for specific extensions.
 
-```json
+```
 "import/extensions": [
   <severity>,
   "never" | "always" | "ignorePackages",


### PR DESCRIPTION
Fixes weird red highlighting on docs.

Before: 

![image](https://user-images.githubusercontent.com/1969329/37435865-3a20b1e4-2839-11e8-9322-80dd243ca8e9.png)

After:

![image](https://user-images.githubusercontent.com/1969329/37435886-55f78f00-2839-11e8-8477-f44a5d231483.png)
