### PR TITLE
Added support for argv parameter of webpack`s config-as-a-function

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -47,6 +47,7 @@ exports.resolve = function (source, file, settings) {
   var configPath = get(settings, 'config')
     , configIndex = get(settings, 'config-index')
     , env = get(settings, 'env')
+    , argv = get(settings, 'argv', {})
     , packageDir
 
   log('Config path from settings:', configPath)
@@ -87,13 +88,13 @@ exports.resolve = function (source, file, settings) {
   }
 
   if (typeof webpackConfig === 'function') {
-    webpackConfig = webpackConfig(env, {})
+    webpackConfig = webpackConfig(env, argv)
   }
 
   if (Array.isArray(webpackConfig)) {
     webpackConfig = webpackConfig.map(cfg => {
       if (typeof cfg === 'function') {
-        return cfg(env, {})
+        return cfg(env, argv)
       }
 
       return cfg

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -114,4 +114,25 @@ describe("config", function () {
     expect(resolve('bar', file, settings)).to.have.property('path')
         .and.equal(path.join(__dirname, 'files', 'some', 'goofy', 'path', 'bar.js'))
   })
+
+  it('passes argv to config when it is a function', function() {
+    var settings = {
+      config: require(path.join(__dirname, './files/webpack.function.config.js')),
+      argv: {
+        mode: 'test'
+      }
+    }
+
+    expect(resolve('baz', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'some', 'bar', 'bar.js'))
+  })
+
+  it('passes a default empty argv object to config when it is a function', function() {
+    var settings = {
+      config: require(path.join(__dirname, './files/webpack.function.config.js')),
+      argv: undefined
+    }
+
+    expect(function () { resolve('baz', file, settings) }).to.not.throw(Error)
+  })
 })

--- a/resolvers/webpack/test/files/webpack.function.config.js
+++ b/resolvers/webpack/test/files/webpack.function.config.js
@@ -1,12 +1,13 @@
 var path = require('path')
 var pluginsTest = require('webpack-resolver-plugin-test')
 
-module.exports = function(env) {
+module.exports = function(env, argv) {
   return {
     resolve: {
       alias: {
         'foo': path.join(__dirname, 'some', 'goofy', 'path', 'foo.js'),
         'bar': env ? path.join(__dirname, 'some', 'goofy', 'path', 'bar.js') : undefined,
+        'baz': argv.mode === 'test' ? path.join(__dirname, 'some', 'bar', 'bar.js') : undefined,
         'some-alias': path.join(__dirname, 'some'),
       },
       modules: [


### PR DESCRIPTION
Some people may rely on the map of options passed to webpack (as I do), thus it would be nice to be able to provide this second parameter instead of just an empty object.