### PR TITLE
no-unused-modules: make sure that rule with no options will not fail 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "memo-parser"
   ],
   "scripts": {
-    "watch": "cross-env NODE_PATH=./src mocha --watch --compilers js:babel-register --recursive tests/src",
+    "watch": "npm run mocha -- --watch tests/src",
     "pretest": "linklocal",
     "posttest": "eslint ./src",
-    "test": "cross-env BABEL_ENV=test NODE_PATH=./src nyc -s mocha -R dot --recursive tests/src -t 5s",
+    "mocha": "cross-env BABEL_ENV=test NODE_PATH=./src nyc -s mocha -R dot --recursive -t 5s",
+    "test": "npm run mocha tests/src",
     "test-compiled": "npm run prepublish && NODE_PATH=./lib mocha --compilers js:babel-register --recursive tests/src",
     "test-all": "npm test && for resolver in ./resolvers/*; do cd $resolver && npm test && cd ../..; done",
     "prepublish": "gulp prepublish",

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -261,7 +261,7 @@ module.exports = {
       ignoreExports = [],
       missingExports,
       unusedExports,
-    } = context.options[0]
+    } = context.options[0] || {}
 
     if (unusedExports && !preparationDone) {
       doPreparation(src, ignoreExports, context)

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -22,6 +22,7 @@ const unusedExportsOptions = [{
 // tests for missing exports
 ruleTester.run('no-unused-modules', rule, {
   valid: [
+    test({ code: 'export default function noOptions() {}' }),
     test({ options: missingExportsOptions,
            code: 'export default () => 1'}),
     test({ options: missingExportsOptions,


### PR DESCRIPTION
Currently rule is failing in console, if no options are provided, but none of them is required, as `src` has preset fallback for it, other params are optional (even though without setting `missingExports` or `unusedExports`, to true this rule is not really used). 