### PR TITLE
WIP: Add Wallaby.js config

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,29 @@
+module.exports = (wallaby) => ({
+  files: [
+    'src/**/*.js',
+    'package.json',
+    'config/**/*.js',
+    'tests/src/utils.js',
+    'tests/src/core/parseStubParser.js',
+    { pattern: '**/.eslintrc', instrument: false },
+    { pattern: 'tests/files/**/*.*', instrument: false },
+  ],
+
+  tests: [
+    'tests/**/*.js',
+    '!tests/src/utils.js',
+    '!tests/src/core/parseStubParser.js',
+    '!tests/files/**/*.*',
+  ],
+
+  env: {
+    type: 'node',
+    params: {
+      env: `NODE_PATH=./src`,
+    },
+  },
+
+  compilers: {
+    '**/*.js': wallaby.compilers.babel(),
+  },
+})


### PR DESCRIPTION
Howdy! I was working on a new rule for this project and thought it'd be nice to add support for [Wallaby.js](https://wallabyjs.com/) so that I could run the tests in real-time.

This config *almost* works. Here's the output Wallaby gives me:

```
6 failing tests, 1685 passing 
  
  ​​​​Typescript named invalid import { NotExported } from "./typescript"​​​​ ​​​[2 ms]​​​​
     
    Should have 1 error but had 0: [] 
  
  ​​​​Typescript named invalid import { MissingType } from "./typescript"​​​​ ​​​[1 ms]​​​​
     
    Should have 1 error but had 0: [] 
  
  ​​​​no-amd invalid require(["a"], function(a) { console.log(a); })​​​​ ​​​[1 ms]​​​​
     
    Should have 1 error but had 0: [] 
  
  ​​​​no-amd invalid require([], function() {})​​​​ ​​​[2 ms]​​​​
     
    Should have 1 error but had 0: [] 
  
  ​​​​no-amd invalid define(["a"], function(a) { console.log(a); })​​​​ ​​​[1 ms]​​​​
     
    Should have 1 error but had 0: [] 

  ​​​​no-amd invalid define([], function() {})​​​​ ​​​[2 ms]​​​​
     
    Should have 1 error but had 0: [] 
```

I can't explain what's going on with those rules. 😕 

---

Anyway, feel free to close out this PR! I just wanted to share my work, in case anyone else is interested in using Wallaby with this project.