### PR TITLE
Fixed flow types imports

### DIFF
--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -31,7 +31,7 @@ module.exports = {
         if (im.type !== type) return
 
         // ignore type imports
-        if(im.importKind === 'type') return
+        if (im.importKind === 'type') return
 
         const deepLookup = imports.hasDeep(im[key].name)
 

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -30,6 +30,9 @@ module.exports = {
       node.specifiers.forEach(function (im) {
         if (im.type !== type) return
 
+        // ignore type imports
+        if(im.importKind === 'type') return
+
         const deepLookup = imports.hasDeep(im[key].name)
 
         if (!deepLookup.found) {

--- a/tests/files/flowtypes.js
+++ b/tests/files/flowtypes.js
@@ -10,3 +10,6 @@ export type MyType = {
 export interface MyInterface {}
 
 export class MyClass {}
+
+export opaque type MyOpaqueType: string = string;
+

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -270,6 +270,12 @@ ruleTester.run('named', rule, {
       }],
     }),
 
+    test({
+      code: 'import  { type MyOpaqueType, MyMissingClass } from "./flowtypes"',
+      parser: 'babel-eslint',
+      errors: ["MyMissingClass not found in './flowtypes'"],
+    }),
+
     // jsnext
     test({
       code: '/*jsnext*/ import { createSnorlax } from "redux"',

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -72,6 +72,14 @@ ruleTester.run('named', rule, {
       code: 'import type { MissingType } from "./flowtypes"',
       parser: 'babel-eslint',
     }),
+    test({
+      code: 'import type { MyOpaqueType } from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import  { type MyOpaqueType, MyClass } from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
 
     // TypeScript
     test({


### PR DESCRIPTION
#1057 has fixed #921 for the basic case, in which an import is the only thing imported from a specific file.
Sometimes types and functions/classes need to be imported from the same file. This PR fixes also that specific instance:
```
import  { type MyOpaqueType, MyClass } from "./flowtypes"',
```

I have added some tests for all these cases

Fixes #1115.