### PR TITLE
Fix overwriting of dynamic import() CallExpression

### DIFF
--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -31,12 +31,8 @@ module.exports = {
     function checkSourceValue(sourceNode, importer) {
       const imported = Exports.get(sourceNode.value, context)
 
-      if (sourceNode.parent && sourceNode.parent.importKind === 'type') {
+      if (importer.importKind === 'type') {
         return // no Flow import resolution
-      }
-
-      if (sourceNode._babelType === 'Literal') {
-        return // no Flow import resolution, workaround for ESLint < 5.x
       }
 
       if (imported == null) {

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -37,7 +37,20 @@ ruleTester.run('no-cycle', rule, {
       options: [{ maxDepth: 1 }],
     }),
     test({
+      code: 'import { foo, bar } from "./depth-two"',
+      options: [{ maxDepth: 1 }],
+    }),
+    test({
+      code: 'import("./depth-two").then(function({ foo }){})',
+      options: [{ maxDepth: 1 }],
+      parser: 'babel-eslint',
+    }),
+    test({
       code: 'import type { FooType } from "./depth-one"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import type { FooType, BarType } from "./depth-one"',
       parser: 'babel-eslint',
     }),
   ],
@@ -85,8 +98,27 @@ ruleTester.run('no-cycle', rule, {
       errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
     }),
     test({
+      code: 'import one, { two, three } from "./depth-three-star"',
+      errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
+    }),
+    test({
       code: 'import { bar } from "./depth-three-indirect"',
       errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
+    }),
+    test({
+      code: 'import { bar } from "./depth-three-indirect"',
+      errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import("./depth-three-star")',
+      errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import("./depth-three-indirect")',
+      errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
+      parser: 'babel-eslint',
     }),
   ],
 })

--- a/tests/src/rules/no-relative-parent-imports.js
+++ b/tests/src/rules/no-relative-parent-imports.js
@@ -93,6 +93,14 @@ ruleTester.run('no-relative-parent-imports', rule, {
         line: 1,
         column: 17
       }]
+    }),
+    test({
+      code: 'import("../../api/service")',
+      errors: [ {
+        message: 'Relative imports from parent directories are not allowed. Please either pass what you\'re importing through at runtime (dependency injection), move `index.js` to same directory as `../../api/service` or consider making `../../api/service` a package.',
+        line: 1,
+        column: 8
+      }],
     })
   ],
 })

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -29,6 +29,8 @@ function runResolverTests(resolver) {
       rest({ code: "import bar from './bar.js';" }),
       rest({ code: "import {someThing} from './test-module';" }),
       rest({ code: "import fs from 'fs';" }),
+      rest({ code: "import('fs');"
+           , parser: 'babel-eslint' }),
 
       rest({ code: 'import * as foo from "a"' }),
 
@@ -114,6 +116,13 @@ function runResolverTests(resolver) {
                             "module 'in-alternate-root'."
                  , type: 'Literal',
                  }]}),
+      rest({
+      code: "import('in-alternate-root').then(function({DEEP}){});",
+      errors: [{ message: 'Unable to resolve path to ' +
+                          "module 'in-alternate-root'."
+                , type: 'Literal',
+                }],
+      parser: 'babel-eslint'}),
 
       rest({ code: 'export { foo } from "./does-not-exist"'
            , errors: ["Unable to resolve path to module './does-not-exist'."] }),

--- a/tests/src/rules/no-useless-path-segments.js
+++ b/tests/src/rules/no-useless-path-segments.js
@@ -17,7 +17,6 @@ function runResolverTests(resolver) {
       test({ code: 'import "."' }),
       test({ code: 'import ".."' }),
       test({ code: 'import fs from "fs"' }),
-      test({ code: 'import fs from "fs"' }),
 
       // ES modules + noUselessIndex
       test({ code: 'import "../index"' }), // noUselessIndex is false by default
@@ -28,6 +27,13 @@ function runResolverTests(resolver) {
       test({ code: 'import "./malformed.js"', options: [{ noUselessIndex: true }] }), // ./malformed directory does not exist
       test({ code: 'import "./malformed"', options: [{ noUselessIndex: true }] }), // ./malformed directory does not exist
       test({ code: 'import "./importType"', options: [{ noUselessIndex: true }] }), // ./importType.js does not exist
+
+      test({ code: 'import(".")'
+           , parser: 'babel-eslint' }),
+      test({ code: 'import("..")'
+           , parser: 'babel-eslint' }),
+      test({ code: 'import("fs").then(function(fs){})'
+           , parser: 'babel-eslint' }),
     ],
 
     invalid: [
@@ -189,6 +195,21 @@ function runResolverTests(resolver) {
         code: 'import "../index.js"',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "../index.js", should be ".."'],
+      }),
+      test({
+        code: 'import("./")',
+        errors: [ 'Useless path segments for "./", should be "."'],
+        parser: 'babel-eslint',
+      }),
+      test({
+        code: 'import("../")',
+        errors: [ 'Useless path segments for "../", should be ".."'],
+        parser: 'babel-eslint',
+      }),
+      test({
+        code: 'import("./deep//a")',
+        errors: [ 'Useless path segments for "./deep//a", should be "./deep/a"'],
+        parser: 'babel-eslint',
       }),
     ],
   })

--- a/utils/moduleVisitor.js
+++ b/utils/moduleVisitor.js
@@ -91,7 +91,9 @@ exports.default = function visitModules(visitor, options) {
   }
 
   if (options.commonjs || options.amd) {
+    const currentCallExpression = visitors['CallExpression']
     visitors['CallExpression'] = function (call) {
+      if (currentCallExpression) currentCallExpression(call)
       if (options.commonjs) checkCommon(call)
       if (options.amd) checkAMD(call)
     }


### PR DESCRIPTION
Closes #1035
Closes #1166

So turns out, dynamic imports were already supported in `moduleVisitor` but they were being overwritten if `commonjs` or `amd` options were set.

- Fixed by saving the current `CallExpression` and including it in the function that's overwriting it.
- Added test cases for `import()` in rules using the `moduleVisitor`. Not sure why, but I couldn't get the `no-cycle` rule to throw errors with `import()`.
- Fixes issues with parser `babel-eslint` not working with `no-cycle`, due to the "flow workaround" for `eslint@<5`

This might be breaking for some users, though.

Also since `import()` can work with URLs, maybe we should use something like [`isURL` from `validator`](https://github.com/chriso/validator.js#validators) to ignore URL imports?