### PR TITLE
[fix] `no-unused-modules`: make `import { name as otherName }` work

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -405,7 +405,7 @@ ExportMap.parse = function (path, content, context) {
           importedSpecifiers.add(specifier.type)
         }
         if (specifier.type === 'ImportSpecifier') {
-          importedSpecifiers.add(specifier.local.name)
+          importedSpecifiers.add(specifier.imported.name)
         }
       })
     }

--- a/tests/files/no-unused-modules/file-h.js
+++ b/tests/files/no-unused-modules/file-h.js
@@ -4,4 +4,6 @@ function h2() {
   return 3
 }
 
-export { h1, h2 }
+const h3 = true
+
+export { h1, h2, h3 }

--- a/tests/files/no-unused-modules/file-p.js
+++ b/tests/files/no-unused-modules/file-p.js
@@ -1,0 +1,1 @@
+import { h3 as h0 } from './file-h'

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -118,7 +118,7 @@ ruleTester.run('no-unused-modules', rule, {
            filename: testFilePath('./no-unused-modules/file-g.js'),
            errors: [error(`exported declaration 'g' not used within other modules`)]}),
     test({ options: unusedExportsOptions,
-           code: 'const h1 = 3; function h2() { return 3 }; export { h1, h2 }',
+           code: 'const h1 = 3; function h2() { return 3 }; const h3 = true; export { h1, h2, h3 }',
            filename: testFilePath('./no-unused-modules/file-h.js'),
            errors: [error(`exported declaration 'h1' not used within other modules`)]}),
     test({ options: unusedExportsOptions,


### PR DESCRIPTION
Fixes #1339, part 2