### PR TITLE
`order` rule: add pathGroups option to add support to order by paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - support `parseForESLint` from custom parser ([#1435], thanks [@JounQin])
 - [`no-extraneous-dependencies`]: Implement support for [bundledDependencies](https://npm.github.io/using-pkgs-docs/package-json/types/bundleddependencies.html) ([#1436], thanks [@schmidsi]))
 - [`no-unused-modules`]: add flow type support ([#1542], thanks [@rfermann])
+- [`order`]: Adds support for pathGroups to allow ordering by defined patterns ([#795], [#1386], thanks [@Mairu])
 
 ### Fixed
 - [`default`]: make error message less confusing ([#1470], thanks [@golopot])
@@ -644,6 +645,7 @@ for info on changes for earlier releases.
 [#1401]: https://github.com/benmosher/eslint-plugin-import/pull/1401
 [#1393]: https://github.com/benmosher/eslint-plugin-import/pull/1393
 [#1389]: https://github.com/benmosher/eslint-plugin-import/pull/1389
+[#1386]: https://github.com/benmosher/eslint-plugin-import/pull/1386
 [#1377]: https://github.com/benmosher/eslint-plugin-import/pull/1377
 [#1375]: https://github.com/benmosher/eslint-plugin-import/pull/1375
 [#1372]: https://github.com/benmosher/eslint-plugin-import/pull/1372
@@ -788,6 +790,7 @@ for info on changes for earlier releases.
 [#863]: https://github.com/benmosher/eslint-plugin-import/issues/863
 [#842]: https://github.com/benmosher/eslint-plugin-import/issues/842
 [#839]: https://github.com/benmosher/eslint-plugin-import/issues/839
+[#795]: https://github.com/benmosher/eslint-plugin-import/issues/795
 [#793]: https://github.com/benmosher/eslint-plugin-import/issues/793
 [#720]: https://github.com/benmosher/eslint-plugin-import/issues/720
 [#717]: https://github.com/benmosher/eslint-plugin-import/issues/717
@@ -1025,3 +1028,4 @@ for info on changes for earlier releases.
 [@Taranys]: https://github.com/Taranys
 [@maxmalov]: https://github.com/maxmalov
 [@marcusdarmstrong]: https://github.com/marcusdarmstrong
+[@Mairu]: https://github.com/Mairu

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -94,6 +94,32 @@ You can set the options like this:
 "import/order": ["error", {"groups": ["index", "sibling", "parent", "internal", "external", "builtin"]}]
 ```
 
+### `pathGroups: [array of objects]`:
+
+To be able so group by paths mostly needed with aliases pathGroups can be defined.
+
+Properties of the objects
+
+| property       | required | type   | description   |
+|----------------|:--------:|--------|---------------|
+| pattern        |     x    | string | minimatch pattern for the paths to be in this group (will not be used for builtins or externals) |
+| patternOptions |          | object | options for minimatch, default: { nocomment: true } |
+| group          |     x    | string | one of the allowed groups, the pathGroup will be positioned relative to this group |
+| position       |          | string | defines where around the group the pathGroup will be positioned, can be 'after' or 'before', if not provided pathGroup will be positioned like the group |
+
+```json
+{
+  "import/order": ["error", {
+    "pathGroups": [
+      {
+        "pattern": "~/**",
+        "group": "external"
+      }
+    ]
+  }]
+}
+```
+
 ### `newlines-between: [ignore|always|always-and-inside-groups|never]`:
 
 


### PR DESCRIPTION
Well there are multiple issues and pull requests open regarding the ordering of groups by paths.
Because I saw that the proposed approach in https://github.com/benmosher/eslint-plugin-import/issues/795 was "accepted" I implemented it this way.

But if @ljharb has changed his mind in the mean time and would prefer something like custom groups as proposed in https://github.com/benmosher/eslint-plugin-import/issues/1015#issuecomment-388573720 I can also rework this.