### PR TITLE
feat: enable passing cwd as an option to webpack resolve

### DIFF
--- a/resolvers/webpack/CHANGELOG.md
+++ b/resolvers/webpack/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Added
+- [New] enable passing cwd as an option to `eslint-import-resolver-webpack` ([#1503], thanks [@Aghassi])
+
 ## 0.11.1 - 2019-04-13
 
 ### Fixed
@@ -117,6 +120,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - `interpret` configs (such as `.babel.js`).
   Thanks to [@gausie] for the initial PR ([#164], ages ago! 😅) and [@jquense] for tests ([#278]).
 
+[#1503]: https://github.com/benmosher/eslint-plugin-import/pull/1503
 [#1297]: https://github.com/benmosher/eslint-plugin-import/pull/1297
 [#1261]: https://github.com/benmosher/eslint-plugin-import/pull/1261
 [#1220]: https://github.com/benmosher/eslint-plugin-import/pull/1220
@@ -166,3 +170,4 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 [@mattkrick]: https://github.com/mattkrick
 [@idudinov]: https://github.com/idudinov
 [@keann]: https://github.com/keann
+[@Aghassi]: https://github.com/Aghassi

--- a/resolvers/webpack/test/example.js
+++ b/resolvers/webpack/test/example.js
@@ -1,0 +1,9 @@
+var path = require('path')
+
+var resolve = require('../index').resolve
+
+var file = path.join(__dirname, 'files', 'src', 'dummy.js')
+
+var webpackDir = path.join(__dirname, "different-package-location")
+
+console.log(resolve('main-module', file, { config: "webpack.config.js", cwd: webpackDir}))

--- a/resolvers/webpack/test/root.js
+++ b/resolvers/webpack/test/root.js
@@ -6,6 +6,7 @@ var resolve = require('../index').resolve
 
 
 var file = path.join(__dirname, 'files', 'src', 'dummy.js')
+var webpackDir = path.join(__dirname, "different-package-location")
 
 describe("root", function () {
   it("works", function () {
@@ -32,5 +33,13 @@ describe("root", function () {
       .property('path')
       .to.equal(path.join(__dirname, 'files', 'bower_components', 'typeahead.js'))
   })
-
+  it("supports passing a different directory to load webpack from", function () {
+    // Webpack should still be able to resolve the config here
+    expect(resolve('main-module', file, { config: "webpack.config.js", cwd: webpackDir}))
+      .property('path')
+      .to.equal(path.join(__dirname, 'files', 'src', 'main-module.js'))
+    expect(resolve('typeahead', file, { config: "webpack.config.js", cwd: webpackDir}))
+      .property('path')
+      .to.equal(path.join(__dirname, 'files', 'bower_components', 'typeahead.js'))
+  })
 })


### PR DESCRIPTION
This enables users to change the lookup of the webpack module
for the resolve functionality should it not be in the user's
local node_modules. This pertains to the case of a CLI where the
CLI may be in charge of webpack, and the user's repo doesn't have it.

Related to https://github.com/benmosher/eslint-plugin-import/issues/1502