### PR TITLE
Fix crash due to export * with no-unused-modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`import/order`]: fix autofix to not move imports across fn calls ([#1253], thanks [@tihonove])
 - [`prefer-default-export`]: fix false positive with type export ([#1506], thanks [@golopot])
 - [`extensions`]: Fix `ignorePackages` to produce errors ([#1521], thanks [@saschanaz])
+- [`no-unused-modules`]: fix crash due to `export *` ([#1496], thanks [@Taranys])
 
 ### Docs
 - [`no-useless-path-segments`]: add docs for option `commonjs` ([#1507], thanks [@golopot])
@@ -626,6 +627,7 @@ for info on changes for earlier releases.
 [#1519]: https://github.com/benmosher/eslint-plugin-import/pull/1519
 [#1507]: https://github.com/benmosher/eslint-plugin-import/pull/1507
 [#1506]: https://github.com/benmosher/eslint-plugin-import/pull/1506
+[#1496]: https://github.com/benmosher/eslint-plugin-import/pull/1496
 [#1495]: https://github.com/benmosher/eslint-plugin-import/pull/1495
 [#1472]: https://github.com/benmosher/eslint-plugin-import/pull/1472
 [#1470]: https://github.com/benmosher/eslint-plugin-import/pull/1470
@@ -1016,3 +1018,4 @@ for info on changes for earlier releases.
 [@brendo]: https://github.com/brendo
 [@saschanaz]: https://github.com/saschanaz
 [@brettz9]: https://github.com/brettz9
+[@Taranys]: https://github.com/Taranys

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -88,8 +88,13 @@ const prepareImportsAndExports = (srcFiles, context) => {
 
       // dependencies === export * from
       const currentExportAll = new Set()
-      dependencies.forEach(value => {
-        currentExportAll.add(value().path)
+      dependencies.forEach(getDependency => {
+        const dependency = getDependency()
+        if (dependency === null) {
+          return
+        }
+
+        currentExportAll.add(dependency.path)
       })
       exportAll.set(file, currentExportAll)
 

--- a/tests/files/no-unused-modules/cjs.js
+++ b/tests/files/no-unused-modules/cjs.js
@@ -1,0 +1,7 @@
+// Simple import extracted from 'redux-starter-kit' compiled file
+
+function isPlain(val) {
+  return true;
+}
+
+exports.isPlain = isPlain;

--- a/tests/files/no-unused-modules/filte-r.js
+++ b/tests/files/no-unused-modules/filte-r.js
@@ -1,0 +1,1 @@
+export * from './cjs'

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -453,6 +453,11 @@ describe('test behaviour for new file', () => {
       test({ options: unusedExportsOptions,
              code: `export * from '${testFilePath('./no-unused-modules/file-added-0.js')}'`,
              filename: testFilePath('./no-unused-modules/file-0.js')}),
+      // Test export * from 'external-compiled-library'
+      test({ options: unusedExportsOptions,
+        code: `export * from 'external-compiled-library'`,
+        filename: testFilePath('./no-unused-modules/file-r.js'),
+      }),
     ],
     invalid: [
       test({ options: unusedExportsOptions,
@@ -668,5 +673,16 @@ describe('correctly report flow types', () => {
         ],
       }),
     ],
+  })
+})
+
+describe('Avoid errors if re-export all from umd compiled library', () => {
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({ options: unusedExportsOptions,
+        code: `export * from '${testFilePath('./no-unused-modules/bin.js')}'`,
+        filename: testFilePath('./no-unused-modules/main/index.js')}),
+    ],
+    invalid: [],
   })
 })


### PR DESCRIPTION
fix #1382 

After investigating, It comes from this line
https://github.com/benmosher/eslint-plugin-import/blob/5e143b23f3b89096e1b6a268af723f60c1ecb22f/src/ExportMap.js#L316

In my case, `export * from 'redux-starter-kit'` is not detected as unambigous and it `return null` which crash no-unused-modules

I didn't find any good way to test it. I'm looking forward for some advices on how I can test this issue :)