### PR TITLE
[patch] use `resolve` instead of `builtin-modules`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "eslint": "2.x - 4.x"
   },
   "dependencies": {
-    "builtin-modules": "^1.1.1",
     "contains-path": "^0.1.0",
     "debug": "^2.6.8",
     "doctrine": "1.5.0",
@@ -88,7 +87,8 @@
     "has": "^1.0.1",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.3",
-    "read-pkg-up": "^2.0.0"
+    "read-pkg-up": "^2.0.0",
+    "resolve": "^1.6.0"
   },
   "nyc": {
     "require": [

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -1,5 +1,5 @@
 import cond from 'lodash/cond'
-import builtinModules from 'builtin-modules'
+import coreModules from 'resolve/lib/core'
 import { join } from 'path'
 
 import resolve from 'eslint-module-utils/resolve'
@@ -24,7 +24,7 @@ export function isAbsolute(name) {
 export function isBuiltIn(name, settings) {
   const base = baseModule(name)
   const extras = (settings && settings['import/core-modules']) || []
-  return builtinModules.indexOf(base) !== -1 || extras.indexOf(base) > -1
+  return coreModules[base] || extras.indexOf(base) > -1
 }
 
 function isExternalPath(path, name, settings) {


### PR DESCRIPTION
`resolve` has a much more thorough list of builtins, and since I maintain it, we can keep it updated more easily than with `builtin-modules`.