### PR TITLE
[core]: regex marking packages as internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 
 ### Added
+- [`internal-regex`]: regex pattern for marking packages "internal"  ([#1491], thanks [@Librazy])
+
+### Added
 - [`group-exports`]: make aggregate module exports valid ([#1472], thanks [@atikenny])
 - [`no-namespace`]: Make rule fixable ([#1401], thanks [@TrevorBurnham])
 - support `parseForESLint` from custom parser ([#1435], thanks [@JounQin])

--- a/README.md
+++ b/README.md
@@ -402,6 +402,20 @@ settings:
 [`eslint_d`]: https://www.npmjs.com/package/eslint_d
 [`eslint-loader`]: https://www.npmjs.com/package/eslint-loader
 
+#### `import/internal-regex`
+
+A regex for packages should be treated as internal. Useful when you are utilizing a monorepo setup or developing a set of packages that depend on each other.
+
+By default, any package referenced from [`import/external-module-folders`](#importexternal-module-folders) will be considered as "external", including packages in a monorepo like yarn workspace or lerna emvironentment. If you want to mark these packages as "internal" this will be useful.
+
+For example, if you pacakges in a monorepo are all in `@scope`, you can configure `import/internal-regex` like this
+
+```yaml
+# .eslintrc.yml
+settings:
+  import/internal-regex: ^@scope/
+```
+
 
 ## SublimeLinter-eslint
 

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -168,4 +168,8 @@ import sibling from './foo';
 
 - [`import/external-module-folders`] setting
 
+- [`import/internal-regex`] setting
+
 [`import/external-module-folders`]: ../../README.md#importexternal-module-folders
+
+[`import/internal-regex`]: ../../README.md#importinternal-regex

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -54,8 +54,9 @@ export function isScopedMain(name) {
 }
 
 function isInternalModule(name, settings, path) {
+  const internalScope = (settings && settings['import/internal-regex'])
   const matchesScopedOrExternalRegExp = scopedRegExp.test(name) || externalModuleRegExp.test(name)
-  return (matchesScopedOrExternalRegExp && !isExternalPath(path, name, settings))
+  return (matchesScopedOrExternalRegExp && (internalScope && new RegExp(internalScope).test(name) || !isExternalPath(path, name, settings)))
 }
 
 function isRelativeToParent(name) {

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -51,7 +51,7 @@ describe('importType(name)', function () {
     const pathContext = testContext({ 'import/resolver': { node: { paths: [pathToTestFiles] } } })
     expect(importType('@importType/index', pathContext)).to.equal('internal')
   })
-    
+
   it("should return 'internal' for internal modules that are referenced by aliases", function () {
     const pathContext = testContext({ 'import/resolver': { node: { paths: [pathToTestFiles] } } })
     expect(importType('@my-alias/fn', pathContext)).to.equal('internal')
@@ -128,6 +128,16 @@ describe('importType(name)', function () {
   it("should return 'internal' for module from 'node_modules' if 'node_modules' missed in 'external-module-folders'", function() {
     const foldersContext = testContext({ 'import/external-module-folders': [] })
     expect(importType('resolve', foldersContext)).to.equal('internal')
+  })
+
+  it("should return 'internal' for module from 'node_modules' if its name matched 'internal-regex'", function() {
+    const foldersContext = testContext({ 'import/internal-regex': '^@org' })
+    expect(importType('@org/foobar', foldersContext)).to.equal('internal')
+  })
+
+  it("should return 'external' for module from 'node_modules' if its name did not match 'internal-regex'", function() {
+    const foldersContext = testContext({ 'import/internal-regex': '^@bar' })
+    expect(importType('@org/foobar', foldersContext)).to.equal('external')
   })
 
   it("should return 'external' for module from 'node_modules' if 'node_modules' contained in 'external-module-folders'", function() {


### PR DESCRIPTION
fixes #1125

We are developing packages in a monorepo and packages depend on each other so we need to separate our package from external dependency. We used to [tslint/ordered-imports](https://palantir.github.io/tslint/rules/ordered-imports/) which allow custom group by regex pattern.

This PR added a new setting which allowed user to provide a regex pattern and packages that match that pattern will be marked internal.