### PR TITLE
fix: aliased internal modules that look like core modules

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -38,10 +38,6 @@ exports.resolve = function (source, file, settings) {
     source = source.slice(0, finalQuestionMark)
   }
 
-  if (source in coreLibs) {
-    return { found: true, path: coreLibs[source] }
-  }
-
   var webpackConfig
 
   var configPath = get(settings, 'config')
@@ -73,7 +69,7 @@ exports.resolve = function (source, file, settings) {
           throw e
         }
       } else {
-        log("No config path found relative to", file, "; using {}")
+        log('No config path found relative to', file, '; using {}')
         webpackConfig = {}
       }
 
@@ -123,6 +119,10 @@ exports.resolve = function (source, file, settings) {
   try {
     return { found: true, path: resolveSync(path.dirname(file), source) }
   } catch (err) {
+    if (source in coreLibs) {
+      return { found: true, path: coreLibs[source] }
+    }
+
     log('Error during module resolution:', err)
     return { found: false }
   }
@@ -136,7 +136,7 @@ function getResolveSync(configPath, webpackConfig) {
   if (!cached) {
     cached = {
       key: cacheKey,
-      value: createResolveSync(configPath, webpackConfig)
+      value: createResolveSync(configPath, webpackConfig),
     }
     // put in front and pop last item
     if (_cache.unshift(cached) > MAX_CACHE) {

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -21,7 +21,9 @@ export function isAbsolute(name) {
   return name.indexOf('/') === 0
 }
 
-export function isBuiltIn(name, settings) {
+// path is defined only when a resolver resolves to a non-standard path
+export function isBuiltIn(name, settings, path) {
+  if (path) return false
   const base = baseModule(name)
   const extras = (settings && settings['import/core-modules']) || []
   return coreModules[base] || extras.indexOf(base) > -1

--- a/tests/files/constants/index.js
+++ b/tests/files/constants/index.js
@@ -1,0 +1,1 @@
+export const FOO = 'FOO'

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -70,8 +70,7 @@ describe('importType(name)', function () {
     const pathContext = testContext({ 'import/resolver': { webpack: { config: webpackConfig } } })
     expect(importType('constants/index', pathContext)).to.equal('internal')
     expect(importType('constants/', pathContext)).to.equal('internal')
-    // the following assertion fails because the webpack resolver runs an resolve.isCore('constants') without first checking paths config
-    // expect(importType('constants', pathContext)).to.equal('internal')
+    expect(importType('constants', pathContext)).to.equal('internal')
   })
 
   it("should return 'parent' for internal modules that go through the parent", function() {

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -7,6 +7,7 @@ import { testContext } from '../utils'
 
 describe('importType(name)', function () {
   const context = testContext()
+  const pathToTestFiles = path.join(__dirname, '..', '..', 'files')
 
   it("should return 'absolute' for paths starting with a /", function() {
     expect(importType('/', context)).to.equal('absolute')
@@ -42,18 +43,35 @@ describe('importType(name)', function () {
   })
 
   it("should return 'internal' for non-builtins resolved outside of node_modules", function () {
-    const pathContext = testContext({ "import/resolver": { node: { paths: [ path.join(__dirname, '..', '..', 'files') ] } } })
+    const pathContext = testContext({ "import/resolver": { node: { paths: [pathToTestFiles] } } })
     expect(importType('importType', pathContext)).to.equal('internal')
   })
 
   it.skip("should return 'internal' for scoped packages resolved outside of node_modules", function () {
-    const pathContext = testContext({ "import/resolver": { node: { paths: [ path.join(__dirname, '..', '..', 'files') ] } } })
+    const pathContext = testContext({ "import/resolver": { node: { paths: [pathToTestFiles] } } })
     expect(importType('@importType/index', pathContext)).to.equal('internal')
   })
     
   it("should return 'internal' for internal modules that are referenced by aliases", function () {
-    const pathContext = testContext({ 'import/resolver': { node: { paths: [path.join(__dirname, '..', '..', 'files')] } } })
+    const pathContext = testContext({ 'import/resolver': { node: { paths: [pathToTestFiles] } } })
     expect(importType('@my-alias/fn', pathContext)).to.equal('internal')
+  })
+
+  it("should return 'internal' for aliased internal modules that look like core modules (node resolver)", function () {
+    const pathContext = testContext({ 'import/resolver': { node: { paths: [pathToTestFiles] } } })
+    expect(importType('constants/index', pathContext)).to.equal('internal')
+    expect(importType('constants/', pathContext)).to.equal('internal')
+    // resolves exact core modules over internal modules
+    expect(importType('constants', pathContext)).to.equal('builtin')
+  })
+
+  it("should return 'internal' for aliased internal modules that look like core modules (webpack resolver)", function () {
+    const webpackConfig = { resolve: { modules: [pathToTestFiles, 'node_modules'] } }
+    const pathContext = testContext({ 'import/resolver': { webpack: { config: webpackConfig } } })
+    expect(importType('constants/index', pathContext)).to.equal('internal')
+    expect(importType('constants/', pathContext)).to.equal('internal')
+    // the following assertion fails because the webpack resolver runs an resolve.isCore('constants') without first checking paths config
+    // expect(importType('constants', pathContext)).to.equal('internal')
   })
 
   it("should return 'parent' for internal modules that go through the parent", function() {


### PR DESCRIPTION
## What

Update `isBuiltIn` to return `false` if a path is returned from a resolver. 
Previously an alias like 'constants/foo' would be classified as a builtin rather than internal since 'constants' is a core module of node. Fixes one of the issues mentioned in #1034.

Update webpack resolver to attempt to resolve modules internally before classifying them as builtin.

Add several tests to cover these cases.

## Example

```
project
└── src
    └── constants
        └── index.js
```

```json
{
  "settings": {
    "import/resolver": {
      "node": {
        "paths": ["/project/src"]
      }
    }
  }
}
```

Result:

```js
// BEFORE
import { FOO } from 'constants/index'
import { isObject } from 'lodash'

// AFTER
import { isObject } from 'lodash'
import { FOO } from 'constants/index'
```