### PR TITLE
[no-relative-parent-imports] support windows

### DIFF
--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -57,7 +57,7 @@ function isInternalModule(name, settings, path) {
 }
 
 function isRelativeToParent(name) {
-  return name.indexOf('../') === 0
+  return /^\.\.[\\/]/.test(name)
 }
 
 const indexFiles = ['.', './', './index', './index.js']
@@ -66,7 +66,7 @@ function isIndex(name) {
 }
 
 function isRelativeToSibling(name) {
-  return name.indexOf('./') === 0
+  return /^\.[\\/]/.test(name)
 }
 
 const typeTest = cond([


### PR DESCRIPTION
make rule `no-relative-parent-imports` support windows

as you see, appveyor ci failed in master branch, i think because windows uses `\` as a directory delimiter
so i change path check to use regular expression `[\\/]`