### PR TITLE
[fix] `no-unused-modules`: don't crash when lint file outside src-folder

### DIFF
--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -302,6 +302,14 @@ module.exports = {
         return
       }
 
+      // refresh list of source files
+      const srcFiles = resolveFiles(getSrc(src), ignoreExports)
+
+      // make sure file to be linted is included in source files
+      if (!srcFiles.has(file)) {
+        return
+      }
+
       exports = exportList.get(file)
 
       // special case: export * from 

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -592,3 +592,13 @@ describe('do not report missing export for ignored file', () => {
     invalid: [],
   })
 })
+
+// lint file not available in `src`
+ruleTester.run('no-unused-modules', rule, {
+  valid: [
+    test({ options: unusedExportsOptions,
+            code: `export const jsxFoo = 'foo'; export const jsxBar = 'bar'`,
+            filename: testFilePath('../jsx/named.jsx')}),
+  ],
+  invalid: [],
+})


### PR DESCRIPTION
Fixes #1338 