### PR TITLE
Ignore type imports for named rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+- Ignore type imports for named rule ([#931], thanks [@mattijsbliek])
 - Add documentation for [`no-useless-path-segments`] rule ([#1068], thanks [@manovotny])
 - Fixer for [`first`] ([#1046], thanks [@fengkfengk])
 

--- a/docs/rules/named.md
+++ b/docs/rules/named.md
@@ -8,10 +8,11 @@ Note: for packages, the plugin will find exported names
 from [`jsnext:main`], if present in `package.json`.
 Redux's npm module includes this key, and thereby is lintable, for example.
 
-A module path that is [ignored] or not [unambiguously an ES module] will not be reported when imported.
+A module path that is [ignored] or not [unambiguously an ES module] will not be reported when imported. Note that type imports, as used by [Flow], are always ignored.
 
 [ignored]: ../../README.md#importignore
 [unambiguously an ES module]: https://github.com/bmeck/UnambiguousJavaScriptGrammar
+[Flow]: https://flow.org/
 
 
 ## Rule Details

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -11,7 +11,8 @@ module.exports = {
 
   create: function (context) {
     function checkSpecifiers(key, type, node) {
-      if (node.source == null) return // local export, ignore
+      // ignore local exports and type imports
+      if (node.source == null || node.importKind === 'type') return
 
       if (!node.specifiers
             .some(function (im) { return im.type === type })) {

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -67,18 +67,10 @@ ruleTester.run('named', rule, {
     test({ code: 'import { deepProp } from "./named-exports"' }),
     test({ code: 'import { deepSparseElement } from "./named-exports"' }),
 
-    // flow types
+    // should ignore imported flow types, even if they don’t exist
     test({
-      code: 'import type { MyType } from "./flowtypes"',
-      'parser': 'babel-eslint',
-    }),
-    test({
-      code: 'import type { MyInterface } from "./flowtypes"',
-      'parser': 'babel-eslint',
-    }),
-    test({
-      code: 'import type { MyClass } from "./flowtypes"',
-      'parser': 'babel-eslint',
+      code: 'import type { MissingType } from "./flowtypes"',
+      parser: 'babel-eslint',
     }),
 
     // TypeScript
@@ -243,16 +235,6 @@ ruleTester.run('named', rule, {
     //     type: 'Literal',
     //   }],
     // }),
-
-    // flow types
-    test({
-      code: 'import type { MissingType } from "./flowtypes"',
-      parser: 'babel-eslint',
-      errors: [{
-        message: "MissingType not found in './flowtypes'",
-        type: 'Identifier',
-      }],
-    }),
 
     // TypeScript
     test({


### PR DESCRIPTION
This fixes #931 for the named rule. This was done to play nice with flow-typed in the following situation:

```js
/*
 * Import an NPM module and grab the type definition from flow-typed
 */
import Something from 'my-npm-package';
// This type isn’t actually in the npm package but in the flow-typed directory, so eslint-import cannot resolve it.
import type { SomethingType } from 'my-npm-package';
```

Closes #1060.