### PR TITLE
doc(no-relative-parent-imports): rename title

### DIFF
--- a/docs/rules/no-default-export.md
+++ b/docs/rules/no-default-export.md
@@ -1,4 +1,4 @@
-# no-default-export
+# `import/no-default-export`
 
 Prohibit default exports. Mostly an inverse of [`prefer-default-export`].
 

--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -1,4 +1,4 @@
-# import/no-deprecated
+# `import/no-deprecated`
 
 Reports use of a deprecated name, as indicated by a JSDoc block with a `@deprecated`
 tag or TomDoc `Deprecated: ` comment.

--- a/docs/rules/no-named-export.md
+++ b/docs/rules/no-named-export.md
@@ -1,4 +1,4 @@
-# no-named-export
+# `import/no-named-export`
 
 Prohibit named exports. Mostly an inverse of [`no-default-export`].
 

--- a/docs/rules/no-relative-parent-imports.md
+++ b/docs/rules/no-relative-parent-imports.md
@@ -1,4 +1,4 @@
-# no-relative-parent-imports
+# import/no-relative-parent-imports
 
 Use this rule to prevent imports to folders in relative parent paths.
 

--- a/docs/rules/no-self-import.md
+++ b/docs/rules/no-self-import.md
@@ -1,4 +1,4 @@
-# Forbid a module from importing itself
+# Forbid a module from importing itself (`import/no-self-import`)
 
 Forbid a module from importing itself. This can sometimes happen during refactoring.
 


### PR DESCRIPTION
Renamed the title of this page to be the full name of the rule, like on the rest of the docs.