### PR TITLE
Fix apparent corner case with `import/no-commonjs` rule

### DIFF
--- a/src/rules/no-commonjs.js
+++ b/src/rules/no-commonjs.js
@@ -91,6 +91,7 @@ module.exports = {
         if (
           call.parent.type !== 'ExpressionStatement'
           && call.parent.type !== 'VariableDeclarator'
+          && call.parent.type !== 'AssignmentExpression'
         ) return
 
         if (call.callee.type !== 'Identifier') return

--- a/tests/src/rules/no-commonjs.js
+++ b/tests/src/rules/no-commonjs.js
@@ -60,6 +60,7 @@ ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
 
     // imports
     { code: 'var x = require("x")', errors: [ { message: IMPORT_MESSAGE }] },
+    { code: 'x = require("x")', errors: [ { message: IMPORT_MESSAGE }] },
     { code: 'require("x")', errors: [ { message: IMPORT_MESSAGE }] },
 
     // exports


### PR DESCRIPTION
`var x = require("x")` will throw an error, but `var x; x = require("x")` does not.