### PR TITLE
Update parser options

### DIFF
--- a/config/recommended.js
+++ b/config/recommended.js
@@ -18,11 +18,4 @@ module.exports = {
     'import/no-named-as-default-member': 'warn',
     'import/no-duplicates': 'warn'
   },
-
-  // need all these for parsing dependencies (even if _your_ code doesn't need
-  // all of them)
-  parserOptions: {
-    sourceType: 'module',
-    ecmaVersion: 2018,
-  },
 }


### PR DESCRIPTION
Latest eslint version issues a deprecation warning for "parserOptions.ecmaFeatures.experimentalObjectRestSpread"
Removed it and changed ecmaVersion to 2018 as suggested on https://eslint.org/docs/user-guide/configuring#deprecated