### PR TITLE
Fix import/order autofixer when using typescript-eslint-parser

### DIFF
--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -97,8 +97,8 @@ function findRootNode(node) {
 function findEndOfLineWithComments(sourceCode, node) {
   const tokensToEndOfLine = takeTokensAfterWhile(sourceCode, node, commentOnSameLineAs(node))
   let endOfTokens = tokensToEndOfLine.length > 0
-    ? tokensToEndOfLine[tokensToEndOfLine.length - 1].end
-    : node.end
+    ? tokensToEndOfLine[tokensToEndOfLine.length - 1].range[1]
+    : node.range[1]
   let result = endOfTokens
   for (let i = endOfTokens; i < sourceCode.text.length; i++) {
     if (sourceCode.text[i] === '\n') {
@@ -121,7 +121,7 @@ function commentOnSameLineAs(node) {
 
 function findStartOfLineWithComments(sourceCode, node) {
   const tokensToEndOfLine = takeTokensBeforeWhile(sourceCode, node, commentOnSameLineAs(node))
-  let startOfTokens = tokensToEndOfLine.length > 0 ? tokensToEndOfLine[0].start : node.start
+  let startOfTokens = tokensToEndOfLine.length > 0 ? tokensToEndOfLine[0].range[0] : node.range[0]
   let result = startOfTokens
   for (let i = startOfTokens - 1; i > 0; i--) {
     if (sourceCode.text[i] !== ' ' && sourceCode.text[i] !== '\t') {
@@ -296,11 +296,11 @@ function fixNewLineAfterImport(context, previousImport) {
   const tokensToEndOfLine = takeTokensAfterWhile(
     context.getSourceCode(), prevRoot, commentOnSameLineAs(prevRoot))
 
-  let endOfLine = prevRoot.end
+  let endOfLine = prevRoot.range[1]
   if (tokensToEndOfLine.length > 0) {
-    endOfLine = tokensToEndOfLine[tokensToEndOfLine.length - 1].end
+    endOfLine = tokensToEndOfLine[tokensToEndOfLine.length - 1].range[1]
   }
-  return (fixer) => fixer.insertTextAfterRange([prevRoot.start, endOfLine], '\n')
+  return (fixer) => fixer.insertTextAfterRange([prevRoot.range[0], endOfLine], '\n')
 }
 
 function removeNewLineAfterImport(context, currentImport, previousImport) {

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -1260,5 +1260,21 @@ ruleTester.run('order', rule, {
         message: '`fs` import should occur before import of `async`',
       }],
     })),
+    // fix incorrect order with typescript-eslint-parser
+    test({
+      code: `
+        var async = require('async');
+        var fs = require('fs');
+      `,
+      output: `
+        var fs = require('fs');
+        var async = require('async');
+      `,
+      parser: 'typescript-eslint-parser',
+      errors: [{
+        ruleId: 'order',
+        message: '`fs` import should occur before import of `async`',
+      }],
+    }),
   ],
 })


### PR DESCRIPTION
Addresses https://github.com/benmosher/eslint-plugin-import/issues/1086#issuecomment-383093638

# Why?

When using `typescript-eslint-parser`, AST nodes have a `range` trie but not `start` and `end`. Apparently `eslint` prefers using `range` instead of `.start` and `.end` as well, see https://github.com/eslint/eslint/issues/8956.

# How

Replace use of `.start` and `.end` with `range[0]` and `range[1]` respectively in the `order` rule.

# Test

I added a test to reproduce the error and then a separate commit to prove this fixes it. All other tests pass.