### PR TITLE
fix(export): Support typescript namespaces

### DIFF
--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -2,6 +2,28 @@ import ExportMap, { recursivePatternCapture } from '../ExportMap'
 import docsUrl from '../docsUrl'
 import includes from 'array-includes'
 
+/*
+Notes on Typescript namespaces aka TSModuleDeclaration:
+
+There are two forms:
+- active namespaces: namespace Foo {} / module Foo {}
+- ambient modules; declare module "eslint-plugin-import" {}
+
+active namespaces:
+- cannot contain a default export
+- cannot contain an export all
+- cannot contain a multi name export (export { a, b })
+- can have active namespaces nested within them
+
+ambient namespaces:
+- can only be defined in .d.ts files
+- cannot be nested within active namespaces
+- have no other restrictions
+*/
+
+const rootProgram = 'root'
+const tsTypePrefix = 'type:'
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -11,10 +33,15 @@ module.exports = {
   },
 
   create: function (context) {
-    const named = new Map()
+    const namespace = new Map([[rootProgram, new Map()]])
 
-    function addNamed(name, node, type) {
-      const key = type ? `${type}:${name}` : name
+    function addNamed(name, node, parent, isType) {
+      if (!namespace.has(parent)) {
+        namespace.set(parent, new Map())
+      }
+      const named = namespace.get(parent)
+
+      const key = isType ? `${tsTypePrefix}${name}` : name
       let nodes = named.get(key)
 
       if (nodes == null) {
@@ -25,30 +52,43 @@ module.exports = {
       nodes.add(node)
     }
 
-    return {
-      'ExportDefaultDeclaration': (node) => addNamed('default', node),
+    function getParent(node) {
+      if (node.parent && node.parent.type === 'TSModuleBlock') {
+        return node.parent.parent
+      }
 
-      'ExportSpecifier': function (node) {
-        addNamed(node.exported.name, node.exported)
-      },
+      // just in case somehow a non-ts namespace export declaration isn't directly
+      // parented to the root Program node
+      return rootProgram
+    }
+
+    return {
+      'ExportDefaultDeclaration': (node) => addNamed('default', node, getParent(node)),
+
+      'ExportSpecifier': (node) => addNamed(node.exported.name, node.exported, getParent(node)),
 
       'ExportNamedDeclaration': function (node) {
         if (node.declaration == null) return
+
+        const parent = getParent(node)
+        // support for old typescript versions
+        const isTypeVariableDecl = node.declaration.kind === 'type'
 
         if (node.declaration.id != null) {
           if (includes([
             'TSTypeAliasDeclaration',
             'TSInterfaceDeclaration',
           ], node.declaration.type)) {
-            addNamed(node.declaration.id.name, node.declaration.id, 'type')
+            addNamed(node.declaration.id.name, node.declaration.id, parent, true)
           } else {
-            addNamed(node.declaration.id.name, node.declaration.id)
+            addNamed(node.declaration.id.name, node.declaration.id, parent, isTypeVariableDecl)
           }
         }
 
         if (node.declaration.declarations != null) {
           for (let declaration of node.declaration.declarations) {
-            recursivePatternCapture(declaration.id, v => addNamed(v.name, v))
+            recursivePatternCapture(declaration.id, v =>
+              addNamed(v.name, v, parent, isTypeVariableDecl))
           }
         }
       },
@@ -63,11 +103,14 @@ module.exports = {
           remoteExports.reportErrors(context, node)
           return
         }
+
+        const parent = getParent(node)
+
         let any = false
         remoteExports.forEach((v, name) =>
           name !== 'default' &&
           (any = true) && // poor man's filter
-          addNamed(name, node))
+          addNamed(name, node, parent))
 
         if (!any) {
           context.report(node.source,
@@ -76,13 +119,20 @@ module.exports = {
       },
 
       'Program:exit': function () {
-        for (let [name, nodes] of named) {
-          if (nodes.size <= 1) continue
+        for (let [, named] of namespace) {
+          for (let [name, nodes] of named) {
+            if (nodes.size <= 1) continue
 
-          for (let node of nodes) {
-            if (name === 'default') {
-              context.report(node, 'Multiple default exports.')
-            } else context.report(node, `Multiple exports of name '${name}'.`)
+            for (let node of nodes) {
+              if (name === 'default') {
+                context.report(node, 'Multiple default exports.')
+              } else {
+                context.report(
+                  node,
+                  `Multiple exports of name '${name.replace(tsTypePrefix, '')}'.`
+                )
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Fixes #1300

- Added nested export scope support
- Fixed broken test on ESLint v3 caused by old typescript parser