### PR TITLE
feat: support import ts definition

### DIFF
--- a/config/typescript.js
+++ b/config/typescript.js
@@ -2,7 +2,7 @@
  * Adds `.jsx`, `.ts` and `.tsx` as an extension, and enables JSX/TSX parsing.
  */
 var jsExtensions = ['.js', '.jsx'];
-var tsExtensions = ['.ts', '.tsx'];
+var tsExtensions = ['.d.ts','.ts', '.tsx'];
 var allExtensions = jsExtensions.concat(tsExtensions);
 
 module.exports = {


### PR DESCRIPTION
Typescript support extension with [.d.ts](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)

But in current config of `import` , it should complain error when try import custom type.