### PR TITLE
Updated lodash in order to fix CVE-2018-3721

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import",
-  "version": "2.14.1",
+  "version": "2.14.0",
   "description": "Import with sanity.",
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Import with sanity.",
   "engines": {
     "node": ">=4"
@@ -21,7 +21,7 @@
     "test": "cross-env BABEL_ENV=test NODE_PATH=./src nyc -s mocha -R dot --recursive tests/src -t 5s",
     "test-compiled": "npm run prepublish && NODE_PATH=./lib mocha --compilers js:babel-register --recursive tests/src",
     "test-all": "npm test && for resolver in ./resolvers/*; do cd $resolver && npm test && cd ../..; done",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "coveralls": "nyc report --reporter lcovonly && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
@@ -79,7 +79,7 @@
     "eslint-import-resolver-node": "^0.3.1",
     "eslint-module-utils": "^2.2.0",
     "has": "^1.0.1",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.11",
     "minimatch": "^3.0.3",
     "read-pkg-up": "^2.0.0",
     "resolve": "^1.6.0"


### PR DESCRIPTION
- [x] Fixed CVE-2018-3721 (more information: https://nvd.nist.gov/vuln/detail/CVE-2018-3721)
- [x] Use `prepare` instead of deprecated `prepublish` (more information: https://github.com/npm/npm/issues/10074)