### PR TITLE
Patch to create version 2.13.1 to fix breaking dependency after eslint-module-utils ~2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+## [2.13.1] - 2019-01-28
+### Fixed
+- [Issue #1269](https://github.com/benmosher/eslint-plugin-import/issues/1269) a breaking change to `eslint-module-utils` version `2.3.0` is now reflected in `package.json` dependencies.
+
+
 
 ## [2.13.0] - 2018-06-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
-## [2.13.1] - 2019-01-28
+## [2.13.X] - 2019-01-XX
 ### Fixed
 - [Issue #1269](https://github.com/benmosher/eslint-plugin-import/issues/1269) a breaking change to `eslint-module-utils` version `2.3.0` is now reflected in `package.json` dependencies.
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "debug": "^2.6.8",
     "doctrine": "1.5.0",
     "eslint-import-resolver-node": "^0.3.1",
-    "eslint-module-utils": "^2.2.0",
+    "eslint-module-utils": "~2.2.0",
     "has": "^1.0.1",
     "lodash": "^4.17.4",
     "minimatch": "^3.0.3",


### PR DESCRIPTION
See issue #1269 