### PR TITLE
[extensions] Better document. Add unit tests. (#1248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-extraneous-dependencies`]: ensure `node.source` is truthy ([#1589], thanks [@ljharb])
 - [`extensions`]: Ignore query strings when checking for extensions ([#1572], thanks [@pcorpet])
 
+### Docs
+- [`extensions`]: improve `ignorePackages` docs ([#1248], thanks [@ivo-stefchev])
+
 ### Added
 - [`order`]: add option pathGroupsExcludedImportTypes to allow ordering of external import types ([#1565], thanks [@Mairu])
 
@@ -693,6 +696,7 @@ for info on changes for earlier releases.
 [#1277]: https://github.com/benmosher/eslint-plugin-import/pull/1277
 [#1257]: https://github.com/benmosher/eslint-plugin-import/pull/1257
 [#1253]: https://github.com/benmosher/eslint-plugin-import/pull/1253
+[#1248]: https://github.com/benmosher/eslint-plugin-import/pull/1248
 [#1238]: https://github.com/benmosher/eslint-plugin-import/pull/1238
 [#1235]: https://github.com/benmosher/eslint-plugin-import/pull/1235
 [#1234]: https://github.com/benmosher/eslint-plugin-import/pull/1234
@@ -1063,3 +1067,4 @@ for info on changes for earlier releases.
 [@dbrewer5]: https://github.com/dbrewer5
 [@rsolomon]: https://github.com/rsolomon
 [@joaovieira]: https://github.com/joaovieira
+[@ivo-stefchev]: https://github.com/ivo-stefchev

--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -29,12 +29,29 @@ By providing both a string and an object, the string will set the default settin
   <severity>,
   "never" | "always" | "ignorePackages",
   {
-    <extension>: "never" | "always" | "ignorePackages" 
+    <extension>: "never" | "always" | "ignorePackages"
   }
 ]
 ```
 
 For example, `["error", "never", { "svg": "always" }]` would require that all extensions are omitted, except for "svg".
+
+`ignorePackages` can be set as a separate boolean option like this:
+```
+"import/extensions": [
+  <severity>,
+  "never" | "always" | "ignorePackages",
+  {
+    ignorePackages: true | false,
+    pattern: {
+      <extension>: "never" | "always" | "ignorePackages"
+    }
+  }
+]
+```
+In that case, if you still want to specify extensions, you can do so inside the **pattern** property.
+Default value of `ignorePackages` is `false`.
+
 
 ### Exception
 


### PR DESCRIPTION
I was curious of how this rule worked, so I went the easiest way and wrote a bunch of unit tests for the buildProperties (a method that returns the options from the config for the extensions rule) method.