### PR TITLE
fix: import/no-cycle triggering errors for Flow imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`prefer-default-export`]: fix false positive with type export ([#1506], thanks [@golopot])
 - [`extensions`]: Fix `ignorePackages` to produce errors ([#1521], thanks [@saschanaz])
 - [`no-unused-modules`]: fix crash due to `export *` ([#1496], thanks [@Taranys])
+- [`no-cycle`]: should not warn for Flow imports ([#1494], thanks [@maxmalov])
 
 ### Docs
 - [`no-useless-path-segments`]: add docs for option `commonjs` ([#1507], thanks [@golopot])
@@ -629,6 +630,7 @@ for info on changes for earlier releases.
 [#1506]: https://github.com/benmosher/eslint-plugin-import/pull/1506
 [#1496]: https://github.com/benmosher/eslint-plugin-import/pull/1496
 [#1495]: https://github.com/benmosher/eslint-plugin-import/pull/1495
+[#1494]: https://github.com/benmosher/eslint-plugin-import/pull/1494
 [#1472]: https://github.com/benmosher/eslint-plugin-import/pull/1472
 [#1470]: https://github.com/benmosher/eslint-plugin-import/pull/1470
 [#1436]: https://github.com/benmosher/eslint-plugin-import/pull/1436
@@ -1019,3 +1021,4 @@ for info on changes for earlier releases.
 [@saschanaz]: https://github.com/saschanaz
 [@brettz9]: https://github.com/brettz9
 [@Taranys]: https://github.com/Taranys
+[@maxmalov]: https://github.com/maxmalov

--- a/tests/files/cycles/flow-types-depth-one.js
+++ b/tests/files/cycles/flow-types-depth-one.js
@@ -1,0 +1,6 @@
+// @flow
+
+import type { FooType } from './flow-types-depth-two';
+import { type BarType, bar } from './flow-types-depth-two';
+
+export { bar }

--- a/tests/files/cycles/flow-types-depth-two.js
+++ b/tests/files/cycles/flow-types-depth-two.js
@@ -1,0 +1,1 @@
+import { foo } from './depth-one'

--- a/tests/files/cycles/flow-types.js
+++ b/tests/files/cycles/flow-types.js
@@ -1,0 +1,6 @@
+// @flow
+
+import type { FooType } from './flow-types-depth-two';
+import { type BarType } from './flow-types-depth-two';
+
+export const bar = 1;

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -53,6 +53,10 @@ ruleTester.run('no-cycle', rule, {
       code: 'import type { FooType, BarType } from "./depth-one"',
       parser: require.resolve('babel-eslint'),
     }),
+    test({
+      code: 'import { bar } from "./flow-types"',
+      parser: require.resolve('babel-eslint'),
+    }),
   ],
   invalid: [
     test({
@@ -119,6 +123,11 @@ ruleTester.run('no-cycle', rule, {
       code: 'import("./depth-three-indirect")',
       errors: [error(`Dependency cycle via ./depth-two:1=>./depth-one:1`)],
       parser: require.resolve('babel-eslint'),
+    }),
+    test({
+      code: 'import { bar } from "./flow-types-depth-one"',
+      parser: require.resolve('babel-eslint'),
+      errors: [error(`Dependency cycle via ./flow-types-depth-two:4=>./depth-one:1`)],
     }),
   ],
 })


### PR DESCRIPTION
The changes fix a complex circular dependency where Flow type imports are transient dependencies of the checked module. Basically such imports can be ignored too since they will be stripped anyway

Fixes #1343