### PR TITLE
No useless index in import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ in which case it is specified as `['.js', '.jsx']`.
 
 ```js
 "settings": {
+  "import/extensions": [
+    ".js",
+    ".jsx"
+  ]
+}
+```
+
+If you require more granular extension definitions, you can use:
+
+```js
+"settings": {
   "import/resolver": {
     "node": {
       "extensions": [

--- a/docs/rules/no-useless-path-segments.md
+++ b/docs/rules/no-useless-path-segments.md
@@ -11,6 +11,9 @@ my-project
 ├── app.js
 ├── footer.js
 ├── header.js
+└── helpers.js
+└── helpers
+    └── index.js
 └── pages
     ├── about.js
     ├── contact.js
@@ -30,6 +33,8 @@ import "../pages/about.js"; // should be "./pages/about.js"
 import "../pages/about"; // should be "./pages/about"
 import "./pages//about"; // should be "./pages/about"
 import "./pages/"; // should be "./pages"
+import "./pages/index"; // should be "./pages" (except if there is a ./pages.js file)
+import "./pages/index.js"; // should be "./pages" (except if there is a ./pages.js file)
 ```
 
 The following patterns are NOT considered problems:
@@ -46,3 +51,25 @@ import ".";
 import "..";
 import fs from "fs";
 ```
+
+## Options
+
+### noUselessIndex
+
+If you want to detect unnecessary `/index` or `/index.js` (depending on the specified file extensions, see below) imports in your paths, you can enable the option `noUselessIndex`. By default it is set to `false`:
+```js
+"import/no-useless-path-segments": ["error", {
+  noUselessIndex: true,
+}]
+```
+
+Additionally to the patterns described above, the following imports are considered problems if `noUselessIndex` is enabled:
+
+```js
+// in my-project/app.js
+import "./helpers/index"; // should be "./helpers/" (not auto-fixable to `./helpers` because this would lead to an ambiguous import of `./helpers.js` and `./helpers/index.js`)
+import "./pages/index"; // should be "./pages" (auto-fixable)
+import "./pages/index.js"; // should be "./pages" (auto-fixable)
+```
+
+Note: `noUselessIndex` only avoids ambiguous imports for `.js` files if you haven't specified other resolved file extensions. See [Settings: import/extensions](https://github.com/benmosher/eslint-plugin-import#importextensions) for details.

--- a/tests/src/core/ignore.js
+++ b/tests/src/core/ignore.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 
-import isIgnored, { hasValidExtension } from 'eslint-module-utils/ignore'
+import isIgnored, { getFileExtensions, hasValidExtension } from 'eslint-module-utils/ignore'
 
 import * as utils from '../utils'
 
@@ -55,4 +55,36 @@ describe('ignore', function () {
     })
   })
 
+  describe('getFileExtensions', function () {
+    it('returns a set with the file extension ".js" if "import/extensions" is not configured', function () {
+      const fileExtensions = getFileExtensions({})
+
+      expect(fileExtensions).to.include('.js')
+    })
+
+    it('returns a set with the file extensions configured in "import/extension"', function () {
+      const settings = {
+        'import/extensions': ['.js', '.jsx'],
+      }
+
+      const fileExtensions = getFileExtensions(settings)
+
+      expect(fileExtensions).to.include('.js')
+      expect(fileExtensions).to.include('.jsx')
+    })
+
+    it('returns a set with the file extensions configured in "import/extension" and "import/parsers"', function () {
+      const settings = {
+        'import/parsers': {
+          'typescript-eslint-parser': ['.ts', '.tsx'],
+        },
+      }
+
+      const fileExtensions = getFileExtensions(settings)
+
+      expect(fileExtensions).to.include('.js') // If "import/extensions" is not configured, this is the default
+      expect(fileExtensions).to.include('.ts')
+      expect(fileExtensions).to.include('.tsx')
+    })
+  })
 })

--- a/tests/src/rules/no-useless-path-segments.js
+++ b/tests/src/rules/no-useless-path-segments.js
@@ -7,20 +7,31 @@ const rule = require('rules/no-useless-path-segments')
 function runResolverTests(resolver) {
   ruleTester.run(`no-useless-path-segments (${resolver})`, rule, {
     valid: [
-      // commonjs with default options
+      // CommonJS modules with default options
       test({ code: 'require("./../files/malformed.js")' }),
 
-      // esmodule
+      // ES modules with default options
       test({ code: 'import "./malformed.js"' }),
       test({ code: 'import "./test-module"' }),
       test({ code: 'import "./bar/"' }),
       test({ code: 'import "."' }),
       test({ code: 'import ".."' }),
       test({ code: 'import fs from "fs"' }),
+      test({ code: 'import fs from "fs"' }),
+
+      // ES modules + noUselessIndex
+      test({ code: 'import "../index"' }), // noUselessIndex is false by default
+      test({ code: 'import "../my-custom-index"', options: [{ noUselessIndex: true }] }),
+      test({ code: 'import "./bar.js"', options: [{ noUselessIndex: true }] }), // ./bar/index.js exists
+      test({ code: 'import "./bar"', options: [{ noUselessIndex: true }] }),
+      test({ code: 'import "./bar/"', options: [{ noUselessIndex: true }] }), // ./bar.js exists
+      test({ code: 'import "./malformed.js"', options: [{ noUselessIndex: true }] }), // ./malformed directory does not exist
+      test({ code: 'import "./malformed"', options: [{ noUselessIndex: true }] }), // ./malformed directory does not exist
+      test({ code: 'import "./importType"', options: [{ noUselessIndex: true }] }), // ./importType.js does not exist
     ],
 
     invalid: [
-      // commonjs
+      // CommonJS modules
       test({
         code: 'require("./../files/malformed.js")',
         options: [{ commonjs: true }],
@@ -62,7 +73,49 @@ function runResolverTests(resolver) {
         errors: [ 'Useless path segments for "./deep//a", should be "./deep/a"'],
       }),
 
-      // esmodule
+      // CommonJS modules + noUselessIndex
+      test({
+        code: 'require("./bar/index.js")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "./bar/index.js", should be "./bar/"'], // ./bar.js exists
+      }),
+      test({
+        code: 'require("./bar/index")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "./bar/index", should be "./bar/"'], // ./bar.js exists
+      }),
+      test({
+        code: 'require("./importPath/")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "./importPath/", should be "./importPath"'], // ./importPath.js does not exist
+      }),
+      test({
+        code: 'require("./importPath/index.js")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "./importPath/index.js", should be "./importPath"'], // ./importPath.js does not exist
+      }),
+      test({
+        code: 'require("./importType/index")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "./importType/index", should be "./importType"'], // ./importPath.js does not exist
+      }),
+      test({
+        code: 'require("./index")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "./index", should be "."'],
+      }),
+      test({
+        code: 'require("../index")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "../index", should be ".."'],
+      }),
+      test({
+        code: 'require("../index.js")',
+        options: [{ commonjs: true, noUselessIndex: true }],
+        errors: ['Useless path segments for "../index.js", should be ".."'],
+      }),
+
+      // ES modules
       test({
         code: 'import "./../files/malformed.js"',
         errors: [ 'Useless path segments for "./../files/malformed.js", should be "../files/malformed.js"'],
@@ -95,8 +148,50 @@ function runResolverTests(resolver) {
         code: 'import "./deep//a"',
         errors: [ 'Useless path segments for "./deep//a", should be "./deep/a"'],
       }),
-     ],
-   })
+
+      // ES modules + noUselessIndex
+      test({
+        code: 'import "./bar/index.js"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "./bar/index.js", should be "./bar/"'], // ./bar.js exists
+      }),
+      test({
+        code: 'import "./bar/index"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "./bar/index", should be "./bar/"'], // ./bar.js exists
+      }),
+      test({
+        code: 'import "./importPath/"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "./importPath/", should be "./importPath"'], // ./importPath.js does not exist
+      }),
+      test({
+        code: 'import "./importPath/index.js"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "./importPath/index.js", should be "./importPath"'], // ./importPath.js does not exist
+      }),
+      test({
+        code: 'import "./importPath/index"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "./importPath/index", should be "./importPath"'], // ./importPath.js does not exist
+      }),
+      test({
+        code: 'import "./index"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "./index", should be "."'],
+      }),
+      test({
+        code: 'import "../index"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "../index", should be ".."'],
+      }),
+      test({
+        code: 'import "../index.js"',
+        options: [{ noUselessIndex: true }],
+        errors: ['Useless path segments for "../index.js", should be ".."'],
+      }),
+    ],
+  })
 }
 
 ['node', 'webpack'].forEach(runResolverTests)

--- a/utils/ignore.js
+++ b/utils/ignore.js
@@ -34,6 +34,7 @@ function makeValidExtensionSet(settings) {
 
   return exts
 }
+exports.getFileExtensions = makeValidExtensionSet
 
 exports.default = function ignore(path, context) {
   // check extension whitelist first (cheap)


### PR DESCRIPTION
As discussed in #394, this PR adds an option `noUselessIndex` to detect (and fix) paths containing unnecessary `index` parts (with or without file extension):

Given the following file structure:
```
my-project
├── foo.js
└── foo
    └── index.js
└── bar
    └── index.js
```

Before:
```
import 'foo/index' // No warning
import 'bar/index' // No warning
```

After:
```
import './foo/index.js' // Warning (fixable to `./foo/`)
import './foo/index' // Warning (fixable to `./foo/`)
import './bar/index' // Warning (fixable to `./bar`)
```

#### Implementation detail:
I've replaced the `sumBy` function with `reduce` to get rid of Lodash (not necessary in this case IMO). A benchmark which compares these 2 alternatives shows no difference between them or a slight advantage for `reduce`: https://www.measurethat.net/Benchmarks/ShowResult/46787

Fixes #394.