### PR TITLE
[resolvers/webpack] [breaking] Allow to resolve config path relative to working directory

### DIFF
--- a/resolvers/webpack/README.md
+++ b/resolvers/webpack/README.md
@@ -42,7 +42,7 @@ settings:
       config: 'webpack.dev.config.js'
 ```
 
-or with explicit config file name:
+or with explicit config file index:
 
 ```yaml
 ---
@@ -51,6 +51,16 @@ settings:
     webpack:
       config: 'webpack.multiple.config.js'
       config-index: 1   # take the config at index 1
+```
+
+or with explicit config file path relative to your projects's working directory:
+
+```yaml
+---
+settings:
+  import/resolver:
+    webpack:
+      config: './configs/webpack.dev.config.js'
 ```
 
 or with explicit config object:

--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -48,7 +48,7 @@ exports.resolve = function (source, file, settings) {
 
   var webpackConfig
 
-  var configPath = get(settings, 'config')
+  var _configPath = get(settings, 'config')
     /**
      * Attempt to set the current working directory.
      * If none is passed, default to the `cwd` where the config is located.
@@ -58,6 +58,10 @@ exports.resolve = function (source, file, settings) {
     , env = get(settings, 'env')
     , argv = get(settings, 'argv', {})
     , packageDir
+
+  var configPath = typeof _configPath === 'string' && _configPath.startsWith('.')
+    ? path.resolve(_configPath)
+    : _configPath
 
   log('Config path from settings:', configPath)
 

--- a/resolvers/webpack/test/config.js
+++ b/resolvers/webpack/test/config.js
@@ -72,6 +72,14 @@ describe("config", function () {
         .and.equal(path.join(__dirname, 'files', 'some', 'absolutely', 'goofy', 'path', 'foo.js'))
   })
 
+  it("finds config object when config uses a path relative to working dir", function () {
+    var settings = {
+      config: './test/files/some/absolute.path.webpack.config.js',
+    }
+    expect(resolve('foo', file, settings)).to.have.property('path')
+        .and.equal(path.join(__dirname, 'files', 'some', 'absolutely', 'goofy', 'path', 'foo.js'))
+  })
+
   it("finds the first config with a resolve section when config is an array of config objects", function () {
     var settings = {
       config: require(path.join(__dirname, './files/webpack.config.multiple.js')),


### PR DESCRIPTION
**note**: We should probably increment major version, because it'll change the behavior a configPath starting with '.' (in a more 'expected' way, but still different, https://github.com/caub/eslint-import-resolver-webpack-bug demonstrates this)