### PR TITLE
Fix #1266, make SourceCode only for no-deprecated rule

### DIFF
--- a/src/rules/no-deprecated.js
+++ b/src/rules/no-deprecated.js
@@ -31,7 +31,8 @@ module.exports = {
       if (node.type !== 'ImportDeclaration') return
       if (node.source == null) return // local export, ignore
 
-      const imports = Exports.get(node.source.value, context)
+      const options = {parseComments: true}
+      const imports = Exports.get(node.source.value, context, options)
       if (imports == null) return
 
       let moduleDeprecation

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -98,9 +98,10 @@ describe('ExportMap', function () {
       context('deprecated imports', function () {
         let imports
         before('parse file', function () {
-          const path = getFilename('deprecated.js')
-              , contents = fs.readFileSync(path, { encoding: 'utf8' })
-          imports = ExportMap.parse(path, contents, parseContext)
+          const path = getFilename('deprecated.js'),
+            contents = fs.readFileSync(path, {encoding: 'utf8'}),
+            options = {parseComments: true}
+          imports = ExportMap.parse(path, contents, parseContext, options)
 
           // sanity checks
           expect(imports.errors).to.be.empty
@@ -112,7 +113,7 @@ describe('ExportMap', function () {
           expect(imports.get('fn'))
             .to.have.deep.property('doc.tags[0].title', 'deprecated')
           expect(imports.get('fn'))
-            .to.have.deep.property('doc.tags[0].description', "please use 'x' instead.")
+            .to.have.deep.property('doc.tags[0].description', 'please use \'x\' instead.')
         })
 
         it('works with default imports.', function () {


### PR DESCRIPTION
Parsing source code allocates a lot of memory since `SourceCode` instances are built recursively for each node in the dependency graph:
https://github.com/benmosher/eslint-plugin-import/blob/1ec80fa35fa1819e2d35a70e68fb6a149fb57c5e/src/ExportMap.js#L349

`SourceCode` instance is only used to capture docs from leading comments that are actually used **only** for [no-deprecated](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-deprecated.md) rule:
https://github.com/benmosher/eslint-plugin-import/blob/1ec80fa35fa1819e2d35a70e68fb6a149fb57c5e/src/ExportMap.js#L417-L418

https://github.com/benmosher/eslint-plugin-import/blob/1ec80fa35fa1819e2d35a70e68fb6a149fb57c5e/src/ExportMap.js#L453-L454

https://github.com/benmosher/eslint-plugin-import/blob/1ec80fa35fa1819e2d35a70e68fb6a149fb57c5e/src/ExportMap.js#L456-L459

However, `SourceCode` instances are built even if [no-deprecated](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-deprecated.md) rule is turned off (btw the rule is in Stage 0 and is still work in progress). The PR prevents negative impact on other rules.

Here's memory consumption before/after PR for pretty large code base, [no-deprecated](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-deprecated.md) rule is disabled for both cases:

![image](https://user-images.githubusercontent.com/748074/51806854-108fb800-2290-11e9-9a31-90218b9d55f8.png)


The 1st process failed with `heap out of memory` error.