### PR TITLE
New: Add order-member rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export const rules = {
   'no-nodejs-modules': require('./rules/no-nodejs-modules'),
   'no-webpack-loader-syntax': require('./rules/no-webpack-loader-syntax'),
   'order': require('./rules/order'),
+  'order-member': require('./rules/order-member'),
   'newline-after-import': require('./rules/newline-after-import'),
   'prefer-default-export': require('./rules/prefer-default-export'),
   'no-default-export': require('./rules/no-default-export'),

--- a/src/rules/order-member.js
+++ b/src/rules/order-member.js
@@ -1,0 +1,102 @@
+/**
+ * import { b, c, a } from 'a'
+ * to
+ * import { a, b, c } from 'a'
+ */
+import docsUrl from '../docsUrl'
+
+const messages = {
+  notInOrder: 'Imported members must be sorted alphabetically',
+}
+
+const schema = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      caseInsensitive: { type: 'boolean' },
+    },
+  },
+  maxItems: 1,
+}
+
+const defaultOption = { caseInsensitive: false }
+
+/**
+ * @param {ImportSpecifier} node 
+ * @returns {string}
+ */
+function buildImportString(node) {
+  return node.imported.name === node.local.name
+    ? node.imported.name
+    : `${node.imported.name} as ${node.local.name}`
+}
+
+/**
+ * @param {string} strA 
+ * @param {string} strB 
+ * @returns {number} -1, 0, 1 for sort
+ */
+function sortImport(strA, strB) {
+  if (strA > strB) {
+    return 1
+  }
+  if (strA < strB) {
+    return -1
+  }
+  return 0
+}
+
+function create(ctx) {
+  const { caseInsensitive } = ctx.options[0] || defaultOption
+
+  const getNameForSort = (node) => (
+    caseInsensitive ? node.imported.name.toLowerCase() : node.imported.name
+  )
+
+  return {
+    ImportDeclaration: (node) => {
+      const imports = node.specifiers.filter(
+        s => s.type === 'ImportSpecifier'
+      )
+
+      const ordered = imports.every((val, idx) => (
+        idx >= imports.length - 1
+        || getNameForSort(val) <= getNameForSort(imports[idx + 1])
+      ))
+      if (ordered) {
+        return
+      }
+
+      const fix = (fixer) => {
+        const orderedImports = [...imports]
+        orderedImports.sort((nodeA, nodeB) => sortImport(
+          getNameForSort(nodeA),
+          getNameForSort(nodeB)
+        ))
+        return orderedImports.map((orderedImport, idx) => fixer.replaceText(
+          imports[idx], buildImportString(orderedImport)
+        ))
+      }
+
+      ctx.report({
+        fix,
+        node,
+        messageId: 'notInOrder',
+      })
+    },
+  }
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    schema,
+    messages,
+    docs: {
+      url: docsUrl('order-member'),
+    },
+  },
+  create,
+}

--- a/tests/src/rules/order-member.js
+++ b/tests/src/rules/order-member.js
@@ -1,0 +1,58 @@
+import { test } from '../utils';
+import { RuleTester } from 'eslint';
+
+const ruleTester = new RuleTester();
+const rule = require('rules/order-member');
+
+ruleTester.run('importOrder', rule, {
+  valid: [
+    test({
+      code: "import { A, Z, a, b, c as z, d } from 'file';",
+    }),
+    test({
+      code: "import { a, b, c as z, d } from 'file';",
+    }),
+    test({
+      code: "import { a, A, B, b } from 'file';",
+      options: [{ caseInsensitive: true }],
+    }),
+    test({
+      code: "import defaultImport from 'file';",
+    }),
+    test({
+      code: "import * as namespaceImport from 'file';",
+    }),
+    test({
+      code: "import defaultImport, * as namespaceImport from 'file';",
+    }),
+    test({
+      code: "import defaultImport, { a, b, c as z, d } from 'file';",
+      options: [{ caseInsensitive: true }],
+    }),
+  ],
+  invalid: [
+    test({
+      code: "import { c, a } from 'file'",
+      options: [{ caseInsensitive: true }],
+      output: "import { a, c } from 'file'",
+      errors: [{ messageId: 'notInOrder' }],
+    }),
+    test({
+      // sort must be stable
+      code: "import { aa, c, Aa, B as z, b } from 'file'",
+      options: [{ caseInsensitive: true }],
+      output: "import { aa, Aa, B as z, b, c } from 'file'",
+      errors: [{ messageId: 'notInOrder' }],
+    }),
+    test({
+      code: "import defaultImport, { a, z, e, b, q } from 'file';",
+      output: "import defaultImport, { a, b, e, q, z } from 'file';",
+      errors: [{ messageId: 'notInOrder' }],
+    }),
+    test({
+      code: "import defaultImport, { a, z, Z, e, A, b, q } from 'file';",
+      output: "import defaultImport, { A, Z, a, b, e, q, z } from 'file';",
+      errors: [{ messageId: 'notInOrder' }],
+    }),
+  ],
+});


### PR DESCRIPTION
Add a new rule to order the import member.

e.g.
`import { c, b, d, a, e } from 'foo'`
becomes
`import { a, b, c, d, e } from 'foo'`

It's case sensitive by default.
e.g.
`import { c, b, d, A, a, Z, e } from 'foo'`
becomes
`import { A, Z, a, b, c, d, e } from 'foo'`

There is a option to make it case insensitive
e.g.
`import { c, b, d, A, a, B, e } from 'foo'`
becomes (It's stable sort)
`import { A, a, b, B, c, d, e } from 'foo'`


**The doc will be updated once approved**