### PR TITLE
Support CommonJS in Extensions

### DIFF
--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -36,6 +36,26 @@ By providing both a string and an object, the string will set the default settin
 
 For example, `["error", "never", { "svg": "always" }]` would require that all extensions are omitted, except for "svg".
 
+### Options
+
+By default, only ES6 imports will be resolved:
+
+```js
+/*eslint import/extensions: 2*/
+import x from './foo' // reports Missing file extension "js" for "./foo"
+
+import x from './foo.js' // no problem
+```
+
+If `{commonjs: true}` is provided, `require` calls will be resolved:
+
+```js
+/*eslint import/extensions: [2, { commonjs: true }]*/
+const x = require('./foo') // reports Missing file extension "js" for "./foo"
+
+const x = require('./foo.js') // no problem
+```
+
 ### Exception
 
 When disallowing the use of certain extensions this rule makes an exception and allows the use of extension when the file would not be resolvable without extension.

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -116,6 +116,26 @@ ruleTester.run('extensions', rule, {
       ].join('\n'),
       options: [ 'never' ],
     }),
+
+    test({
+      code: `
+        const foo = require('./foo.js')
+        const bar = require('./bar.json')
+        const Component = require('./Component.jsx')
+        const express = require('express')
+      `,
+      options: [ 'always', {commonjs: true, ignorePackages: true} ],
+    }),
+
+    test({
+      code: `
+        const foo = require('./foo')
+        const bar = require('./bar')
+        const Component = require('./Component')
+        const express = require('express')
+      `,
+      options: [ 'never', {commonjs: true, ignorePackages: true} ],
+    }),
   ],
 
   invalid: [
@@ -358,6 +378,49 @@ ruleTester.run('extensions', rule, {
           column: 21,
         },
       ],
+    }),
+
+    test({
+      code: `
+        const foo = require('./foo.js')
+        const bar = require('./bar.json')
+        const Component = require('./Component')
+        const baz = require('foo/baz')
+        const express = require('express')
+      `,
+      options: [ 'always', {commonjs: true, ignorePackages: true} ],
+      errors: [
+        {
+          message: 'Missing file extension for "./Component"',
+          line: 4,
+          column: 27,
+        }, {
+          message: 'Missing file extension for "foo/baz"',
+          line: 5,
+          column: 21,
+        },
+      ],
+    }),
+
+    test({
+      code: `
+        const foo = require('./foo.js')
+        const bar = require('./bar.json')
+        const Component = require('./Component.jsx')
+        const express = require('express')
+      `,
+      errors: [
+        {
+          message: 'Unexpected use of file extension "js" for "./foo.js"',
+          line: 2,
+          column: 21,
+        }, {
+          message: 'Unexpected use of file extension "jsx" for "./Component.jsx"',
+          line: 4,
+          column: 27,
+        },
+      ],
+      options: [ 'never', {commonjs: true, ignorePackages: true} ],
     }),
   ],
 })


### PR DESCRIPTION
This applies the same logic of the `import/extensions` rule to CommonJS-style require paths. Similar to the `import/no-unresolved` rule, it's enabled with a `{ commonjs: true }` option so existing setups aren't disrupted.

I've added notes to the rule's docs, as well as 4 tests (in the style as similar tests for this rule). Please let me know if you have any questions/comments/concerns.