### PR TITLE
Add support for require.resolve

### DIFF
--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -150,6 +150,23 @@ function runResolverTests(resolver) {
         }],
       }),
 
+      rest({
+        code: 'var bar = require.resolve("./baz")',
+        options: [{ commonjs: true }],
+        errors: [{
+          message: "Unable to resolve path to module './baz'.",
+          type: 'Literal',
+        }],
+      }),
+      rest({
+        code: 'require.resolve("./baz")',
+        options: [{ commonjs: true }],
+        errors: [{
+          message: "Unable to resolve path to module './baz'.",
+          type: 'Literal',
+        }],
+      }),
+
       // amd
       rest({
         code: 'require(["./baz"], function (bar) {})',

--- a/utils/moduleVisitor.js
+++ b/utils/moduleVisitor.js
@@ -49,8 +49,15 @@ exports.default = function visitModules(visitor, options) {
   // for CommonJS `require` calls
   // adapted from @mctep: http://git.io/v4rAu
   function checkCommon(call) {
-    if (call.callee.type !== 'Identifier') return
-    if (call.callee.name !== 'require') return
+    if (call.callee.type === 'Identifier') {
+      if (call.callee.name !== 'require') return
+    }
+    else if (call.callee.type === 'MemberExpression') {
+      if (call.callee.object.name !== 'require') return
+      if (call.callee.property.name !== 'resolve') return
+    }
+    else return
+
     if (call.arguments.length !== 1) return
 
     const modulePath = call.arguments[0]


### PR DESCRIPTION
Related to discussion in #1035 ([link to comment](https://github.com/benmosher/eslint-plugin-import/issues/1035#issuecomment-416503352)).

So far I've only added `require.resolve` for `commonjs` with `no-unresolved`, let me know if I should add it anywhere else.