### PR TITLE
Fix broken .babelrc

### DIFF
--- a/resolvers/webpack/.babelrc
+++ b/resolvers/webpack/.babelrc
@@ -1,1 +1,3 @@
-../../.babelrc
+{
+  "extends": "../../.babelrc"
+}

--- a/resolvers/webpack/.babelrc
+++ b/resolvers/webpack/.babelrc
@@ -1,3 +1,3 @@
 {
-  "extends": "../../.babelrc "
+  "extends": "../../.babelrc"
 }

--- a/resolvers/webpack/.babelrc
+++ b/resolvers/webpack/.babelrc
@@ -1,3 +1,3 @@
 {
-  "extends": "../../.babelrc"
+  "extends": "../../.babelrc "
 }


### PR DESCRIPTION
Reason for change:
If I checkout the code with Windows line ends (CRLF), `npm install` where appropriate, and `npm test` - the tests fail.

Deleting this `.babelrc` file makes the test pass, but [breaks CI](https://github.com/benmosher/eslint-plugin-import/pull/1514).

Opening the old `.babelrc` file in my editor yields the following error: "Expected a JSON object, array or literal .jsonc(0)". (sort of linting the .babelrc)