### PR TITLE
[Rules] add meta.type for all rules

### DIFF
--- a/src/rules/default.js
+++ b/src/rules/default.js
@@ -3,6 +3,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('default'),
     },

--- a/src/rules/dynamic-import-chunkname.js
+++ b/src/rules/dynamic-import-chunkname.js
@@ -3,6 +3,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('dynamic-import-chunkname'),
     },

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -3,6 +3,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('export'),
     },

--- a/src/rules/exports-last.js
+++ b/src/rules/exports-last.js
@@ -8,6 +8,7 @@ function isNonExportStatement({ type }) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('exports-last'),
     },

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -55,6 +55,7 @@ function buildProperties(context) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('extensions'),
     },

--- a/src/rules/first.js
+++ b/src/rules/first.js
@@ -2,6 +2,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('first'),
     },
@@ -105,7 +106,7 @@ module.exports = {
                   insertSourceCode =
                     insertSourceCode.trim() + insertSourceCode.match(/^(\s+)/)[0]
               }
-              insertFixer = lastLegalImp ? 
+              insertFixer = lastLegalImp ?
                             fixer.insertTextAfter(lastLegalImp, insertSourceCode) :
                             fixer.insertTextBefore(body[0], insertSourceCode)
               const fixers = [insertFixer].concat(removeFixers)

--- a/src/rules/group-exports.js
+++ b/src/rules/group-exports.js
@@ -1,6 +1,7 @@
 import docsUrl from '../docsUrl'
 
 const meta = {
+  type: 'suggestion',
   docs: {
     url: docsUrl('group-exports'),
   },

--- a/src/rules/max-dependencies.js
+++ b/src/rules/max-dependencies.js
@@ -16,6 +16,7 @@ const countDependencies = (dependencies, lastNode, context) => {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('max-dependencies'),
     },

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -4,6 +4,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('named'),
     },

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -5,6 +5,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('namespace'),
     },

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -45,6 +45,7 @@ function isClassWithDecorator(node) {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       url: docsUrl('newline-after-import'),
     },

--- a/src/rules/no-absolute-path.js
+++ b/src/rules/no-absolute-path.js
@@ -4,6 +4,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-absolute-path'),
     },

--- a/src/rules/no-amd.js
+++ b/src/rules/no-amd.js
@@ -11,6 +11,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
     meta: {
+        type: 'suggestion',
         docs: {
             url: docsUrl('no-amd'),
         },

--- a/src/rules/no-anonymous-default-export.js
+++ b/src/rules/no-anonymous-default-export.js
@@ -72,6 +72,7 @@ const defaults = Object.keys(defs)
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-anonymous-default-export'),
     },

--- a/src/rules/no-commonjs.js
+++ b/src/rules/no-commonjs.js
@@ -41,6 +41,7 @@ const schemaObject = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-commonjs'),
     },

--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -10,6 +10,7 @@ import docsUrl from '../docsUrl'
 // todo: cache cycles / deep relationships for faster repeat evaluation
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: { url: docsUrl('no-cycle') },
     schema: [makeOptionsSchema({
       maxDepth:{

--- a/src/rules/no-default-export.js
+++ b/src/rules/no-default-export.js
@@ -1,5 +1,6 @@
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {},
   },
 

--- a/src/rules/no-deprecated.js
+++ b/src/rules/no-deprecated.js
@@ -17,6 +17,7 @@ function getDeprecation(metadata) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-deprecated'),
     },

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -13,6 +13,7 @@ function checkImports(imported, context) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('no-duplicates'),
     },

--- a/src/rules/no-dynamic-require.js
+++ b/src/rules/no-dynamic-require.js
@@ -15,6 +15,7 @@ function isStaticValue(arg) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-dynamic-require'),
     },

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -158,6 +158,7 @@ function testConfig(config, filename) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('no-extraneous-dependencies'),
     },

--- a/src/rules/no-internal-modules.js
+++ b/src/rules/no-internal-modules.js
@@ -7,6 +7,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-internal-modules'),
     },

--- a/src/rules/no-mutable-exports.js
+++ b/src/rules/no-mutable-exports.js
@@ -2,6 +2,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-mutable-exports'),
     },

--- a/src/rules/no-named-as-default-member.js
+++ b/src/rules/no-named-as-default-member.js
@@ -14,6 +14,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-named-as-default-member'),
     },

--- a/src/rules/no-named-as-default.js
+++ b/src/rules/no-named-as-default.js
@@ -4,6 +4,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('no-named-as-default'),
     },

--- a/src/rules/no-named-default.js
+++ b/src/rules/no-named-default.js
@@ -2,6 +2,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-named-default'),
     },

--- a/src/rules/no-named-export.js
+++ b/src/rules/no-named-export.js
@@ -2,6 +2,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: { url: docsUrl('no-named-export') },
   },
 

--- a/src/rules/no-namespace.js
+++ b/src/rules/no-namespace.js
@@ -12,6 +12,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-namespace'),
     },

--- a/src/rules/no-nodejs-modules.js
+++ b/src/rules/no-nodejs-modules.js
@@ -10,6 +10,7 @@ function reportIfMissing(context, node, allowed, name) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-nodejs-modules'),
     },

--- a/src/rules/no-relative-parent-imports.js
+++ b/src/rules/no-relative-parent-imports.js
@@ -7,6 +7,7 @@ import importType from '../core/importType'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-relative-parent-imports'),
     },

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -7,6 +7,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('no-restricted-paths'),
     },

--- a/src/rules/no-self-import.js
+++ b/src/rules/no-self-import.js
@@ -21,6 +21,7 @@ function isImportingSelf(context, node, requireName) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Forbid a module from importing itself',
       recommended: true,

--- a/src/rules/no-unassigned-import.js
+++ b/src/rules/no-unassigned-import.js
@@ -54,6 +54,7 @@ function create(context) {
 module.exports = {
   create,
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-unassigned-import'),
     },

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -10,6 +10,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('no-unresolved'),
     },

--- a/src/rules/no-useless-path-segments.js
+++ b/src/rules/no-useless-path-segments.js
@@ -35,6 +35,7 @@ const countRelParent = x => sumBy(x, v => v === '..')
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('no-useless-path-segments'),
     },

--- a/src/rules/no-webpack-loader-syntax.js
+++ b/src/rules/no-webpack-loader-syntax.js
@@ -11,6 +11,7 @@ function reportIfNonStandard(context, node, name) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       url: docsUrl('no-webpack-loader-syntax'),
     },

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -362,6 +362,7 @@ function makeNewlinesBetweenReport (context, imported, newlinesBetweenImports) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('order'),
     },

--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -4,6 +4,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('prefer-default-export'),
     },

--- a/src/rules/unambiguous.js
+++ b/src/rules/unambiguous.js
@@ -8,6 +8,7 @@ import docsUrl from '../docsUrl'
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       url: docsUrl('unambiguous'),
     },


### PR DESCRIPTION
This PR fixes #1229 .

It adds `meta.type` for the rules. `meta.type` is added since ESLint 5.9.0 and described [here](https://eslint.org/docs/developer-guide/working-with-rules#rule-basics).