### PR TITLE
fix [import/named] for importing from a module which re-exports named exports from a node_modules module

### DIFF
--- a/tests/files/re-export-node_modules.js
+++ b/tests/files/re-export-node_modules.js
@@ -1,0 +1,1 @@
+export * from 'eslint'

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -26,6 +26,7 @@ ruleTester.run('named', rule, {
     test({code: 'import { destructingRenamedAssign } from "./named-exports"'}),
     test({code: 'import { ActionTypes } from "./qc"'}),
     test({code: 'import {a, b, c, d} from "./re-export"'}),
+    test({code: 'import {RuleTester} from "./re-export-node_modules"'}),
 
     test({ code: 'import { jsxFoo } from "./jsx/AnotherComponent"'
          , settings: { 'import/resolve': { 'extensions': ['.js', '.jsx'] } } }),


### PR DESCRIPTION
This adds a failing test for #1446

I'm not sure how to proceed, but hopefully this helps someone diagnose the issue.