### PR TITLE
Avoid flow imports in no-cycle rule

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -418,6 +418,7 @@ ExportMap.parse = function (path, content, context) {
     const getter = thunkFor(p, context)
     m.imports.set(p, {
       getter,
+      importKind: declaration.importKind,
       source: {  // capturing actual node reference holds full AST in memory!
         value: declaration.source.value,
         loc: declaration.source.loc,

--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -51,7 +51,8 @@ module.exports = {
         if (traversed.has(m.path)) return
         traversed.add(m.path)
 
-        for (let [path, { getter, source }] of m.imports) {
+        for (let [path, { getter, importKind, source }] of m.imports) {
+          if (importKind === 'type') continue
           if (path === myPath) return true
           if (traversed.has(path)) continue
           if (route.length + 1 < maxDepth) {


### PR DESCRIPTION
Avoid flow imports in no-cycle rule
Currently no-cycle rule is not working with babel parser, errors are being skipped due to 
```
if (sourceNode._babelType === 'Literal') {	
  return // no Flow import resolution, workaround for ESLint < 5.x	
}
```

fixes #1166