### PR TITLE
no-extraneous-dependencies: multiple packageDir(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,18 @@ settings:
 [`eslint_d`]: https://www.npmjs.com/package/eslint_d
 [`eslint-loader`]: https://www.npmjs.com/package/eslint-loader
 
+#### `import/paths`
+
+Settings for `package.json` lookup paths in order to include their defined dependencies in addition to the next-immediate `package.json` relative to the linted file. For example, the [`no-extraneous-dependencies`] rule.
+
+This is useful in scenarios where your workspace includes several hierarchical `package.json` files. For example, a [lerna](https://github.com/lerna/lerna) monorepo where you've hoisted all your `devDependencies` to the `package.json` at the root of the monorepo.
+
+```yaml
+# .eslintrc.yml
+settings:
+  import/paths: ['.', 'packages/my-dev-utils']
+```
+
 ## SublimeLinter-eslint
 
 SublimeLinter-eslint introduced a change to support `.eslintignore` files

--- a/README.md
+++ b/README.md
@@ -353,17 +353,6 @@ settings:
 [`eslint_d`]: https://www.npmjs.com/package/eslint_d
 [`eslint-loader`]: https://www.npmjs.com/package/eslint-loader
 
-#### `import/paths`
-
-Settings for `package.json` lookup paths in order to include their defined dependencies in addition to the next-immediate `package.json` relative to the linted file. For example, the [`no-extraneous-dependencies`] rule.
-
-This is useful in scenarios where your workspace includes several hierarchical `package.json` files. For example, a [lerna](https://github.com/lerna/lerna) monorepo where you've hoisted all your `devDependencies` to the `package.json` at the root of the monorepo.
-
-```yaml
-# .eslintrc.yml
-settings:
-  import/paths: ['.', 'packages/my-dev-utils']
-```
 
 ## SublimeLinter-eslint
 

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -35,6 +35,13 @@ Also there is one more option called `packageDir`, this option is to specify the
 "import/no-extraneous-dependencies": ["error", {"packageDir": './some-dir/'}]
 ```
 
+It may also be an array of multiple paths, to support monorepos or other novel project
+folder layouts:
+
+```js
+"import/no-extraneous-dependencies": ["error", {"packageDir": ['./some-dir/', './root-pkg']}]
+```
+
 ## Rule Details
 
 Given the following `package.json`:

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "doctrine": "1.5.0",
     "eslint-import-resolver-node": "^0.3.1",
     "eslint-module-utils": "^2.1.1",
-    "has": "^1.0.1",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.3",
     "read-pkg-up": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "doctrine": "1.5.0",
     "eslint-import-resolver-node": "^0.3.1",
     "eslint-module-utils": "^2.2.0",
+    "has": "^1.0.1",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.3",
     "read-pkg-up": "^2.0.0",

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -30,10 +30,10 @@ function getDependencies(context, packageDir) {
       peerDependencies: {},
     }
 
-    if (Object.prototype.hasOwnProperty(context.settings, 'import/paths')) {
+    if (Object.prototype.hasOwnProperty.call(context.settings, 'import/paths')) {
       paths.push(
         ...context.settings['import/paths']
-          .map(path.resolve)
+          .map((dir) => path.resolve(dir))
       )
     }
 

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs'
+import has from 'has'
 import readPkgUp from 'read-pkg-up'
 import minimatch from 'minimatch'
 import resolve from 'eslint-module-utils/resolve'
@@ -30,7 +31,7 @@ function getDependencies(context, packageDir) {
       peerDependencies: {},
     }
 
-    if (Object.prototype.hasOwnProperty.call(context.settings, 'import/paths')) {
+    if (has(context.settings, 'import/paths')) {
       paths.push(
         ...context.settings['import/paths']
           .map((dir) => path.resolve(dir))

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -38,14 +38,7 @@ function getDependencies(context, packageDir) {
     }
 
     if (packageDir) {
-      paths.unshift(packageDir)
-    } else {
-      Object.assign(
-        packageContent,
-        extractDepFields(
-          readPkgUp.sync({cwd: context.getFilename(), normalize: false}).pkg
-        )
-      )
+      paths.push(packageDir)
     }
 
     if (paths.length) {
@@ -56,6 +49,14 @@ function getDependencies(context, packageDir) {
       })
     }
 
+    if (!packageDir) {
+      Object.assign(
+        packageContent,
+        extractDepFields(
+          readPkgUp.sync({cwd: context.getFilename(), normalize: false}).pkg
+        )
+      )
+    }
 
     if (![
       packageContent.dependencies,

--- a/tests/files/monorepo/package.json
+++ b/tests/files/monorepo/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "left-pad": "^1.2.0"
+  }
+}

--- a/tests/files/monorepo/packages/nested-package/package.json
+++ b/tests/files/monorepo/packages/nested-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nested-monorepo-pkg",
+  "dependencies": {
+    "react": "^16.0.0"
+  }
+}

--- a/tests/files/node_modules/left-pad
+++ b/tests/files/node_modules/left-pad
@@ -1,0 +1,1 @@
+not-a-dependency

--- a/tests/files/node_modules/react
+++ b/tests/files/node_modules/react
@@ -1,0 +1,1 @@
+not-a-dependency

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -15,6 +15,8 @@ const packageFileWithSyntaxErrorMessage = (() => {
   }
 })()
 const packageDirWithFlowTyped = path.join(__dirname, '../../files/with-flow-typed')
+const packageDirMonoRepoRoot = path.join(__dirname, '../../files/monorepo')
+const packageDirMonoRepoWithNested = path.join(__dirname, '../../files/monorepo/packages/nested-package')
 
 ruleTester.run('no-extraneous-dependencies', rule, {
   valid: [
@@ -75,8 +77,42 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{packageDir: packageDirWithFlowTyped}],
       parser: 'babel-eslint',
     }),
+    test({
+      code: 'import react from "react";',
+      options: [{packageDir: packageDirMonoRepoWithNested}],
+      // filename: path.join(process.cwd(), 'foo.spec.js'),
+    }),
+    test({
+      code: 'import leftpad from "left-pad";',
+      options: [{packageDir: packageDirMonoRepoWithNested}],
+      settings: { 'import/paths': [packageDirMonoRepoRoot] },
+      // filename: path.join(process.cwd(), 'foo.spec.js'),
+    }),
+    test({
+      code: 'import leftpad from "left-pad";',
+      options: [{packageDir: packageDirMonoRepoRoot}],
+      settings: { 'import/paths': [packageDirMonoRepoRoot] },
+    }),
   ],
   invalid: [
+    test({
+      code: 'import "not-a-dependency"',
+      options: [{packageDir: packageDirMonoRepoWithNested}],
+      settings: { 'import/paths': [packageDirMonoRepoRoot] },
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+      }],
+    }),
+    test({
+      code: 'import "not-a-dependency"',
+      options: [{packageDir: packageDirMonoRepoRoot}],
+      settings: { 'import/paths': [packageDirMonoRepoRoot] },
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+      }],
+    }),
     test({
       code: 'import "not-a-dependency"',
       errors: [{

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -80,13 +80,11 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'import react from "react";',
       options: [{packageDir: packageDirMonoRepoWithNested}],
-      // filename: path.join(process.cwd(), 'foo.spec.js'),
     }),
     test({
       code: 'import leftpad from "left-pad";',
       options: [{packageDir: packageDirMonoRepoWithNested}],
       settings: { 'import/paths': [packageDirMonoRepoRoot] },
-      // filename: path.join(process.cwd(), 'foo.spec.js'),
     }),
     test({
       code: 'import leftpad from "left-pad";',
@@ -97,7 +95,17 @@ ruleTester.run('no-extraneous-dependencies', rule, {
   invalid: [
     test({
       code: 'import "not-a-dependency"',
-      options: [{packageDir: packageDirMonoRepoWithNested}],
+      filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
+      settings: { 'import/paths': [packageDirMonoRepoRoot] },
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+      }],
+    }),
+    test({
+      code: 'import "not-a-dependency"',
+      filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
+      options: [{packageDir: packageDirMonoRepoRoot}],
       settings: { 'import/paths': [packageDirMonoRepoRoot] },
       errors: [{
         ruleId: 'no-extraneous-dependencies',

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -83,20 +83,18 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'import leftpad from "left-pad";',
-      options: [{packageDir: packageDirMonoRepoWithNested}],
-      settings: { 'import/paths': [packageDirMonoRepoRoot] },
+      options: [{packageDir: [packageDirMonoRepoWithNested, packageDirMonoRepoRoot]}],
     }),
     test({
       code: 'import leftpad from "left-pad";',
       options: [{packageDir: packageDirMonoRepoRoot}],
-      settings: { 'import/paths': [packageDirMonoRepoRoot] },
     }),
   ],
   invalid: [
     test({
       code: 'import "not-a-dependency"',
       filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
-      settings: { 'import/paths': [packageDirMonoRepoRoot] },
+      options: [{packageDir: packageDirMonoRepoRoot }],
       errors: [{
         ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
@@ -106,7 +104,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "not-a-dependency"',
       filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
       options: [{packageDir: packageDirMonoRepoRoot}],
-      settings: { 'import/paths': [packageDirMonoRepoRoot] },
       errors: [{
         ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
@@ -115,7 +112,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'import "not-a-dependency"',
       options: [{packageDir: packageDirMonoRepoRoot}],
-      settings: { 'import/paths': [packageDirMonoRepoRoot] },
       errors: [{
         ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
@@ -241,5 +237,31 @@ ruleTester.run('no-extraneous-dependencies', rule, {
         message: 'The package.json file could not be parsed: ' + packageFileWithSyntaxErrorMessage,
       }],
     }),
-  ],
+    test({
+      code: 'import leftpad from "left-pad";',
+      filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
+      options: [{packageDir: packageDirMonoRepoWithNested}],
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: "'left-pad' should be listed in the project's dependencies. Run 'npm i -S left-pad' to add it",
+      }],
+    }),
+    test({
+      code: 'import react from "react";',
+      filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: "'react' should be listed in the project's dependencies. Run 'npm i -S react' to add it",
+      }],
+    }),
+    test({
+      code: 'import react from "react";',
+      filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
+      options: [{packageDir: packageDirMonoRepoRoot}],
+      errors: [{
+        ruleId: 'no-extraneous-dependencies',
+        message: "'react' should be listed in the project's dependencies. Run 'npm i -S react' to add it",
+      }],
+    }),
+  ]
 })


### PR DESCRIPTION
Continuation of @hulkish's work on #1016, but removes `import/paths` setting and instead supports both a single string or an array of string paths for the existing `packageDir` option.

Closes #1016.
Closes #1053.
Closes #935.
Closes #458.