### PR TITLE
feat:add an ignore option for 'no-extraneous-dependencies'

### DIFF
--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -15,10 +15,20 @@ This rule supports the following options:
 
 `peerDependencies`: If set to `false`, then the rule will show an error when `peerDependencies` are imported. Defaults to `false`.
 
+`ignore`:  Some modules can be ignored by the ignore parameter.It supports regular expressions
+
 You can set the options like this:
 
 ```js
-"import/no-extraneous-dependencies": ["error", {"devDependencies": false, "optionalDependencies": false, "peerDependencies": false}]
+"import/no-extraneous-dependencies": [
+  "error", 
+  {
+    "devDependencies": false, 
+    "optionalDependencies": false,
+    "peerDependencies": false,
+    "ignore": ["@org", "@org/module", "@org/custom-.*"]
+  }
+]
 ```
 
 You can also use an array of globs instead of literal booleans:

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -106,6 +106,22 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import rightpad from "right-pad";',
       options: [{packageDir: [packageDirMonoRepoRoot, packageDirMonoRepoWithNested]}],
     }),
+    test({
+      code: 'import ignore from "@org/not-a-dependency"',
+      options: [{ignore: ['@org'] }],
+    }),
+    test({
+      code: 'import ignore from "@org/not-a-dependency"',
+      options: [{ignore: ['@org/not-a-dependency'] }],
+    }),
+    test({
+      code: 'import ignore from "not-a-dependency"',
+      options: [{ignore: ['not-a-dependency'] }],
+    }),
+    test({
+      code: 'import ignore from "not-a-dependency/index"',
+      options: [{ignore: ['not-a-dependency'] }],
+    }),
   ],
   invalid: [
     test({


### PR DESCRIPTION
If the alias module starts with "@", the current "no-extraneous-dependencies" rule will report an error in the case of "@custom/XXX".

