### PR TITLE
[fix] `named`: ignore Flow import typeof and export type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+- [`named`]: ignore Flow `typeof` imports and `type` exports ([#1345], thanks [@loganfsmyth])
+
 ## [2.17.2] - 2019-04-16
 
 ### Fixed
@@ -553,6 +555,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1345]: https://github.com/benmosher/eslint-plugin-import/pull/1345
 [#1331]: https://github.com/benmosher/eslint-plugin-import/pull/1331
 [#1330]: https://github.com/benmosher/eslint-plugin-import/pull/1330
 [#1320]: https://github.com/benmosher/eslint-plugin-import/pull/1320
@@ -887,3 +890,4 @@ for info on changes for earlier releases.
 [@bradzacher]: https://github.com/bradzacher
 [@feychenie]: https://github.com/feychenie
 [@kiwka]: https://github.com/kiwka
+[@loganfsmyth]: https://github.com/loganfsmyth

--- a/docs/rules/named.md
+++ b/docs/rules/named.md
@@ -8,7 +8,7 @@ Note: for packages, the plugin will find exported names
 from [`jsnext:main`], if present in `package.json`.
 Redux's npm module includes this key, and thereby is lintable, for example.
 
-A module path that is [ignored] or not [unambiguously an ES module] will not be reported when imported. Note that type imports, as used by [Flow], are always ignored.
+A module path that is [ignored] or not [unambiguously an ES module] will not be reported when imported. Note that type imports and exports, as used by [Flow], are always ignored.
 
 [ignored]: ../../README.md#importignore
 [unambiguously an ES module]: https://github.com/bmeck/UnambiguousJavaScriptGrammar

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -12,8 +12,11 @@ module.exports = {
 
   create: function (context) {
     function checkSpecifiers(key, type, node) {
-      // ignore local exports and type imports
-      if (node.source == null || node.importKind === 'type') return
+      // ignore local exports and type imports/exports
+      if (node.source == null || node.importKind === 'type' ||
+          node.importKind === 'typeof'  || node.exportKind === 'type') {
+        return
+      }
 
       if (!node.specifiers
             .some(function (im) { return im.type === type })) {
@@ -32,7 +35,7 @@ module.exports = {
         if (im.type !== type) return
 
         // ignore type imports
-        if (im.importKind === 'type') return
+        if (im.importKind === 'type' || im.importKind === 'typeof') return
 
         const deepLookup = imports.hasDeep(im[key].name)
 

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -70,9 +70,13 @@ ruleTester.run('named', rule, {
     test({ code: 'import { deepProp } from "./named-exports"' }),
     test({ code: 'import { deepSparseElement } from "./named-exports"' }),
 
-    // should ignore imported flow types, even if they don’t exist
+    // should ignore imported/exported flow types, even if they don’t exist
     test({
       code: 'import type { MissingType } from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import typeof { MissingType } from "./flowtypes"',
       parser: 'babel-eslint',
     }),
     test({
@@ -80,7 +84,31 @@ ruleTester.run('named', rule, {
       parser: 'babel-eslint',
     }),
     test({
-      code: 'import  { type MyOpaqueType, MyClass } from "./flowtypes"',
+      code: 'import typeof { MyOpaqueType } from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import { type MyOpaqueType, MyClass } from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import { typeof MyOpaqueType, MyClass } from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import typeof MissingType from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'import typeof * as MissingType from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'export type { MissingType } from "./flowtypes"',
+      parser: 'babel-eslint',
+    }),
+    test({
+      code: 'export type { MyOpaqueType } from "./flowtypes"',
       parser: 'babel-eslint',
     }),
 


### PR DESCRIPTION
Expand the cases added by #1057 and #1106 to handle the other forms of Flow import/export.