### PR TITLE
[Namespace] add check for null ExportMap

### DIFF
--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -187,7 +187,11 @@ module.exports = {
             }
 
             path.push(property.key.name)
-            testKey(property.value, namespace.get(property.key.name).namespace, path)
+            const dependencyExportMap = namespace.get(property.key.name)
+            // could be null when ignored or ambiguous
+            if (dependencyExportMap !== null) {
+              testKey(property.value, dependencyExportMap.namespace, path)
+            }
             path.pop()
           }
         }

--- a/tests/files/re-export-common.js
+++ b/tests/files/re-export-common.js
@@ -1,0 +1,1 @@
+export { a as foo } from './common'

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -104,6 +104,11 @@ const valid = [
     parser: 'babel-eslint',
   }),
 
+  // #1144: should handle re-export CommonJS as namespace
+  test({
+    code: `import * as ns from './re-export-common'; const {foo} = ns;`,
+  }),
+
   // JSX
   test({
     code: 'import * as Names from "./named-exports"; const Foo = <Names.a/>',


### PR DESCRIPTION
This PR fixes #1144 .

The issue happens when the dependency has `null` `ExportMap`, which happens for ignored or ambiguous modules.

This PR adds a check before doing more verification on the `ExportMap`.

Test is added following the issue.