### PR TITLE
Support ESLint v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,6 @@ matrix:
   # issues with typescript deps in this version intersection
   - node_js: '4'
     env: ESLINT_VERSION=4
-  - env: ESLINT_VERSION=6
 
 before_install:
   - 'nvm install-latest-npm'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
 os: linux
 
 env:
-  - ESLINT_VERSION=^6.0.0-alpha
+  - ESLINT_VERSION=6
   - ESLINT_VERSION=5
   - ESLINT_VERSION=4
   - ESLINT_VERSION=3
@@ -59,16 +59,16 @@ matrix:
   - node_js: '4'
     env: ESLINT_VERSION=5
   - node_js: '4'
-    env: ESLINT_VERSION=^6.0.0-alpha
+    env: ESLINT_VERSION=6
   - node_js: '6'
-    env: ESLINT_VERSION=^6.0.0-alpha
+    env: ESLINT_VERSION=6
 
   fast_finish: true
   allow_failures:
   # issues with typescript deps in this version intersection
   - node_js: '4'
     env: ESLINT_VERSION=4
-  - env: ESLINT_VERSION=^6.0.0-alpha
+  - env: ESLINT_VERSION=6
 
 before_install:
   - 'nvm install-latest-npm'

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/benmosher/eslint-plugin-import",
   "devDependencies": {
     "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
-    "@typescript-eslint/parser": "^1.5.0",
+    "@typescript-eslint/parser": "1.10.3-alpha.13",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "homepage": "https://github.com/benmosher/eslint-plugin-import",
   "devDependencies": {
+    "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
     "@typescript-eslint/parser": "^1.5.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
@@ -58,13 +59,12 @@
     "chai": "^4.2.0",
     "coveralls": "^3.0.2",
     "cross-env": "^4.0.0",
-    "eslint": "2.x - 5.x",
+    "eslint": "2.x - 6.x",
     "eslint-import-resolver-node": "file:./resolvers/node",
     "eslint-import-resolver-typescript": "^1.0.2",
     "eslint-import-resolver-webpack": "file:./resolvers/webpack",
-    "eslint-module-utils": "file:./utils",
     "eslint-import-test-order-redirect": "file:./tests/files/order-redirect",
-    "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
+    "eslint-module-utils": "file:./utils",
     "eslint-plugin-import": "2.x",
     "linklocal": "^2.8.2",
     "mocha": "^3.5.3",
@@ -77,7 +77,7 @@
     "typescript-eslint-parser": "^22.0.0"
   },
   "peerDependencies": {
-    "eslint": "2.x - 5.x"
+    "eslint": "2.x - 6.x"
   },
   "dependencies": {
     "array-includes": "^3.0.3",

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -15,7 +15,10 @@ try {
   var FileEnumerator = require('eslint/lib/cli-engine/file-enumerator').FileEnumerator
   listFilesToProcess = function (src) {
     var e = new FileEnumerator()
-    return Array.from(e.iterateFiles(src))
+    return Array.from(e.iterateFiles(src), ({ filePath, ignored }) => ({
+      ignored,
+      filename: filePath,
+    }))
   }
 } catch (e1) {
   try {

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -336,11 +336,14 @@ describe('ExportMap', function () {
 
     const configs = [
       // ['string form', { 'typescript-eslint-parser': '.ts' }],
-      ['array form', { 'typescript-eslint-parser': ['.ts', '.tsx'] }],
     ]
 
     if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
       configs.push(['array form', { '@typescript-eslint/parser': ['.ts', '.tsx'] }])
+    }
+
+    if (semver.satisfies(eslintPkg.version, '<6.0.0')) {
+      configs.push(['array form', { 'typescript-eslint-parser': ['.ts', '.tsx'] }])
     }
 
     configs.forEach(([description, parserConfig]) => {

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -187,6 +187,7 @@ describe('ExportMap', function () {
       jsdocTests({
         parserPath: 'espree',
         parserOptions: {
+          ecmaVersion: 2015,
           sourceType: 'module',
           attachComment: true,
         },
@@ -195,6 +196,7 @@ describe('ExportMap', function () {
       jsdocTests({
         parserPath: 'espree',
         parserOptions: {
+          ecmaVersion: 2015,
           sourceType: 'module',
           attachComment: true,
         },
@@ -206,6 +208,7 @@ describe('ExportMap', function () {
       jsdocTests({
         parserPath: 'babel-eslint',
         parserOptions: {
+          ecmaVersion: 2015,
           sourceType: 'module',
           attachComment: true,
         },
@@ -214,6 +217,7 @@ describe('ExportMap', function () {
       jsdocTests({
         parserPath: 'babel-eslint',
         parserOptions: {
+          ecmaVersion: 2015,
           sourceType: 'module',
           attachComment: true,
         },
@@ -223,8 +227,8 @@ describe('ExportMap', function () {
   })
 
   context('exported static namespaces', function () {
-    const espreeContext = { parserPath: 'espree', parserOptions: { sourceType: 'module' }, settings: {} }
-    const babelContext = { parserPath: 'babel-eslint', parserOptions: { sourceType: 'module' }, settings: {} }
+    const espreeContext = { parserPath: 'espree', parserOptions: { ecmaVersion: 2015, sourceType: 'module' }, settings: {} }
+    const babelContext = { parserPath: 'babel-eslint', parserOptions: { ecmaVersion: 2015, sourceType: 'module' }, settings: {} }
 
     it('works with espree & traditional namespace exports', function () {
       const path = getFilename('deep/a.js')
@@ -255,7 +259,7 @@ describe('ExportMap', function () {
   })
 
   context('deep namespace caching', function () {
-    const espreeContext = { parserPath: 'espree', parserOptions: { sourceType: 'module' }, settings: {} }
+    const espreeContext = { parserPath: 'espree', parserOptions: { ecmaVersion: 2015, sourceType: 'module' }, settings: {} }
     let a
     before('sanity check and prime cache', function (done) {
       // first version

--- a/tests/src/core/parse.js
+++ b/tests/src/core/parse.js
@@ -20,7 +20,7 @@ describe('parse(content, { settings, ecmaFeatures })', function () {
   })
 
   it('infers jsx from ecmaFeatures when using stock parser', function () {
-    expect(() => parse(path, content, { settings: {}, parserPath: 'espree', parserOptions: { sourceType: 'module', ecmaFeatures: { jsx: true } } }))
+    expect(() => parse(path, content, { settings: {}, parserPath: 'espree', parserOptions: { ecmaVersion: 2015, sourceType: 'module', ecmaFeatures: { jsx: true } } }))
       .not.to.throw(Error)
   })
 

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -28,19 +28,19 @@ ruleTester.run('default', rule, {
 
     // es7 export syntax
     test({ code: 'export bar from "./bar"'
-         , parser: 'babel-eslint' }),
+         , parser: require.resolve('babel-eslint') }),
     test({ code: 'export { default as bar } from "./bar"' }),
     test({ code: 'export bar, { foo } from "./bar"'
-         , parser: 'babel-eslint' }),
+         , parser: require.resolve('babel-eslint') }),
     test({ code: 'export { default as bar, foo } from "./bar"' }),
     test({ code: 'export bar, * as names from "./bar"'
-         , parser: 'babel-eslint' }),
+         , parser: require.resolve('babel-eslint') }),
 
     // sanity check
     test({ code: 'export {a} from "./named-exports"' }),
     test({
       code: 'import twofer from "./trampoline"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     // jsx
@@ -68,27 +68,27 @@ ruleTester.run('default', rule, {
     // from no-errors
     test({
       code: "import Foo from './jsx/FooES7.js';",
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     // #545: more ES7 cases
     test({
       code: "import bar from './default-export-from.js';",
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: "import bar from './default-export-from-named.js';",
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: "import bar from './default-export-from-ignored.js';",
       settings: { 'import/ignore': ['common'] },
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: "export bar from './default-export-from-ignored.js';",
       settings: { 'import/ignore': ['common'] },
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     ...SYNTAX_CASES,
@@ -113,23 +113,23 @@ ruleTester.run('default', rule, {
     // es7 export syntax
     test({
       code: 'export baz from "./named-exports"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ['No default export found in module.'],
     }),
     test({
       code: 'export baz, { bar } from "./named-exports"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ['No default export found in module.'],
     }),
     test({
       code: 'export baz, * as names from "./named-exports"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ['No default export found in module.'],
     }),
     // exports default from a module with no default
     test({
       code: 'import twofer from "./broken-trampoline"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ['No default export found in module.'],
     }),
 

--- a/tests/src/rules/dynamic-import-chunkname.js
+++ b/tests/src/rules/dynamic-import-chunkname.js
@@ -14,7 +14,7 @@ const pickyCommentOptions = [{
 const multipleImportFunctionOptions = [{
   importFunctions: ['dynamicImport', 'definitelyNotStaticImport'],
 }]
-const parser = 'babel-eslint'
+const parser = require.resolve('babel-eslint')
 
 const noLeadingCommentError = 'dynamic imports require a leading comment with the webpack chunkname'
 const nonBlockCommentError = 'dynamic imports require a /* foo */ style comment, not a // foo comment'

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -112,10 +112,14 @@ ruleTester.run('export', rule, {
 
 context('Typescript', function () {
   // Typescript
-  const parsers = [require.resolve('typescript-eslint-parser')]
+  const parsers = []
 
   if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
     parsers.push(require.resolve('@typescript-eslint/parser'))
+  }
+
+  if (semver.satisfies(eslintPkg.version, '<6.0.0')) {
+    parsers.push(require.resolve('typescript-eslint-parser'))
   }
 
   parsers.forEach((parser) => {

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -112,10 +112,10 @@ ruleTester.run('export', rule, {
 
 context('Typescript', function () {
   // Typescript
-  const parsers = ['typescript-eslint-parser']
+  const parsers = [require.resolve('typescript-eslint-parser')]
 
   if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
-    parsers.push('@typescript-eslint/parser')
+    parsers.push(require.resolve('@typescript-eslint/parser'))
   }
 
   parsers.forEach((parser) => {

--- a/tests/src/rules/max-dependencies.js
+++ b/tests/src/rules/max-dependencies.js
@@ -66,7 +66,7 @@ ruleTester.run('max-dependencies', rule, {
 
     test({
       code: 'import type { x } from \'./foo\'; import type { y } from \'./bar\'',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       options: [{
         max: 1,
       }],

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -286,10 +286,14 @@ ruleTester.run('named (export *)', rule, {
 
 context('Typescript', function () {
   // Typescript
-  const parsers = [require.resolve('typescript-eslint-parser')]
+  const parsers = []
 
   if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
     parsers.push(require.resolve('@typescript-eslint/parser'))
+  }
+
+  if (semver.satisfies(eslintPkg.version, '<6.0.0')) {
+    parsers.push(require.resolve('typescript-eslint-parser'))
   }
 
   parsers.forEach((parser) => {

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -55,11 +55,11 @@ ruleTester.run('named', rule, {
     // es7
     test({
       code: 'export bar, { foo } from "./bar"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import { foo, bar } from "./named-trampoline"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     // regression tests
@@ -74,43 +74,43 @@ ruleTester.run('named', rule, {
     // should ignore imported/exported flow types, even if they don’t exist
     test({
       code: 'import type { MissingType } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import typeof { MissingType } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import type { MyOpaqueType } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import typeof { MyOpaqueType } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import { type MyOpaqueType, MyClass } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import { typeof MyOpaqueType, MyClass } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import typeof MissingType from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import typeof * as MissingType from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'export type { MissingType } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'export type { MyOpaqueType } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     // jsnext
@@ -188,17 +188,17 @@ ruleTester.run('named', rule, {
     // es7
     test({
       code: 'export bar2, { bar } from "./bar"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ["bar not found in './bar'"],
     }),
     test({
       code: 'import { foo, bar, baz } from "./named-trampoline"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ["baz not found in './named-trampoline'"],
     }),
     test({
       code: 'import { baz } from "./broken-trampoline"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ["baz not found via broken-trampoline.js -> named-exports.js"],
     }),
 
@@ -214,7 +214,7 @@ ruleTester.run('named', rule, {
 
     test({
       code: 'import  { type MyOpaqueType, MyMissingClass } from "./flowtypes"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ["MyMissingClass not found in './flowtypes'"],
     }),
 
@@ -286,10 +286,10 @@ ruleTester.run('named (export *)', rule, {
 
 context('Typescript', function () {
   // Typescript
-  const parsers = ['typescript-eslint-parser']
+  const parsers = [require.resolve('typescript-eslint-parser')]
 
   if (semver.satisfies(eslintPkg.version, '>5.0.0')) {
-    parsers.push('@typescript-eslint/parser')
+    parsers.push(require.resolve('@typescript-eslint/parser'))
   }
 
   parsers.forEach((parser) => {

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -56,16 +56,16 @@ const valid = [
   // es7 //
   /////////
   test({ code: 'export * as names from "./named-exports"'
-       , parser: 'babel-eslint' }),
+       , parser: require.resolve('babel-eslint') }),
   test({ code: 'export defport, * as names from "./named-exports"'
-       , parser: 'babel-eslint' }),
+       , parser: require.resolve('babel-eslint') }),
   // non-existent is handled by no-unresolved
   test({ code: 'export * as names from "./does-not-exist"'
-       , parser: 'babel-eslint' }),
+       , parser: require.resolve('babel-eslint') }),
 
   test({
     code: 'import * as Endpoints from "./issue-195/Endpoints"; console.log(Endpoints.Users)',
-    parser: 'babel-eslint',
+    parser: require.resolve('babel-eslint'),
   }),
 
   // respect hoisting
@@ -80,11 +80,11 @@ const valid = [
   test({ code: "import * as names from './default-export'; console.log(names.default)" }),
   test({
    code: 'export * as names from "./default-export"',
-   parser: 'babel-eslint',
+   parser: require.resolve('babel-eslint'),
   }),
   test({
     code: 'export defport, * as names from "./default-export"',
-    parser: 'babel-eslint',
+    parser: require.resolve('babel-eslint'),
   }),
 
   // #456: optionally ignore computed references
@@ -102,7 +102,7 @@ const valid = [
   }),
   test({
     code: `import * as names from './named-exports'; const {a, b, ...rest} = names;`,
-    parser: 'babel-eslint',
+    parser: require.resolve('babel-eslint'),
   }),
 
   // #1144: should handle re-export CommonJS as namespace
@@ -163,7 +163,7 @@ const invalid = [
 
   test({
     code: 'import * as Endpoints from "./issue-195/Endpoints"; console.log(Endpoints.Foo)',
-    parser: 'babel-eslint',
+    parser: require.resolve('babel-eslint'),
     errors: ["'Foo' not found in imported namespace 'Endpoints'."],
   }),
 
@@ -217,7 +217,7 @@ const invalid = [
 ///////////////////////
 // deep dereferences //
 //////////////////////
-;[['deep', 'espree'], ['deep-es7', 'babel-eslint']].forEach(function ([folder, parser]) { // close over params
+;[['deep', require.resolve('espree')], ['deep-es7', require.resolve('babel-eslint')]].forEach(function ([folder, parser]) { // close over params
   valid.push(
     test({ parser, code: `import * as a from "./${folder}/a"; console.log(a.b.c.d.e)` }),
     test({ parser, code: `import { b } from "./${folder}/a"; console.log(b.c.d.e)` }),

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -25,6 +25,7 @@ const valid = [
     parserOptions: {
       sourceType: 'module',
       ecmaFeatures: { jsx: true },
+      ecmaVersion: 2015,
     },
   }),
   test({ code: "import * as foo from './common';" }),

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -65,63 +65,63 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
           return somethingElse();
       }
     }`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import path from 'path';\nimport foo from 'foo';\n`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import path from 'path';import foo from 'foo';\n`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import path from 'path';import foo from 'foo';\n\nvar bar = 42;`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\n\nvar bar = 'bar';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\n\n\nvar bar = 'bar';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       options: [{ 'count': 2 }],
     },
     {
       code: `import foo from 'foo';\n\n\n\n\nvar bar = 'bar';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       options: [{ 'count': 4 }],
     },
     {
       code: `var foo = require('foo-module');\n\nvar foo = 'bar';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `var foo = require('foo-module');\n\n\nvar foo = 'bar';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       options: [{ 'count': 2 }],
     },
     {
       code: `var foo = require('foo-module');\n\n\n\n\nvar foo = 'bar';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       options: [{ 'count': 4 }],
     },
     {
       code: `require('foo-module');\n\nvar foo = 'bar';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\nimport { bar } from './bar-lib';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\n\nvar a = 123;\n\nimport { bar } from './bar-lib';`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `var foo = require('foo-module');\n\nvar a = 123;\n\nvar bar = require('bar-lib');`,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `
@@ -130,7 +130,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
           foo();
         }
       `,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `
@@ -139,7 +139,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
           foo();
         }
       `,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `
@@ -149,7 +149,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
           var bar = 42;
         }
       `,
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `//issue 592
@@ -157,13 +157,13 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         @SomeDecorator(require('./some-file'))
         class App {}
       `,
-      parserOptions: { sourceType: 'module' },
-      parser: 'babel-eslint',
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
     },
     {
       code: `var foo = require('foo');\n\n@SomeDecorator(foo)\nclass Foo {}`,
-      parserOptions: { sourceType: 'module' },
-      parser: 'babel-eslint',
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
     },
   ],
 
@@ -176,7 +176,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: IMPORT_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\n\nexport default function() {};`,
@@ -187,7 +187,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: IMPORT_ERROR_MESSAGE_MULTIPLE(2),
       } ],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `var foo = require('foo-module');\nvar something = 123;`,
@@ -197,7 +197,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: REQUIRE_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\nexport default function() {};`,
@@ -208,7 +208,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: IMPORT_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `var foo = require('foo-module');\nvar something = 123;`,
@@ -218,7 +218,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: REQUIRE_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\nvar a = 123;\n\nimport { bar } from './bar-lib';\nvar b=456;`,
@@ -234,7 +234,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: IMPORT_ERROR_MESSAGE,
       }],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `var foo = require('foo-module');\nvar a = 123;\n\nvar bar = require('bar-lib');\nvar b=456;`,
@@ -250,7 +250,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
           column: 1,
           message: REQUIRE_ERROR_MESSAGE,
         }],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `var foo = require('foo-module');\nvar a = 123;\n\nrequire('bar-lib');\nvar b=456;`,
@@ -266,7 +266,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
           column: 1,
           message: REQUIRE_ERROR_MESSAGE,
         }],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `var path = require('path');\nvar foo = require('foo');\nvar bar = 42;`,
@@ -316,7 +316,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: IMPORT_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import path from 'path';import foo from 'foo';var bar = 42;`,
@@ -326,7 +326,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 25,
         message: IMPORT_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: `import foo from 'foo';\n@SomeDecorator(foo)\nclass Foo {}`,
@@ -336,8 +336,8 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: IMPORT_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
-      parser: 'babel-eslint',
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
     },
     {
       code: `var foo = require('foo');\n@SomeDecorator(foo)\nclass Foo {}`,
@@ -347,8 +347,8 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         column: 1,
         message: REQUIRE_ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' },
-      parser: 'babel-eslint',
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      parser: require.resolve('babel-eslint'),
     },
   ],
 })

--- a/tests/src/rules/no-amd.js
+++ b/tests/src/rules/no-amd.js
@@ -4,8 +4,8 @@ var ruleTester = new RuleTester()
 
 ruleTester.run('no-amd', require('rules/no-amd'), {
   valid: [
-    { code: 'import "x";', parserOptions: { sourceType: 'module' } },
-    { code: 'import x from "x"', parserOptions: { sourceType: 'module' } },
+    { code: 'import "x";', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: 'import x from "x"', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
     'var x = require("x")',
 
     'require("x")',

--- a/tests/src/rules/no-commonjs.js
+++ b/tests/src/rules/no-commonjs.js
@@ -9,14 +9,14 @@ ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
   valid: [
 
     // imports
-    { code: 'import "x";', parserOptions: { sourceType: 'module' } },
-    { code: 'import x from "x"', parserOptions: { sourceType: 'module' } },
-    { code: 'import x from "x"', parserOptions: { sourceType: 'module' } },
-    { code: 'import { x } from "x"', parserOptions: { sourceType: 'module' } },
+    { code: 'import "x";', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: 'import x from "x"', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: 'import x from "x"', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: 'import { x } from "x"', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
 
     // exports
-    { code: 'export default "x"', parserOptions: { sourceType: 'module' } },
-    { code: 'export function house() {}', parserOptions: { sourceType: 'module' } },
+    { code: 'export default "x"', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: 'export function house() {}', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
     {
       code:
       'function someFunc() {\n'+
@@ -24,7 +24,7 @@ ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
       '\n'+
       '  expect(exports.someProp).toEqual({ a: \'value\' });\n'+
       '}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
 
     // allowed requires

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -43,15 +43,15 @@ ruleTester.run('no-cycle', rule, {
     test({
       code: 'import("./depth-two").then(function({ foo }){})',
       options: [{ maxDepth: 1 }],
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import type { FooType } from "./depth-one"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import type { FooType, BarType } from "./depth-one"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
   ],
   invalid: [
@@ -108,17 +108,17 @@ ruleTester.run('no-cycle', rule, {
     test({
       code: 'import { bar } from "./depth-three-indirect"',
       errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import("./depth-three-star")',
       errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import("./depth-three-indirect")',
       errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
   ],
 })

--- a/tests/src/rules/no-default-export.js
+++ b/tests/src/rules/no-default-export.js
@@ -58,7 +58,7 @@ ruleTester.run('no-default-export', rule, {
     }),
     test({
       code: 'export { a, b } from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     // no exports at all
@@ -74,15 +74,15 @@ ruleTester.run('no-default-export', rule, {
 
     test({
       code: `export type UserId = number;`,
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'export foo from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: `export Memory, { MemoryValue } from './Memory'`,
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
   ],
   invalid: [
@@ -112,7 +112,7 @@ ruleTester.run('no-default-export', rule, {
     }),
     test({
       code: 'export default from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Prefer named exports.',

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -23,7 +23,7 @@ ruleTester.run('no-duplicates', rule, {
     // #225: ignore duplicate if is a flow type import
     test({
       code: "import { x } from './foo'; import type { y } from './foo'",
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
   ],
   invalid: [
@@ -64,7 +64,7 @@ ruleTester.run('no-duplicates', rule, {
     test({
       code: "import type { x } from './foo'; import type { y } from './foo'",
       output: "import type { x , y } from './foo'; ",
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
     }),
 

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -76,7 +76,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'import type MyType from "myflowtyped";',
       options: [{packageDir: packageDirWithFlowTyped}],
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'import react from "react";',
@@ -289,5 +289,5 @@ ruleTester.run('no-extraneous-dependencies', rule, {
         message: "'react' should be listed in the project's dependencies. Run 'npm i -S react' to add it",
       }],
     }),
-  ]
+  ],
 })

--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -25,11 +25,11 @@ ruleTester.run('no-mutable-exports', rule, {
     test({ code: 'class Counter {}\nexport default Counter'}),
     test({ code: 'class Counter {}\nexport { Counter as default }'}),
     test({
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       code: 'export Something from "./something";',
     }),
     test({
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       code: 'type Foo = {}\nexport type {Foo}',
     }),
   ],

--- a/tests/src/rules/no-named-as-default.js
+++ b/tests/src/rules/no-named-as-default.js
@@ -13,13 +13,13 @@ ruleTester.run('no-named-as-default', rule, {
 
     // es7
     test({ code: 'export bar, { foo } from "./bar";'
-         , parser: 'babel-eslint' }),
+         , parser: require.resolve('babel-eslint') }),
     test({ code: 'export bar from "./bar";'
-         , parser: 'babel-eslint' }),
+         , parser: require.resolve('babel-eslint') }),
 
     // #566: don't false-positive on `default` itself
     test({ code: 'export default from "./bar";'
-         , parser: 'babel-eslint' }),
+         , parser: require.resolve('babel-eslint') }),
 
     ...SYNTAX_CASES,
   ],
@@ -39,13 +39,13 @@ ruleTester.run('no-named-as-default', rule, {
     // es7
     test({
       code: 'export foo from "./bar";',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: [ {
         message: 'Using exported name \'foo\' as identifier for default export.'
       , type: 'ExportDefaultSpecifier' } ] }),
     test({
       code: 'export foo, { foo as bar } from "./bar";',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: [ {
         message: 'Using exported name \'foo\' as identifier for default export.'
     , type: 'ExportDefaultSpecifier' } ] }),

--- a/tests/src/rules/no-named-default.js
+++ b/tests/src/rules/no-named-default.js
@@ -19,7 +19,7 @@ ruleTester.run('no-named-default', rule, {
         message: 'Use default import syntax to import \'default\'.',
         type: 'Identifier',
       }],
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),*/
     test({
       code: 'import { default as bar } from "./bar";',

--- a/tests/src/rules/no-named-export.js
+++ b/tests/src/rules/no-named-export.js
@@ -14,7 +14,7 @@ ruleTester.run('no-named-export', rule, {
     }),
     test({
       code: 'export default from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     // no exports at all
@@ -146,7 +146,7 @@ ruleTester.run('no-named-export', rule, {
     }),
     test({
       code: 'export { a, b } from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
@@ -154,7 +154,7 @@ ruleTester.run('no-named-export', rule, {
     }),
     test({
       code: `export type UserId = number;`,
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
@@ -162,7 +162,7 @@ ruleTester.run('no-named-export', rule, {
     }),
     test({
       code: 'export foo from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
@@ -170,7 +170,7 @@ ruleTester.run('no-named-export', rule, {
     }),
     test({
       code: `export Memory, { MemoryValue } from './Memory'`,
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       errors: [{
         ruleId: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',

--- a/tests/src/rules/no-namespace.js
+++ b/tests/src/rules/no-namespace.js
@@ -1,15 +1,15 @@
 import { RuleTester } from 'eslint'
 
-const ERROR_MESSAGE = 'Unexpected namespace import.';
+const ERROR_MESSAGE = 'Unexpected namespace import.'
 
 const ruleTester = new RuleTester()
 
 ruleTester.run('no-namespace', require('rules/no-namespace'), {
   valid: [
-    { code: "import { a, b } from 'foo';", parserOptions: { sourceType: 'module' } },
-    { code: "import { a, b } from './foo';", parserOptions: { sourceType: 'module' } },
-    { code: "import bar from 'bar';", parserOptions: { sourceType: 'module' } },
-    { code: "import bar from './bar';", parserOptions: { sourceType: 'module' } }
+    { code: "import { a, b } from 'foo';", parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: "import { a, b } from './foo';", parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: "import bar from 'bar';", parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: "import bar from './bar';", parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
   ],
 
   invalid: [
@@ -18,27 +18,27 @@ ruleTester.run('no-namespace', require('rules/no-namespace'), {
       errors: [ {
         line: 1,
         column: 8,
-        message: ERROR_MESSAGE
+        message: ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' }
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: "import defaultExport, * as foo from 'foo';",
       errors: [ {
         line: 1,
         column: 23,
-        message: ERROR_MESSAGE
+        message: ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' }
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: "import * as foo from './foo';",
       errors: [ {
         line: 1,
         column: 8,
-        message: ERROR_MESSAGE
+        message: ERROR_MESSAGE,
       } ],
-      parserOptions: { sourceType: 'module' }
-    }
-  ]
-});
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+    },
+  ],
+})

--- a/tests/src/rules/no-relative-parent-imports.js
+++ b/tests/src/rules/no-relative-parent-imports.js
@@ -4,7 +4,7 @@ import { test as _test, testFilePath } from '../utils'
 
 const test = def => _test(Object.assign(def, {
   filename: testFilePath('./internal-modules/plugins/plugin2/index.js'),
-  parser: 'babel-eslint',
+  parser: require.resolve('babel-eslint'),
 }))
 
 const ruleTester = new RuleTester()
@@ -83,24 +83,24 @@ ruleTester.run('no-relative-parent-imports', rule, {
       errors: [ {
         message: 'Relative imports from parent directories are not allowed. Please either pass what you\'re importing through at runtime (dependency injection), move `index.js` to same directory as `./../plugin.js` or consider making `./../plugin.js` a package.',
         line: 1,
-        column: 17
-      }]
+        column: 17,
+      }],
     }),
     test({
       code: 'import foo from "../../api/service"',
       errors: [ {
         message: 'Relative imports from parent directories are not allowed. Please either pass what you\'re importing through at runtime (dependency injection), move `index.js` to same directory as `../../api/service` or consider making `../../api/service` a package.',
         line: 1,
-        column: 17
-      }]
+        column: 17,
+      }],
     }),
     test({
       code: 'import("../../api/service")',
       errors: [ {
         message: 'Relative imports from parent directories are not allowed. Please either pass what you\'re importing through at runtime (dependency injection), move `index.js` to same directory as `../../api/service` or consider making `../../api/service` a package.',
         line: 1,
-        column: 8
+        column: 8,
       }],
-    })
+    }),
   ],
 })

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -30,7 +30,7 @@ function runResolverTests(resolver) {
       rest({ code: "import {someThing} from './test-module';" }),
       rest({ code: "import fs from 'fs';" }),
       rest({ code: "import('fs');"
-           , parser: 'babel-eslint' }),
+           , parser: require.resolve('babel-eslint') }),
 
       rest({ code: 'import * as foo from "a"' }),
 
@@ -40,9 +40,9 @@ function runResolverTests(resolver) {
 
       // stage 1 proposal for export symmetry,
       rest({ code: 'export * as bar from "./bar"'
-           , parser: 'babel-eslint' }),
+           , parser: require.resolve('babel-eslint') }),
       rest({ code: 'export bar from "./bar"'
-           , parser: 'babel-eslint' }),
+           , parser: require.resolve('babel-eslint') }),
       rest({ code: 'import foo from "./jsx/MyUnCoolComponent.jsx"' }),
 
       // commonjs setting
@@ -122,7 +122,7 @@ function runResolverTests(resolver) {
                           "module 'in-alternate-root'."
                 , type: 'Literal',
                 }],
-      parser: 'babel-eslint'}),
+      parser: require.resolve('babel-eslint')}),
 
       rest({ code: 'export { foo } from "./does-not-exist"'
            , errors: ["Unable to resolve path to module './does-not-exist'."] }),
@@ -133,11 +133,11 @@ function runResolverTests(resolver) {
 
       // export symmetry proposal
       rest({ code: 'export * as bar from "./does-not-exist"'
-           , parser: 'babel-eslint'
+           , parser: require.resolve('babel-eslint')
            , errors: ["Unable to resolve path to module './does-not-exist'."],
            }),
       rest({ code: 'export bar from "./does-not-exist"'
-           , parser: 'babel-eslint'
+           , parser: require.resolve('babel-eslint')
            , errors: ["Unable to resolve path to module './does-not-exist'."],
            }),
 

--- a/tests/src/rules/no-useless-path-segments.js
+++ b/tests/src/rules/no-useless-path-segments.js
@@ -29,11 +29,11 @@ function runResolverTests(resolver) {
       test({ code: 'import "./importType"', options: [{ noUselessIndex: true }] }), // ./importType.js does not exist
 
       test({ code: 'import(".")'
-           , parser: 'babel-eslint' }),
+           , parser: require.resolve('babel-eslint') }),
       test({ code: 'import("..")'
-           , parser: 'babel-eslint' }),
+           , parser: require.resolve('babel-eslint') }),
       test({ code: 'import("fs").then(function(fs){})'
-           , parser: 'babel-eslint' }),
+           , parser: require.resolve('babel-eslint') }),
     ],
 
     invalid: [
@@ -199,17 +199,17 @@ function runResolverTests(resolver) {
       test({
         code: 'import("./")',
         errors: [ 'Useless path segments for "./", should be "."'],
-        parser: 'babel-eslint',
+        parser: require.resolve('babel-eslint'),
       }),
       test({
         code: 'import("../")',
         errors: [ 'Useless path segments for "../", should be ".."'],
-        parser: 'babel-eslint',
+        parser: require.resolve('babel-eslint'),
       }),
       test({
         code: 'import("./deep//a")',
         errors: [ 'Useless path segments for "./deep//a", should be "./deep/a"'],
-        parser: 'babel-eslint',
+        parser: require.resolve('babel-eslint'),
       }),
     ],
   })

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -1373,7 +1373,7 @@ ruleTester.run('order', rule, {
       }],
     })),
     // fix incorrect order with typescript-eslint-parser
-    test({
+    testVersion('<6.0.0', {
       code: `
         var async = require('async');
         var fs = require('fs');

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -1382,7 +1382,7 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
         var async = require('async');
       `,
-      parser: 'typescript-eslint-parser',
+      parser: require.resolve('typescript-eslint-parser'),
       errors: [{
         ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
@@ -1398,7 +1398,7 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
         var async = require('async');
       `,
-      parser: '@typescript-eslint/parser',
+      parser: require.resolve('@typescript-eslint/parser'),
       errors: [{
         ruleId: 'order',
         message: '`fs` import should occur before import of `async`',

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -1373,7 +1373,7 @@ ruleTester.run('order', rule, {
       }],
     })),
     // fix incorrect order with typescript-eslint-parser
-    testVersion('<6.0.0', {
+    testVersion('<6.0.0', () => ({
       code: `
         var async = require('async');
         var fs = require('fs');
@@ -1387,9 +1387,9 @@ ruleTester.run('order', rule, {
         ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
-    }),
+    })),
     // fix incorrect order with @typescript-eslint/parser
-    testVersion('>5.0.0', {
+    testVersion('>5.0.0', () => ({
       code: `
         var async = require('async');
         var fs = require('fs');
@@ -1403,6 +1403,6 @@ ruleTester.run('order', rule, {
         ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
-    }),
+    })),
   ].filter((t) => !!t),
 })

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -60,7 +60,7 @@ ruleTester.run('prefer-default-export', rule, {
       }),
     test({
       code: `export Memory, { MemoryValue } from './Memory'`,
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       }),
 
     // no exports at all
@@ -71,17 +71,17 @@ ruleTester.run('prefer-default-export', rule, {
 
     test({
       code: `export type UserId = number;`,
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       }),
 
     // issue #653
     test({
       code: 'export default from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
     test({
       code: 'export { a, b } from "foo.js"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
     }),
 
     // ...SYNTAX_CASES,

--- a/tests/src/rules/unambiguous.js
+++ b/tests/src/rules/unambiguous.js
@@ -38,7 +38,7 @@ ruleTester.run('unambiguous', rule, {
     },
     {
       code: 'function x() {}; export * as y from "z"',
-      parser: 'babel-eslint',
+      parser: require.resolve('babel-eslint'),
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {

--- a/tests/src/rules/unambiguous.js
+++ b/tests/src/rules/unambiguous.js
@@ -10,46 +10,46 @@ ruleTester.run('unambiguous', rule, {
 
     {
       code: 'import y from "z"; function x() {}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'import * as y from "z"; function x() {}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'import { y } from "z"; function x() {}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'import z, { y } from "z"; function x() {}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'function x() {}; export {}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'function x() {}; export { x }',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'function x() {}; export { y } from "z"',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'function x() {}; export * as y from "z"',
       parser: 'babel-eslint',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
       code: 'export function x() {}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
   ],
   invalid: [
     {
       code: 'function x() {}',
-      parserOptions: { sourceType: 'module' },
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       errors: ['This module could be parsed as a valid script.'],
     },
   ],

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -12,7 +12,7 @@ export function testFilePath(relativePath) {
 export const FILENAME = testFilePath('foo.js')
 
 export function testVersion(specifier, t) {
-  return semver.satisfies(eslintPkg.version, specifier) && test(t)
+  return semver.satisfies(eslintPkg.version, specifier) && test(t())
 }
 
 export function test(t) {

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -46,7 +46,7 @@ export const SYNTAX_CASES = [
   test({ code: 'for (let [ foo, bar ] of baz) {}' }),
 
   test({ code: 'const { x, y } = bar' }),
-  test({ code: 'const { x, y, ...z } = bar', parser: 'babel-eslint' }),
+  test({ code: 'const { x, y, ...z } = bar', parser: require.resolve('babel-eslint') }),
 
   // all the exports
   test({ code: 'let x; export { x }' }),
@@ -54,7 +54,7 @@ export const SYNTAX_CASES = [
 
   // not sure about these since they reference a file
   // test({ code: 'export { x } from "./y.js"'}),
-  // test({ code: 'export * as y from "./y.js"', parser: 'babel-eslint'}),
+  // test({ code: 'export * as y from "./y.js"', parser: require.resolve('babel-eslint')}),
 
   test({ code: 'export const x = null' }),
   test({ code: 'export var x = null' }),


### PR DESCRIPTION
The main issues are:
- [x] Use `require.resolve` when passing the `parser` option to `RuleTester` (https://eslint.org/docs/user-guide/migrating-to-6.0.0#rule-tester-parser)
- [x] Add `ecmaVersion` when `sourceType` is `module` (https://eslint.org/docs/user-guide/migrating-to-6.0.0#-the-default-parser-now-validates-options-more-strictly)
- [x] Transform output of the `FileEnumerator` into what the `import/no-unused-modules` rule expects
- [x] `@typescript-eslint/parser` is using an internal module (`eslint/lib/util/traverser`) which has been removed in ESLint@6 and therefore causing an error. It's been fixed in https://github.com/typescript-eslint/typescript-eslint/pull/628 but not been released yet. **(Updated to canary, thanks @golopot)**
- [x] Same as above for `typescript-eslint-parser` but this is an archived package. As I write this I realise I should probably use the `testVersion` function so that tests for this are skipped on `eslint>=6`

To test:
```
npm i eslint@6
npm test
```

The only failing tests should be related to the TypeScript issue above.

Related to https://github.com/airbnb/javascript/issues/2036.
Fixes #1362.
