### PR TITLE
[fix] `export`: false positive for typescript overloads

### DIFF
--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -24,6 +24,21 @@ ambient namespaces:
 const rootProgram = 'root'
 const tsTypePrefix = 'type:'
 
+/**
+ * Detect function overloads like:
+ * ```ts
+ * export function foo(a: number);
+ * export function foo(a: string);
+ * export function foo(a: number|string) { return a; }
+ * ```
+ * @param {Set<Object>} nodes
+ * @returns {boolean}
+ */
+function isTypescriptFunctionOverloads(nodes) {
+  const types = new Set(Array.from(nodes, node => node.parent.type))
+  return types.size === 2 && types.has('TSDeclareFunction') && types.has('FunctionDeclaration')
+}
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -122,6 +137,8 @@ module.exports = {
         for (let [, named] of namespace) {
           for (let [name, nodes] of named) {
             if (nodes.size <= 1) continue
+
+            if (isTypescriptFunctionOverloads(nodes)) continue
 
             for (let node of nodes) {
               if (name === 'default') {

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -118,7 +118,7 @@ context('Typescript', function () {
     parsers.push(require.resolve('@typescript-eslint/parser'))
   }
 
-  if (semver.satisfies(eslintPkg.version, '<6.0.0')) {
+  if (semver.satisfies(eslintPkg.version, '>=4.0.0 <6.0.0')) {
     parsers.push(require.resolve('typescript-eslint-parser'))
   }
 
@@ -144,6 +144,14 @@ context('Typescript', function () {
           code: `
             export const Foo = 1;
             export interface Foo {}
+          `,
+        }, parserConfig)),
+
+        test(Object.assign({
+          code: `
+            export function fff(a: string);
+            export function fff(a: number);
+            export function fff(a: string|number) {};
           `,
         }, parserConfig)),
 


### PR DESCRIPTION
Fixes #1357.

Fixes false positives like this: 
```ts
export function foo(a: number) {}
export function foo(a: string) {}
 ```


