### PR TITLE
fix: utils requires for resolver-node to be dependent #828

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -27,5 +27,8 @@
   "dependencies": {
     "debug": "^2.6.8",
     "pkg-dir": "^2.0.0"
+  },
+  "peerDependencies": {
+    "eslint-import-resolver-node": "^0.3.2"
   }
 }


### PR DESCRIPTION
fix https://github.com/benmosher/eslint-plugin-import/issues/828.
Tested with pnpm by linking resolver-node to module-utils's node_modules folder as if it was declared in peerDependencies, it worked. So I'm assuming just putting it in peerDependencies would work too.