### PR TITLE
Add requireResolve option

### DIFF
--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -68,6 +68,15 @@ function runResolverTests(resolver) {
            , options: [{ amd: true }]}),
       rest({ code: 'define(["./does-not-exist"], function (bar) {})' }),
 
+      // requireResolve setting
+      rest({ code: 'var foo = require.resolve("./bar")'
+           , options: [{ requireResolve: true }]}),
+      rest({ code: 'require.resolve("./bar")'
+           , options: [{ requireResolve: true }]}),
+      rest({ code: 'require.resolve("./does-not-exist")'
+           , options: [{ requireResolve: false }]}),
+      rest({ code: 'require.resolve("./does-not-exist")' }),
+
       // stress tests
       rest({ code: 'require("./does-not-exist", "another arg")'
            , options: [{ commonjs: true, amd: true }]}),
@@ -175,6 +184,24 @@ function runResolverTests(resolver) {
           type: 'Literal',
         },{
           message: "Unable to resolve path to module './does-not-exist'.",
+          type: 'Literal',
+        }],
+      }),
+
+      // requireResolve setting
+      rest({
+        code: 'var bar = require.resolve("./baz")',
+        options: [{ requireResolve: true }],
+        errors: [{
+          message: "Unable to resolve path to module './baz'.",
+          type: 'Literal',
+        }],
+      }),
+      rest({
+        code: 'require.resolve("./baz")',
+        options: [{ requireResolve: true }],
+        errors: [{
+          message: "Unable to resolve path to module './baz'.",
           type: 'Literal',
         }],
       }),


### PR DESCRIPTION
Alternate to #1216 

Adds an option `requireResolve` to check `require.resolve` statements.

Might want to support `require.resolve` by default in a future major version though.