### PR TITLE
[Fix] `newline-after-import`: recognize decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`order`]: Recognize pathGroup config for first group ([#1719], [#1724], thanks [@forivall], [@xpl])
 - [`no-unused-modules`]: Fix re-export not counting as usage when used in combination with import ([#1722], thanks [@Ephem])
 - [`no-duplicates`]: Handle TS import type ([#1676], thanks [@kmui2])
+- [``newline-after-import`: recognize decorators ([#1139], thanks [@atos1990])
 
 ### Changed
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
@@ -770,6 +771,7 @@ for info on changes for earlier releases.
 [#1157]: https://github.com/benmosher/eslint-plugin-import/pull/1157
 [#1151]: https://github.com/benmosher/eslint-plugin-import/pull/1151
 [#1142]: https://github.com/benmosher/eslint-plugin-import/pull/1142
+[#1139]: https://github.com/benmosher/eslint-plugin-import/pull/1139
 [#1137]: https://github.com/benmosher/eslint-plugin-import/pull/1137
 [#1135]: https://github.com/benmosher/eslint-plugin-import/pull/1135
 [#1128]: https://github.com/benmosher/eslint-plugin-import/pull/1128
@@ -1153,3 +1155,4 @@ for info on changes for earlier releases.
 [@Ephem]: https://github.com/Ephem
 [@kmui2]: https://github.com/kmui2
 [@arvigeus]: https://github.com/arvigeus
+[@atos1990]: https://github.com/atos1990

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ test_script:
   - npm --version
 
   # core tests
-  - npm test
+  - npm run tests-only
 
   # resolver tests
   - cd .\resolvers\webpack && npm test && cd ..\..

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -43,6 +43,10 @@ function isClassWithDecorator(node) {
   return node.type === 'ClassDeclaration' && node.decorators && node.decorators.length
 }
 
+function isExportDefaultClass(node) {
+  return node.type === 'ExportDefaultDeclaration' && node.declaration.type === 'ClassDeclaration'
+}
+
 module.exports = {
   meta: {
     type: 'layout',
@@ -68,7 +72,13 @@ module.exports = {
     const requireCalls = []
 
     function checkForNewLine(node, nextNode, type) {
-      if (isClassWithDecorator(nextNode)) {
+      if (isExportDefaultClass(nextNode)) {
+        let classNode = nextNode.declaration
+
+        if (isClassWithDecorator(classNode)) {
+          nextNode = classNode.decorators[0]
+        }
+      } else if (isClassWithDecorator(nextNode)) {
         nextNode = nextNode.decorators[0]
       }
 

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -165,6 +165,16 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       parser: require.resolve('babel-eslint'),
     },
+    {
+      code : `// issue 1004\nimport foo from 'foo';\n\n@SomeDecorator(foo)\nexport default class Test {}`,
+      parserOptions: { sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
+    },
+    {
+      code : `// issue 1004\nconst foo = require('foo');\n\n@SomeDecorator(foo)\nexport default class Test {}`,
+      parserOptions: { sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
+    },
   ],
 
   invalid: [
@@ -338,6 +348,28 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         message: REQUIRE_ERROR_MESSAGE,
       } ],
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
+    },
+    {
+      code: `// issue 10042\nimport foo from 'foo';\n@SomeDecorator(foo)\nexport default class Test {}`,
+      output: `// issue 10042\nimport foo from 'foo';\n\n@SomeDecorator(foo)\nexport default class Test {}`,
+      errors: [ {
+        line: 2,
+        column: 1,
+        message: IMPORT_ERROR_MESSAGE,
+      } ],
+      parserOptions: { sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
+    },
+    {
+      code: `// issue 1004\nconst foo = require('foo');\n@SomeDecorator(foo)\nexport default class Test {}`,
+      output: `// issue 1004\nconst foo = require('foo');\n\n@SomeDecorator(foo)\nexport default class Test {}`,
+      errors: [ {
+        line: 2,
+        column: 1,
+        message: REQUIRE_ERROR_MESSAGE,
+      } ],
+      parserOptions: { sourceType: 'module' },
       parser: require.resolve('babel-eslint'),
     },
   ],


### PR DESCRIPTION
Hi, this is my fix issue https://github.com/benmosher/eslint-plugin-import/issues/1004