### PR TITLE
[ExportMap] fix condition for checking if block comment

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -243,7 +243,7 @@ function captureJsDoc(comments) {
   // capture XSDoc
   comments.forEach(comment => {
     // skip non-block comments
-    if (comment.value.slice(0, 4) !== '*\n *') return
+    if (comment.type !== 'Block') return
     try {
       doc = doctrine.parse(comment.value, { unwrap: true })
     } catch (err) {

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -96,12 +96,12 @@ describe('ExportMap', function () {
 
   context('deprecation metadata', function () {
 
-    function jsdocTests(parseContext) {
+    function jsdocTests(parseContext, lineEnding) {
       context('deprecated imports', function () {
         let imports
         before('parse file', function () {
           const path = getFilename('deprecated.js')
-              , contents = fs.readFileSync(path, { encoding: 'utf8' })
+              , contents = fs.readFileSync(path, { encoding: 'utf8' }).replace(/[\r]\n/g, lineEnding)
           imports = ExportMap.parse(path, contents, parseContext)
 
           // sanity checks
@@ -191,7 +191,15 @@ describe('ExportMap', function () {
           attachComment: true,
         },
         settings: {},
-      })
+      }, '\n')
+      jsdocTests({
+        parserPath: 'espree',
+        parserOptions: {
+          sourceType: 'module',
+          attachComment: true,
+        },
+        settings: {},
+      }, '\r\n')
     })
 
     context('babel-eslint', function () {
@@ -202,7 +210,15 @@ describe('ExportMap', function () {
           attachComment: true,
         },
         settings: {},
-      })
+      }, '\n')
+      jsdocTests({
+        parserPath: 'babel-eslint',
+        parserOptions: {
+          sourceType: 'module',
+          attachComment: true,
+        },
+        settings: {},
+      }, '\r\n')
     })
   })
 


### PR DESCRIPTION
This PR fixes #1233 .

Before the code uses `\n` as line ending to check if the comment is block comment. This PR changes to use `comment.type` which is more reliable.
https://github.com/benmosher/eslint-plugin-import/blob/798eed7e559adab2eac07bf1b3e3518d4b7a4296/src/ExportMap.js#L233

Tests are added for both `\n` and `\r\n`