### PR TITLE
[WIP] Do not report type imports from flow-typed packages

### DIFF
--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -18,6 +18,8 @@ module.exports = {
         return // no named imports/exports
       }
 
+      if (isTypeFromPackage(node)) return
+
       const imports = Exports.get(node.source.value, context)
       if (imports == null) return
 
@@ -45,6 +47,14 @@ module.exports = {
           }
         }
       })
+    }
+
+    function isTypeFromPackage(node) {
+      return node.importKind === 'type' && !hasRelativePath(node.source)
+    }
+
+    function hasRelativePath(source) {
+      return source.value.match(/^\.\//)
     }
 
     return {

--- a/tests/files/with-flow-typed/flow-typed/npm/myflowtyped_v1.x.x.js
+++ b/tests/files/with-flow-typed/flow-typed/npm/myflowtyped_v1.x.x.js
@@ -1,4 +1,6 @@
 // flow-typed signature: ____
 // flow-typed version: ____/myflowtyped_v1.x.x/flow_>=v0.33.x
 
-declare module 'myflowtyped' {}
+declare module 'myflowtyped' {
+  declare export type MyType = boolean;
+}

--- a/tests/files/with-flow-typed/node_modules/myflowtyped/index.js
+++ b/tests/files/with-flow-typed/node_modules/myflowtyped/index.js
@@ -1,0 +1,1 @@
+export const MyFlowTyped = {};

--- a/tests/files/with-flow-typed/node_modules/myflowtyped/package.json
+++ b/tests/files/with-flow-typed/node_modules/myflowtyped/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "myflowtyped",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/files/with-flow-typed/package.json
+++ b/tests/files/with-flow-typed/package.json
@@ -1,3 +1,5 @@
 {
-  "dependencies": {}
+  "dependencies": {
+    "myflowtyped": "1.0.0"
+  }
 }

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -1,4 +1,5 @@
 import { test, SYNTAX_CASES } from '../utils'
+import * as path from 'path'
 import { RuleTester } from 'eslint'
 
 import { CASE_SENSITIVE_FS } from 'eslint-module-utils/resolve'
@@ -11,6 +12,8 @@ function error(name, module) {
   return { message: name + ' not found in \'' + module + '\''
          , type: 'Identifier' }
 }
+
+const packageDirWithFlowTyped = path.join(__dirname, '../../files/with-flow-typed')
 
 ruleTester.run('named', rule, {
   valid: [
@@ -78,6 +81,11 @@ ruleTester.run('named', rule, {
     }),
     test({
       code: 'import type { MyClass } from "./flowtypes"',
+      'parser': 'babel-eslint',
+    }),
+    test({
+      filename: packageDirWithFlowTyped + '/foo.js',
+      code: 'import type { MyType } from "myflowtyped"',
       'parser': 'babel-eslint',
     }),
 


### PR DESCRIPTION
fixes #960

When importing types from packages that are defined in a file inside the `flow-typed` directory, prevent the `named` rule from reporting that the package itself does not provide an export with that name.

Currently there is support for type imports from local files. Restrict these checks to imports with relative paths.

I'm not really sure how much value checking type imports provides since, I suppose, Flow itself is already good at alerting about missing imported types. Maybe type imports should not be checked at
all? At least that appears to be [the route already taken in `no-extraneous-dependencies`](https://github.com/benmosher/eslint-plugin-import/commit/523789f510b0cd1dfd7bbddfd26c1cca82a6d1c0). Does the same hold for Type Scripts?

The alternative of making the `named` rule aware of the top level `flow-typed` directory feels a lot like duplicating functionality that already exists inside Flow.