### PR TITLE
No relative parent imports rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Added
 - Ignore type imports for [`named`] rule ([#931], thanks [@mattijsbliek])
 - Add documentation for [`no-useless-path-segments`] rule ([#1068], thanks [@manovotny])
+- Add [`no-relative-parent-imports`] rule: disallow relative imports from parent directories.
 
 
 # [2.11.0] - 2018-04-09

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 * Forbid a module from importing itself ([`no-self-import`])
 * Forbid a module from importing a module with a dependency path back to itself ([`no-cycle`])
 * Prevent unnecessary path segments in import and require statements ([`no-useless-path-segments`])
+* Forbid importing modules from parent directories ([`no-relative-parent-imports`])
 
 [`no-unresolved`]: ./docs/rules/no-unresolved.md
 [`named`]: ./docs/rules/named.md
@@ -39,6 +40,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 [`no-self-import`]: ./docs/rules/no-self-import.md
 [`no-cycle`]: ./docs/rules/no-cycle.md
 [`no-useless-path-segments`]: ./docs/rules/no-useless-path-segments.md
+[`no-relative-parent-imports`]: ./docs/rules/no-relative-parent-imports.md
 
 ### Helpful warnings
 

--- a/docs/rules/no-relative-parent-imports.md
+++ b/docs/rules/no-relative-parent-imports.md
@@ -1,0 +1,55 @@
+# no-relative-parent-imports
+
+Use this rule to prevent imports to folds in relative parent paths.
+
+It's useful for large codebases codebases to enforce directed-acyclic-graph like folder structures.
+
+
+### Examples
+
+Given the following folder structure:
+
+```
+my-project
+├── lib
+│   ├── a.js
+│   └── b.js
+└── main.js
+```
+
+And the .eslintrc file:
+```
+{
+  ...
+  "rules": {
+    "import/no-relative-parent-imports": "error"
+  }
+}
+```
+
+The following patterns are considered problems:
+
+```js
+/**
+ *  in my-project/lib/a.js
+ */
+
+import bar from '../main'; // Import parent file using a relative path
+```
+
+The following patterns are NOT considered problems:
+
+```js
+/**
+ *  in my-project/main.js
+ */
+
+import foo from 'foo'; // Import package using module path
+import a from './lib/a'; // Import child file using relative path
+
+/**
+ *  in my-project/lib/a.js
+ */
+
+import b from './b'; // Import sibling file using relative path
+```

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export const rules = {
   'no-restricted-paths': require('./rules/no-restricted-paths'),
   'no-internal-modules': require('./rules/no-internal-modules'),
   'group-exports': require('./rules/group-exports'),
+  'no-relative-parent-imports': require('./rules/no-relative-parent-imports'),
 
   'no-self-import': require('./rules/no-self-import'),
   'no-cycle': require('./rules/no-cycle'),

--- a/src/rules/no-relative-parent-imports.js
+++ b/src/rules/no-relative-parent-imports.js
@@ -1,0 +1,36 @@
+import docsUrl from '../docsUrl'
+
+import importType from '../core/importType'
+import isStaticRequire from '../core/staticRequire'
+
+module.exports = {
+  meta: {
+    docs: {
+      url: docsUrl('no-relative-parent-imports'),
+    },
+  },
+
+  create: function noRelativePackages(context) {
+
+    function checkImportForRelativeParentPath(importPath, node) {
+      if (importType(importPath, context) === 'parent') {
+        context.report({
+          node,
+          message: 'Relative imports from parent directories are not allowed. ',
+        })
+      }
+    }
+
+    return {
+      ImportDeclaration(node) {
+        checkImportForRelativeParentPath(node.source.value, node.source)
+      },
+      CallExpression(node) {
+        if (isStaticRequire(node)) {
+          const [ firstArgument ] = node.arguments
+          checkImportForRelativeParentPath(firstArgument.value, firstArgument)
+        }
+      },
+    }
+  },
+}

--- a/tests/src/rules/no-relative-parent-imports.js
+++ b/tests/src/rules/no-relative-parent-imports.js
@@ -1,0 +1,35 @@
+import { RuleTester } from 'eslint'
+import rule from 'rules/no-relative-parent-imports'
+
+import { test, testFilePath } from '../utils'
+
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-relative-parent-imports', rule, {
+  valid: [
+    test({
+      code: 'import foo from "./internal.js"',
+      filename: testFilePath('./internal-modules/plugins/plugin2/index.js'),
+    }),
+    test({
+      code: 'import foo from "./app/index.js"',
+      filename: testFilePath('./internal-modules/plugins/plugin2/index.js'),
+    }),
+    test({
+      code: 'import foo from "package"',
+      filename: testFilePath('./internal-modules/plugins/plugin2/index.js'),
+    }),
+  ],
+
+  invalid: [
+    test({
+      code: 'import foo from "../plugin.js"',
+      filename: testFilePath('./internal-modules/plugins/plugin2/index.js'),
+      errors: [ {
+        message: 'Relative imports from parent directories are not allowed.',
+        line: 1,
+        column: 17,
+      } ],
+    }),
+  ],
+})


### PR DESCRIPTION
# no-relative-parent-imports

Use this rule to prevent imports to folds in relative parent paths.

It's useful for large codebases codebases to enforce directed-acyclic-graph like folder structures.


### Examples

Given the following folder structure:

```
my-project
├── lib
│   ├── a.js
│   └── b.js
└── main.js
```

And the .eslintrc file:
```
{
  ...
  "rules": {
    "import/no-relative-parent-imports": "error"
  }
}
```

The following patterns are considered problems:

```js
/**
 *  in my-project/lib/a.js
 */

import bar from '../main'; // Import parent file using a relative path
```

The following patterns are NOT considered problems:

```js
/**
 *  in my-project/main.js
 */

import foo from 'foo'; // Import package using module path
import a from './lib/a'; // Import child file using relative path

/**
 *  in my-project/lib/a.js
 */

import b from './b'; // Import sibling file using relative path
```
