### PR TITLE
[import/named] fix destructuring assignemnt

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -512,6 +512,10 @@ export function recursivePatternCapture(pattern, callback) {
         recursivePatternCapture(element, callback)
       })
       break
+
+    case 'AssignmentPattern':
+      callback(pattern.left)
+      break
   }
 }
 

--- a/tests/files/named-exports.js
+++ b/tests/files/named-exports.js
@@ -14,6 +14,8 @@ export class ExportedClass {
 // destructuring exports
 
 export var { destructuredProp } = {}
+         , { destructingAssign = null } = {}
+         , { destructingAssign: destructingRenamedAssign = null } = {}
          , [ arrayKeyProp ] = []
          , [ { deepProp } ] = []
          , { arr: [ ,, deepSparseElement ] } = {}

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -273,7 +273,7 @@ describe('ExportMap', function () {
     context('#size', function () {
 
       it('counts the names', () => expect(ExportMap.get('./named-exports', fakeContext))
-        .to.have.property('size', 8))
+        .to.have.property('size', 10))
 
       it('includes exported namespace size', () => expect(ExportMap.get('./export-all', fakeContext))
         .to.have.property('size', 1))

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -22,6 +22,8 @@ ruleTester.run('named', rule, {
     test({code: 'import bar, { foo } from "./bar.js"'}),
     test({code: 'import {a, b, d} from "./named-exports"'}),
     test({code: 'import {ExportedClass} from "./named-exports"'}),
+    test({code: 'import { destructingAssign } from "./named-exports"'}),
+    test({code: 'import { destructingRenamedAssign } from "./named-exports"'}),
     test({code: 'import { ActionTypes } from "./qc"'}),
     test({code: 'import {a, b, c, d} from "./re-export"'}),
 


### PR DESCRIPTION
This PR fixes #718.

The fix is simple, just recognize the `AssignmentPattern` and put the name into the exports map.