### PR TITLE
fix a bunch of tests that were failing

### DIFF
--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -90,16 +90,16 @@ describe('importType(name)', function () {
   })
 
   it("should return 'external' for module from 'node_modules' with default config", function() {
-    expect(importType('builtin-modules', context)).to.equal('external')
+    expect(importType('resolve', context)).to.equal('external')
   })
 
   it("should return 'internal' for module from 'node_modules' if 'node_modules' missed in 'external-module-folders'", function() {
     const foldersContext = testContext({ 'import/external-module-folders': [] })
-    expect(importType('builtin-modules', foldersContext)).to.equal('internal')
+    expect(importType('resolve', foldersContext)).to.equal('internal')
   })
 
   it("should return 'external' for module from 'node_modules' if 'node_modules' contained in 'external-module-folders'", function() {
     const foldersContext = testContext({ 'import/external-module-folders': ['node_modules'] })
-    expect(importType('builtin-modules', foldersContext)).to.equal('external')
+    expect(importType('resolve', foldersContext)).to.equal('external')
   })
 })

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -17,8 +17,8 @@ ruleTester.run('export', rule, {
     test({ code: 'export var [ foo, bar ] = array;' }),
     test({ code: 'export var { foo, bar } = object;' }),
     test({ code: 'export var [ foo, bar ] = array;' }),
-    test({ code: 'export { foo, foo as bar }' }),
-    test({ code: 'export { bar }; export * from "./export-all"' }),
+    test({ code: 'let foo; export { foo, foo as bar }' }),
+    test({ code: 'let bar; export { bar }; export * from "./export-all"' }),
     test({ code: 'export * from "./export-all"' }),
     test({ code: 'export * from "./does-not-exist"' }),
 
@@ -62,7 +62,7 @@ ruleTester.run('export', rule, {
     //   errors: ['Parsing error: Duplicate export \'foo\''],
     // }),
     test({
-      code: 'export { foo }; export * from "./export-all"',
+      code: 'let foo; export { foo }; export * from "./export-all"',
       errors: ['Multiple exports of name \'foo\'.',
                'Multiple exports of name \'foo\'.'],
     }),

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -105,14 +105,14 @@ ruleTester.run('extensions', rule, {
     test({
       code: [
         'export { foo } from "./foo.js"',
-        'export { bar }',
+        'let bar; export { bar }',
       ].join('\n'),
       options: [ 'always' ],
     }),
     test({
       code: [
         'export { foo } from "./foo"',
-        'export { bar }',
+        'let bar; export { bar }',
       ].join('\n'),
       options: [ 'never' ],
     }),
@@ -334,7 +334,7 @@ ruleTester.run('extensions', rule, {
     test({
       code: [
         'export { foo } from "./foo"',
-        'export { bar }',
+        'let bar; export { bar }',
       ].join('\n'),
       options: [ 'always' ],
       errors: [
@@ -348,7 +348,7 @@ ruleTester.run('extensions', rule, {
     test({
       code: [
         'export { foo } from "./foo.js"',
-        'export { bar }',
+        'let bar; export { bar }',
       ].join('\n'),
       options: [ 'never' ],
       errors: [

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -61,7 +61,7 @@ ruleTester.run('named', rule, {
     }),
 
     // regression tests
-    test({ code: 'export { foo as bar }'}),
+    test({ code: 'let foo; export { foo as bar }'}),
 
     // destructured exports
     test({ code: 'import { destructuredProp } from "./named-exports"' }),

--- a/tests/src/rules/no-default-export.js
+++ b/tests/src/rules/no-default-export.js
@@ -29,7 +29,7 @@ ruleTester.run('no-default-export', rule, {
       `,
     }),
     test({
-      code: `export { foo, bar }`,
+      code: `let foo, bar; export { foo, bar }`,
     }),
     test({
       code: `export const { foo, bar } = item;`,
@@ -42,6 +42,7 @@ ruleTester.run('no-default-export', rule, {
     }),
     test({
       code: `
+        let item;
         export const foo = item;
         export { item };
       `,
@@ -102,7 +103,7 @@ ruleTester.run('no-default-export', rule, {
       }],
     }),
     test({
-      code: 'export { foo as default }',
+      code: 'let foo; export { foo as default }',
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Do not alias `foo` as `default`. Just export `foo` itself ' +

--- a/tests/src/rules/no-named-export.js
+++ b/tests/src/rules/no-named-export.js
@@ -10,7 +10,7 @@ ruleTester.run('no-named-export', rule, {
       code: 'export default function bar() {};',
     }),
     test({
-      code: 'export { foo as default }',
+      code: 'let foo; export { foo as default }',
     }),
     test({
       code: 'export default from "foo.js"',
@@ -82,7 +82,7 @@ ruleTester.run('no-named-export', rule, {
       }],
     }),
     test({
-      code: `export { foo, bar }`,
+      code: `let foo, bar; export { foo, bar }`,
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
@@ -111,6 +111,7 @@ ruleTester.run('no-named-export', rule, {
     }),
     test({
       code: `
+        let item;
         export const foo = item;
         export { item };
       `,

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -34,7 +34,7 @@ function runResolverTests(resolver) {
 
       rest({ code: 'export { foo } from "./bar"' }),
       rest({ code: 'export * from "./bar"' }),
-      rest({ code: 'export { foo }' }),
+      rest({ code: 'let foo; export { foo }' }),
 
       // stage 1 proposal for export symmetry,
       rest({ code: 'export * as bar from "./bar"'

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -28,6 +28,7 @@ ruleTester.run('prefer-default-export', rule, {
       }),
     test({
       code: `
+        let foo, bar;
         export { foo, bar }`,
       }),
     test({
@@ -44,11 +45,13 @@ ruleTester.run('prefer-default-export', rule, {
       }),
     test({
       code: `
+        let item;
         export const foo = item;
         export { item };`,
       }),
     test({
       code: `
+        let foo;
         export { foo as default }`,
       }),
     test({

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -43,8 +43,8 @@ export const SYNTAX_CASES = [
   test({ code: 'const { x, y, ...z } = bar', parser: 'babel-eslint' }),
 
   // all the exports
-  test({ code: 'export { x }' }),
-  test({ code: 'export { x as y }' }),
+  test({ code: 'let x; export { x }' }),
+  test({ code: 'let x; export { x as y }' }),
 
   // not sure about these since they reference a file
   // test({ code: 'export { x } from "./y.js"'}),


### PR DESCRIPTION
@ljharb I went took a look at the tests that were failing. seemed like all but one of them existed because there were exports for things that didn't exist, i.e. `export { bar}`, when `bar` isn't defined. 

There is one test currently failing. However, after reading it, I think it should be deleted because what it says isn't true. The test reads: `should return 'internal' for module from 'node_modules' if 'node_modules' missed in 'external-module-folders'. However, the check for isExternalPath checks whether or not the `path` argument is falsy. If it is falsy, or if it is found in the import/external-module-folders, then it returns true. In the case of that test, the path is undefined (because that file doesn't exist), and therefore the test is failing.