### PR TITLE
Added support for correctly ordering unknown types e.g. custom aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+- [`order`]: Adds support for correctly sorting unknown types into a single group (thanks [@swernerx])
+
 ## [2.17.3] - 2019-05-23
 
 ### Fixed

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -86,7 +86,7 @@ How groups are defined, and the order to respect. `groups` must be an array of `
   // Then the rest: internal and external type
 ]
 ```
-The default value is `["builtin", "external", "unknown", "parent", "sibling", "index"]`.
+The default value is `["builtin", "external", "parent", "sibling", "index"]`.
 
 You can set the options like this:
 

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -77,7 +77,7 @@ This rule supports the following options:
 
 ### `groups: [array]`:
 
-How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are: `"builtin"`, `"external"`, `"internal"`, `"parent"`, `"sibling"`, `"index"`. The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
+How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are: `"builtin"`, `"external"`, `"internal"`, `"unknown"`, `"parent"`, `"sibling"`, `"index"`. The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
 ```js
 [
   'builtin', // Built-in types are first
@@ -86,7 +86,7 @@ How groups are defined, and the order to respect. `groups` must be an array of `
   // Then the rest: internal and external type
 ]
 ```
-The default value is `["builtin", "external", "parent", "sibling", "index"]`.
+The default value is `["builtin", "external", "unknown", "parent", "sibling", "index"]`.
 
 You can set the options like this:
 

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -4,7 +4,7 @@ import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 import docsUrl from '../docsUrl'
 
-const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
+const defaultGroups = ['builtin', 'external', 'unknown', 'parent', 'sibling', 'index']
 
 // REPORTING AND FIXING
 
@@ -259,7 +259,7 @@ function isInVariableDeclarator(node) {
     (node.type === 'VariableDeclarator' || isInVariableDeclarator(node.parent))
 }
 
-const types = ['builtin', 'external', 'internal', 'parent', 'sibling', 'index']
+const types = ['builtin', 'external', 'internal', 'unknown', 'parent', 'sibling', 'index']
 
 // Creates an object with type-rank pairs.
 // Example: { index: 0, sibling: 1, parent: 1, external: 1, builtin: 2, internal: 2 }

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -4,7 +4,7 @@ import importType from '../core/importType'
 import isStaticRequire from '../core/staticRequire'
 import docsUrl from '../docsUrl'
 
-const defaultGroups = ['builtin', 'external', 'unknown', 'parent', 'sibling', 'index']
+const defaultGroups = ['builtin', 'external', 'parent', 'sibling', 'index']
 
 // REPORTING AND FIXING
 

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -164,6 +164,42 @@ ruleTester.run('order', rule, {
         var index = require('./');
       `,
     }),
+    // Using unknown import types (e.g. using an resolver alias via babel)
+    test({
+      code: `
+        import fs from 'fs';
+        import { Input } from '-/components/Input';
+        import { Button } from '-/components/Button';
+        import { add } from './helper';`,
+    }),
+    // Using unknown import types (e.g. using an resolver alias via babel) with
+    // a custom group list.
+    test({
+      code: `
+        import { Input } from '-/components/Input';
+        import { Button } from '-/components/Button';
+        import fs from 'fs';
+        import { add } from './helper';`,
+      options: [{
+        groups: [ 'unknown', 'builtin', 'external', 'parent', 'sibling', 'index' ],
+      }],
+    }),
+    // Using unknown import types (e.g. using an resolver alias via babel)
+    // Option: newlines-between: 'always'
+    test({
+      code: `
+        import fs from 'fs';
+
+        import { Input } from '-/components/Input';
+        import { Button } from '-/components/Button';
+
+        import { add } from './helper';`,
+      options: [
+        {
+          'newlines-between': 'always',
+        },
+      ],
+    }),
     // Option: newlines-between: 'always'
     test({
       code: `
@@ -884,6 +920,57 @@ ruleTester.run('order', rule, {
         ruleId: 'order',
         message: '`fs` import should occur after import of `../foo/bar`',
       }],
+    }),
+    // Default order using import with custom import alias
+    test({
+      code: `
+        import { Button } from '-/components/Button';
+        import { add } from './helper';
+        import fs from 'fs';
+      `,
+      output: `
+        import fs from 'fs';
+        import { Button } from '-/components/Button';
+        import { add } from './helper';
+      `,
+      errors: [
+        {
+          line: 4,
+          message: '`fs` import should occur before import of `-/components/Button`',
+        },
+      ],
+    }),
+    // Default order using import with custom import alias
+    test({
+      code: `
+        import fs from 'fs';
+        import { Button } from '-/components/Button';
+        import { LinkButton } from '-/components/Link';
+        import { add } from './helper';
+      `,
+      output: `
+        import fs from 'fs';
+
+        import { Button } from '-/components/Button';
+        import { LinkButton } from '-/components/Link';
+
+        import { add } from './helper';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+        },
+      ],
+      errors: [
+        {
+          line: 2,
+          message: 'There should be at least one empty line between import groups',
+        },
+        {
+          line: 4,
+          message: 'There should be at least one empty line between import groups',
+        },
+      ],
     }),
     // Option newlines-between: 'never' - should report unnecessary line between groups
     test({

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -164,16 +164,19 @@ ruleTester.run('order', rule, {
         var index = require('./');
       `,
     }),
-    // Using unknown import types (e.g. using an resolver alias via babel)
+    // Addijg unknown import types (e.g. using an resolver alias via babel) to the groups.
     test({
       code: `
         import fs from 'fs';
         import { Input } from '-/components/Input';
         import { Button } from '-/components/Button';
         import { add } from './helper';`,
+      options: [{
+        groups: ['builtin', 'external', 'unknown', 'parent', 'sibling', 'index'],
+      }],
     }),
     // Using unknown import types (e.g. using an resolver alias via babel) with
-    // a custom group list.
+    // an alternative custom group list.
     test({
       code: `
         import { Input } from '-/components/Input';
@@ -197,6 +200,7 @@ ruleTester.run('order', rule, {
       options: [
         {
           'newlines-between': 'always',
+          groups: ['builtin', 'external', 'unknown', 'parent', 'sibling', 'index'],
         },
       ],
     }),
@@ -933,6 +937,11 @@ ruleTester.run('order', rule, {
         import { Button } from '-/components/Button';
         import { add } from './helper';
       `,
+      options: [
+        {
+          groups: ['builtin', 'external', 'unknown', 'parent', 'sibling', 'index'],
+        },
+      ],
       errors: [
         {
           line: 4,
@@ -958,6 +967,7 @@ ruleTester.run('order', rule, {
       `,
       options: [
         {
+          groups: ['builtin', 'external', 'unknown', 'parent', 'sibling', 'index'],
           'newlines-between': 'always',
         },
       ],


### PR DESCRIPTION
We figured out that the auto-fix feature of the "order" rule destroyed our custom imports which are using a custom `babel-module` resolver. Settings for the resolver:

```js
'import/resolver': {
  'babel-module': {
    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
    alias: {
      '-': './src/',
    },
  },
},
```

Until now, unknown import types were sorted problematically by the "order" feature. These were not assigned to a common group but loosely added or kept between the other imports. This was especially problematic when using the 'newlines-between'-feature. In this case there was an additional line feed after each unknown import. See examples below.

Example:

```js
import { get } from 'lodash'
import { FormError } from '-/components/Product/Configuration/FormError'
import React, { PureComponent } from 'react'
import { ModalContainer } from '../../../Modal/ModalContainer'
import { addEvent, removeEvent } from '-/common/tracking/basket'
import { ChangeItem } from '-/components/Basket/ChangeItem'
import getBasketProduct from './BasketProduct.gql'
import UpdateItemInBasket from './UpdateItemInBasket.gql'
```

Previous version output:

```js
import { get } from 'lodash'

import { FormError } from '-/components/Product/Configuration/FormError'

import React, { PureComponent } from 'react'

import { ModalContainer } from '../../../Modal/ModalContainer'

import { addEvent, removeEvent } from '-/common/tracking/basket'

import { ChangeItem } from '-/components/Basket/ChangeItem'

import getBasketProduct from './BasketProduct.gql'
import UpdateItemInBasket from './UpdateItemInBasket.gql'
```

New version output:

```js
import { get } from 'lodash'
import React, { PureComponent } from 'react'

import { FormError } from '-/components/Product/Configuration/FormError'
import { addEvent, removeEvent } from '-/common/tracking/basket'
import { ChangeItem } from '-/components/Basket/ChangeItem'

import { ModalContainer } from '../../../Modal/ModalContainer'

import getBasketProduct from './BasketProduct.gql'
import UpdateItemInBasket from './UpdateItemInBasket.gql'
```

I updated the docs accordingly, added new tests and made sure that nothing else broke. The change itself is pretty small but it dramatically changes the result for these situations.