### PR TITLE
minor typo in import/no-cycle rule docs

### DIFF
--- a/docs/rules/no-cycle.md
+++ b/docs/rules/no-cycle.md
@@ -32,7 +32,7 @@ cycles created by `require` within imported modules may not be detected.
 There is a `maxDepth` option available to prevent full expansion of very deep dependency trees:
 
 ```js
-/*eslint import/no-unresolved: [2, { maxDepth: 1 }]*/
+/*eslint import/no-cycle: [2, { maxDepth: 1 }]*/
 
 // dep-c.js
 import './dep-a.js'


### PR DESCRIPTION
In the  [`import/no-cycle`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-cycle.md#maxdepth) docs, there's an example for using options. 

this is the current text: 

```js
/*eslint import/no-unresolved: [2, { maxDepth: 1 }]*/
```

this PR updates it to: 
```js
/*eslint import/no-cycle: [2, { maxDepth: 1 }]*/
```
