### PR TITLE
[bugfix] Re: #1332 - skip warning on a type declaration or alias. 

### DIFF
--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -47,8 +47,15 @@ module.exports = {
         // if there are specifiers, node.declaration should be null
         if (!node.declaration) return
 
-        // don't count flow types exports
+        // don't warn on single type aliases or declarations
         if (node.exportKind === 'type') return
+
+        if (
+          node.declaration.type === 'TSTypeAliasDeclaration' ||
+          node.declaration.type === 'TypeAlias'
+        ) {
+          return
+        }
 
         if (node.declaration.declarations) {
           node.declaration.declarations.forEach(function(declaration) {

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -1,8 +1,6 @@
-import { test, SYNTAX_CASES } from '../utils'
+import { test, SYNTAX_CASES, getTSParsers } from '../utils'
 
 import { RuleTester } from 'eslint'
-import eslintPkg from 'eslint/package.json'
-import semver from 'semver'
 
 var ruleTester = new RuleTester()
   , rule = require('rules/export')
@@ -111,18 +109,7 @@ ruleTester.run('export', rule, {
 
 
 context('Typescript', function () {
-  // Typescript
-  const parsers = []
-
-  if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
-    parsers.push(require.resolve('@typescript-eslint/parser'))
-  }
-
-  if (semver.satisfies(eslintPkg.version, '>=4.0.0 <6.0.0')) {
-    parsers.push(require.resolve('typescript-eslint-parser'))
-  }
-
-  parsers.forEach((parser) => {
+  getTSParsers().forEach((parser) => {
     const parserConfig = {
       parser: parser,
       settings: {

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -1,7 +1,5 @@
-import { test, SYNTAX_CASES } from '../utils'
+import { test, SYNTAX_CASES, getTSParsers } from '../utils'
 import { RuleTester } from 'eslint'
-import eslintPkg from 'eslint/package.json'
-import semver from 'semver'
 
 import { CASE_SENSITIVE_FS } from 'eslint-module-utils/resolve'
 
@@ -285,18 +283,7 @@ ruleTester.run('named (export *)', rule, {
 
 
 context('Typescript', function () {
-  // Typescript
-  const parsers = []
-
-  if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
-    parsers.push(require.resolve('@typescript-eslint/parser'))
-  }
-
-  if (semver.satisfies(eslintPkg.version, '<6.0.0')) {
-    parsers.push(require.resolve('typescript-eslint-parser'))
-  }
-
-  parsers.forEach((parser) => {
+  getTSParsers().forEach((parser) => {
     ['typescript', 'typescript-declare', 'typescript-export-assign'].forEach((source) => {
       ruleTester.run(`named`, rule, {
         valid: [

--- a/tests/src/rules/no-deprecated.js
+++ b/tests/src/rules/no-deprecated.js
@@ -1,9 +1,6 @@
-import { test, SYNTAX_CASES } from '../utils'
+import { test, SYNTAX_CASES, getTSParsers } from '../utils'
 
 import { RuleTester } from 'eslint'
-import eslintPkg from 'eslint/package.json'
-import semver from 'semver'
-
 
 const ruleTester = new RuleTester()
     , rule = require('rules/no-deprecated')
@@ -202,19 +199,7 @@ ruleTester.run('no-deprecated: hoisting', rule, {
 })
 
 describe('Typescript', function () {
-  // Typescript
-  const parsers = []
-
-  if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
-    parsers.push(require.resolve('@typescript-eslint/parser'))
-  }
-
-  // typescript-eslint-parser doesn't support this rule on ESLint <4 for some reason
-  if (semver.satisfies(eslintPkg.version, '>=4.0.0 <6.0.0')) {
-    parsers.push(require.resolve('typescript-eslint-parser'))
-  }
-
-  parsers.forEach((parser) => {
+  getTSParsers().forEach((parser) => {
     const parserConfig = {
       parser: parser,
       settings: {

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -1,4 +1,4 @@
-import { test, testVersion } from '../utils'
+import { test, testVersion, getTSParsers } from '../utils'
 
 import { RuleTester } from 'eslint'
 
@@ -1372,8 +1372,7 @@ ruleTester.run('order', rule, {
         message: '`fs` import should occur before import of `async`',
       }],
     })),
-    // fix incorrect order with typescript-eslint-parser
-    testVersion('<6.0.0', () => ({
+    ...getTSParsers().map(parser => ({
       code: `
         var async = require('async');
         var fs = require('fs');
@@ -1382,23 +1381,7 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
         var async = require('async');
       `,
-      parser: require.resolve('typescript-eslint-parser'),
-      errors: [{
-        ruleId: 'order',
-        message: '`fs` import should occur before import of `async`',
-      }],
-    })),
-    // fix incorrect order with @typescript-eslint/parser
-    testVersion('>5.0.0', () => ({
-      code: `
-        var async = require('async');
-        var fs = require('fs');
-      `,
-      output: `
-        var fs = require('fs');
-        var async = require('async');
-      `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      parser,
       errors: [{
         ruleId: 'order',
         message: '`fs` import should occur before import of `async`',

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -1,8 +1,6 @@
-import { test } from '../utils'
+import { test, getNonDefaultParsers } from '../utils'
 
 import { RuleTester } from 'eslint'
-import eslintPkg from 'eslint/package.json'
-import semver from 'semver'
 
 const ruleTester = new RuleTester()
     , rule = require('rules/prefer-default-export')
@@ -133,18 +131,7 @@ ruleTester.run('prefer-default-export', rule, {
 });
 
 context('Typescript', function() {
-  // Typescript
-  const parsers = [require.resolve('babel-eslint')];
-
-  if (semver.satisfies(eslintPkg.version, '>=4.0.0 <6.0.0')) {
-    parsers.push(require.resolve('typescript-eslint-parser'));
-  }
-
-  if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
-    parsers.push(require.resolve('@typescript-eslint/parser'));
-  }
-
-  parsers.forEach((parser) => {
+  getNonDefaultParsers().forEach((parser) => {
     const parserConfig = {
       parser: parser,
       settings: {

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -9,6 +9,22 @@ export function testFilePath(relativePath) {
   return path.join(process.cwd(), './tests/files', relativePath)
 }
 
+export function getTSParsers() {
+  const parsers = [];
+  if (semver.satisfies(eslintPkg.version, '>=4.0.0 <6.0.0')) {
+    parsers.push(require.resolve('typescript-eslint-parser'));
+  }
+
+  if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
+    parsers.push(require.resolve('@typescript-eslint/parser'));
+  }
+  return parsers;
+}
+
+export function getNonDefaultParsers() {
+  return getTSParsers().concat(require.resolve('babel-eslint'));
+}
+
 export const FILENAME = testFilePath('foo.js')
 
 export function testVersion(specifier, t) {


### PR DESCRIPTION
Attempt at fixing #1332 

Skips warning on a single type declaration or type alias. ~Remove the check for `node.exportKind` as it is `undefined` in all test cases.~ I believe this is used in eslint v2 & 3

This should work with `@typescript-eslint/parser` too, but I'm not testing that here because this repo is still using `typescript-eslint-parser`.

cc. @ljharb 