### PR TITLE
[bugfix] Skip warning on type interfaces

### DIFF
--- a/src/rules/prefer-default-export.js
+++ b/src/rules/prefer-default-export.js
@@ -47,12 +47,16 @@ module.exports = {
         // if there are specifiers, node.declaration should be null
         if (!node.declaration) return
 
-        // don't warn on single type aliases or declarations
+        // don't warn on single type aliases, declarations, or interfaces
         if (node.exportKind === 'type') return
 
+        const { type } = node.declaration
+
         if (
-          node.declaration.type === 'TSTypeAliasDeclaration' ||
-          node.declaration.type === 'TypeAlias'
+          type === 'TSTypeAliasDeclaration' ||
+          type === 'TypeAlias' ||
+          type === 'TSInterfaceDeclaration' ||
+          type === 'InterfaceDeclaration'
         ) {
           return
         }

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -175,6 +175,13 @@ context('Typescript', function() {
           },
           parserConfig,
         ),
+        test (
+          {
+            code: 'export interface foo { bar: string; }',
+            parser,
+          },
+          parserConfig,
+        ),
       ],
       invalid: [],
     });


### PR DESCRIPTION
Similar to https://github.com/benmosher/eslint-plugin-import/pull/1377,
we don't want this rule to apply to exported interfaces.