### PR TITLE
[Fix] `no-cycle`: `create` must *always* return an object, even if no listeners

### DIFF
--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -22,7 +22,7 @@ module.exports = {
 
   create: function (context) {
     const myPath = context.getFilename()
-    if (myPath === '<text>') return  // can't cycle-check a non-file
+    if (myPath === '<text>') return {} // can't cycle-check a non-file
 
     const options = context.options[0] || {}
     const maxDepth = options.maxDepth || Infinity


### PR DESCRIPTION
This is breaking eslint-plugin-airbnb's tests, and will break on any linting that's done on piped-in text.

cc @sharmilajesupaul @not-an-aardvark