### PR TITLE
closes #1293. allows aliases that start with @ to be caught as internal

### DIFF
--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -57,7 +57,8 @@ export function isScopedMain(name) {
 }
 
 function isInternalModule(name, settings, path) {
-  return externalModuleRegExp.test(name) && !isExternalPath(path, name, settings)
+  const matchesScopedOrExternalRegExp = scopedRegExp.test(name) || externalModuleRegExp.test(name)
+  return (matchesScopedOrExternalRegExp && !isExternalPath(path, name, settings))
 }
 
 function isRelativeToParent(name) {
@@ -76,9 +77,9 @@ function isRelativeToSibling(name) {
 const typeTest = cond([
   [isAbsolute, constant('absolute')],
   [isBuiltIn, constant('builtin')],
+  [isInternalModule, constant('internal')],
   [isExternalModule, constant('external')],
   [isScoped, constant('external')],
-  [isInternalModule, constant('internal')],
   [isRelativeToParent, constant('parent')],
   [isIndex, constant('index')],
   [isRelativeToSibling, constant('sibling')],

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -50,6 +50,11 @@ describe('importType(name)', function () {
     const pathContext = testContext({ "import/resolver": { node: { paths: [ path.join(__dirname, '..', '..', 'files') ] } } })
     expect(importType('@importType/index', pathContext)).to.equal('internal')
   })
+    
+  it("should return 'internal' for internal modules that are referenced by aliases", function () {
+    const pathContext = testContext({ 'import/resolver': { node: { paths: [path.join(__dirname, '..', '..', 'files')] } } })
+    expect(importType('@my-alias/fn', pathContext)).to.equal('internal')
+  })
 
   it("should return 'parent' for internal modules that go through the parent", function() {
     expect(importType('../foo', context)).to.equal('parent')


### PR DESCRIPTION
@ljharb as we talked about in the issue, here is the fix. Please let me know if there are any issues. Or if you think we need more tests for this case. I added one. There were already a ton that didn't pass and didn't think I should fix them in this PR.

Fixes #1293. Unblocked by #1295.