### PR TITLE
fix(dynamic-import-chunkname): Add proper webpack comment parsing

### DIFF
--- a/docs/rules/dynamic-import-chunkname.md
+++ b/docs/rules/dynamic-import-chunkname.md
@@ -28,6 +28,10 @@ import(
   /*webpackChunkName:"someModule"*/
   'someModule',
 );
+import(
+  /* webpackChunkName : "someModule" */
+  'someModule',
+);
 
 // chunkname contains a 6 (forbidden by rule config)
 import(
@@ -38,6 +42,12 @@ import(
 // using single quotes instead of double quotes
 import(
   /* webpackChunkName: 'someModule' */
+  'someModule',
+);
+
+// invalid syntax for webpack comment
+import(
+  /* totally not webpackChunkName: "someModule" */
   'someModule',
 );
 
@@ -57,6 +67,15 @@ The following patterns are valid:
   );
   import(
     /* webpackChunkName: "someOtherModule12345789" */
+    'someModule',
+  );
+  import(
+    /* webpackChunkName: "someModule" */
+    /* webpackPrefetch: true */
+    'someModule',
+  );
+  import(
+    /* webpackChunkName: "someModule", webpackPrefetch: true */
     'someModule',
   );
 ```

--- a/tests/src/rules/dynamic-import-chunkname.js
+++ b/tests/src/rules/dynamic-import-chunkname.js
@@ -18,8 +18,10 @@ const parser = 'babel-eslint'
 
 const noLeadingCommentError = 'dynamic imports require a leading comment with the webpack chunkname'
 const nonBlockCommentError = 'dynamic imports require a /* foo */ style comment, not a // foo comment'
-const commentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: "${commentFormat}" */`
-const pickyCommentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: "${pickyCommentFormat}" */`
+const noPaddingCommentError = 'dynamic imports require a block comment padded with spaces - /* foo */'
+const invalidSyntaxCommentError = 'dynamic imports require a "webpack" comment with valid syntax'
+const commentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: "${commentFormat}",? */`
+const pickyCommentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: "${pickyCommentFormat}",? */`
 
 ruleTester.run('dynamic-import-chunkname', rule, {
   valid: [
@@ -81,6 +83,56 @@ ruleTester.run('dynamic-import-chunkname', rule, {
     },
     {
       code: `import(
+        /* webpackChunkName: "someModule", webpackPrefetch: true */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule", webpackPrefetch: true, */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackPrefetch: true, webpackChunkName: "someModule" */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackPrefetch: true, webpackChunkName: "someModule", */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackPrefetch: true */
+        /* webpackChunkName: "someModule" */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackPrefetch: true */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
         /* webpackChunkName: "someModule" */
         'someModule'
       )`,
@@ -124,7 +176,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
       options,
       parser,
       errors: [{
-        message: commentFormatError,
+        message: invalidSyntaxCommentError,
         type: 'CallExpression',
       }],
     },
@@ -148,13 +200,86 @@ ruleTester.run('dynamic-import-chunkname', rule, {
       options,
       parser,
       errors: [{
-        message: commentFormatError,
+        message: invalidSyntaxCommentError,
         type: 'CallExpression',
       }],
     },
     {
       code: `import(
         /* webpackChunkName:"someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /*webpackChunkName: "someModule"*/
+        'someModule'
+      )`,
+      options,
+      parser,
+      errors: [{
+        message: noPaddingCommentError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackChunkName  :  "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" ; */
+        'someModule'
+      )`,
+      options,
+      parser,
+      errors: [{
+        message: invalidSyntaxCommentError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* totally not webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      errors: [{
+        message: invalidSyntaxCommentError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackPrefetch: true */
+        /* webpackChunk: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackPrefetch: true, webpackChunk: "someModule" */
         'someModule'
       )`,
       options,
@@ -183,7 +308,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
       )`,
       options: multipleImportFunctionOptions,
       errors: [{
-        message: commentFormatError,
+        message: invalidSyntaxCommentError,
         type: 'CallExpression',
       }],
     },
@@ -194,7 +319,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
       )`,
       options: multipleImportFunctionOptions,
       errors: [{
-        message: commentFormatError,
+        message: invalidSyntaxCommentError,
         type: 'CallExpression',
       }],
     },
@@ -224,7 +349,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
       )`,
       options,
       errors: [{
-        message: commentFormatError,
+        message: invalidSyntaxCommentError,
         type: 'CallExpression',
       }],
     },
@@ -246,7 +371,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
       )`,
       options,
       errors: [{
-        message: commentFormatError,
+        message: invalidSyntaxCommentError,
         type: 'CallExpression',
       }],
     },


### PR DESCRIPTION
As briefly discussed in #1130, current webpack comment parsing logic (without taking styling into account) is severely flawed, reporting valid comments as errors while also allowing invalid syntax.

This PR adds
* checking for valid syntax the way webpack itself parses these comments
* support for multiple keys in these comments, both in a single comment and in several comments (see examples in docs or tests)

Styling requirements have not been relaxed by these changes.

The main topic of #1130 - allowing single quotes in strings in webpack comments - will be implemented on top of these changes once they are merged.