### PR TITLE
Improve support for Typescript declare structures

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -517,8 +517,6 @@ ExportMap.parse = function (path, content, context) {
       const moduleDecl = ast.body.find((bodyNode) =>
         bodyNode.type === 'TSModuleDeclaration' && bodyNode.id.name === n.expression.name
       )
-      log(moduleDecl)
-      log(moduleDecl.body)
       if (moduleDecl && moduleDecl.body && moduleDecl.body.body) {
         moduleDecl.body.body.forEach((moduleBlockNode) => {
           // Export-assignment exports all members in the namespace, explicitly exported or not.

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -532,7 +532,8 @@ ExportMap.parse = function (path, content, context) {
               )
             )
           } else {
-            m.namespace.set(exportedDecl.id.name,
+            m.namespace.set(
+              exportedDecl.id.name,
               captureDoc(source, docStyleParsers, moduleBlockNode))
           }
         })

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -527,7 +527,8 @@ ExportMap.parse = function (path, content, context) {
           if (exportedDecl.type === 'VariableDeclaration') {
             exportedDecl.declarations.forEach((decl) =>
               recursivePatternCapture(decl.id,(id) => m.namespace.set(
-                id.name, captureDoc(source, docStyleParsers, decl, exportedDecl, moduleBlockNode))
+                id.name,
+                captureDoc(source, docStyleParsers, decl, exportedDecl, moduleBlockNode))
               )
             )
           } else {

--- a/tests/files/typescript-declare.d.ts
+++ b/tests/files/typescript-declare.d.ts
@@ -1,0 +1,33 @@
+export declare type MyType = string
+export declare enum MyEnum {
+  Foo,
+  Bar,
+  Baz
+}
+export declare interface Foo {
+  native: string | number
+  typedef: MyType
+  enum: MyEnum
+}
+
+export declare abstract class Bar {
+  abstract foo(): Foo
+
+  method();
+}
+
+export declare function getFoo() : MyType;
+
+export declare module MyModule {
+  export function ModuleFunction();
+}
+
+export declare namespace MyNamespace {
+  export function NamespaceFunction();
+
+  export module NSModule {
+    export function NSModuleFunction();
+  }
+}
+
+interface NotExported {}

--- a/tests/files/typescript-export-assign.d.ts
+++ b/tests/files/typescript-export-assign.d.ts
@@ -1,0 +1,39 @@
+export = AssignedNamespace;
+
+declare namespace AssignedNamespace {
+  type MyType = string
+  enum MyEnum {
+    Foo,
+    Bar,
+    Baz
+  }
+
+  interface Foo {
+    native: string | number
+    typedef: MyType
+    enum: MyEnum
+  }
+
+  abstract class Bar {
+    abstract foo(): Foo
+
+    method();
+  }
+
+  export function getFoo() : MyType;
+
+  export module MyModule {
+    export function ModuleFunction();
+  }
+
+  export namespace MyNamespace {
+    export function NamespaceFunction();
+
+    export module NSModule {
+      export function NSModuleFunction();
+    }
+  }
+
+  // Export-assignment exports all members in the namespace, explicitly exported or not.
+  // interface NotExported {}
+}

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -292,98 +292,100 @@ context('Typescript', function () {
   }
 
   parsers.forEach((parser) => {
-    ruleTester.run('named', rule, {
-      valid: [
-        test({
-          code: 'import { MyType } from "./typescript"',
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-        }),
-        test({
-          code: 'import { Foo } from "./typescript"',
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-        }),
-        test({
-          code: 'import { Bar } from "./typescript"',
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-        }),
-        test({
-          code: 'import { getFoo } from "./typescript"',
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-        }),
-        test({
-          code: 'import { MyEnum } from "./typescript"',
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-        }),
-        test({
-          code: `
-            import { MyModule } from "./typescript"
-            MyModule.ModuleFunction()
-          `,
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-        }),
-        test({
-          code: `
-            import { MyNamespace } from "./typescript"
-            MyNamespace.NSModule.NSModuleFunction()
-          `,
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-        }),
-      ],
+    ['typescript', 'typescript-declare', 'typescript-export-assign'].forEach((source) => {
+      ruleTester.run(`named`, rule, {
+        valid: [
+          test({
+            code: `import { MyType } from "./${source}"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+          }),
+          test({
+            code: `import { Foo } from "./${source}"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+          }),
+          test({
+            code: `import { Bar } from "./${source}"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+          }),
+          test({
+            code: `import { getFoo } from "./${source}"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+          }),
+          test({
+            code: `import { MyEnum } from "./${source}"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+          }),
+          test({
+            code: `
+              import { MyModule } from "./${source}"
+              MyModule.ModuleFunction()
+            `,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+          }),
+          test({
+            code: `
+              import { MyNamespace } from "./${source}"
+              MyNamespace.NSModule.NSModuleFunction()
+            `,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+          }),
+        ],
 
-      invalid: [
-        test({
-          code: 'import { MissingType } from "./typescript"',
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-          errors: [{
-            message: "MissingType not found in './typescript'",
-            type: 'Identifier',
-          }],
-        }),
-        test({
-          code: 'import { NotExported } from "./typescript"',
-          parser: parser,
-          settings: {
-            'import/parsers': { [parser]: ['.ts'] },
-            'import/resolver': { 'eslint-import-resolver-typescript': true },
-          },
-          errors: [{
-            message: "NotExported not found in './typescript'",
-            type: 'Identifier',
-          }],
-        }),
-      ],
+        invalid: [
+          test({
+            code: `import { MissingType } from "./${source}"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+            errors: [{
+              message: `MissingType not found in './${source}'`,
+              type: 'Identifier',
+            }],
+          }),
+          test({
+            code: `import { NotExported } from "./${source}"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+            errors: [{
+              message: `NotExported not found in './${source}'`,
+              type: 'Identifier',
+            }],
+          }),
+        ],
+      })
     })
   })
 })

--- a/utils/unambiguous.js
+++ b/utils/unambiguous.js
@@ -2,7 +2,7 @@
 exports.__esModule = true
 
 
-const pattern = /(^|;)\s*(export|import)((\s+\w)|(\s*[{*]))/m
+const pattern = /(^|;)\s*(export|import)((\s+\w)|(\s*[{*=]))/m
 /**
  * detect possible imports/exports without a full parse.
  *
@@ -18,7 +18,7 @@ exports.test = function isMaybeUnambiguousModule(content) {
 }
 
 // future-/Babel-proof at the expense of being a little loose
-const unambiguousNodeType = /^(Exp|Imp)ort.*Declaration$/
+const unambiguousNodeType = /^(((Exp|Imp)ort.*Declaration)|TSExportAssignment)$/
 
 /**
  * Given an AST, return true if the AST unambiguously represents a module.

--- a/utils/unambiguous.js
+++ b/utils/unambiguous.js
@@ -18,7 +18,7 @@ exports.test = function isMaybeUnambiguousModule(content) {
 }
 
 // future-/Babel-proof at the expense of being a little loose
-const unambiguousNodeType = /^(((Exp|Imp)ort.*Declaration)|TSExportAssignment)$/
+const unambiguousNodeType = /^(?:(?:Exp|Imp)ort.*Declaration|TSExportAssignment)$/
 
 /**
  * Given an AST, return true if the AST unambiguously represents a module.


### PR DESCRIPTION
This change improves support various forms used in Typescript declaration files. It's often necessary to change import resolution to prefer '.d.ts' files over '.js' files, but doing so breaks existing import resolution for certain types of UMD modules (React, for example).

This patch has two improvements:
* It adds support for the `export declare function foo()` syntax, which wasn't previously recognized
* It adds support for the `export = Namespace` syntax for exporting everything in a namespace.

The `import/named` tests were updated to add both variations as additional test files.