### PR TITLE
When populating ExportMap, only load file if it's not ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - `default`: make error message less confusing ([#1470], thanks [@golopot])
+- Improve performance of `ExportMap.for` by only loading paths when necessary. ([#1519], thanks [@brendo])
 - Support export of a merged TypeScript namespace declaration ([#1495], thanks [@benmunro])
 - [`import/order`]: fix autofix to not move imports across fn calls ([#1253], thanks [@tihonove])
 - [`prefer-default-export`]: fix false positive with type export ([#1506], thanks [@golopot])
@@ -610,6 +611,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1519]: https://github.com/benmosher/eslint-plugin-import/pull/1519
 [#1506]: https://github.com/benmosher/eslint-plugin-import/pull/1506
 [#1495]: https://github.com/benmosher/eslint-plugin-import/pull/1495
 [#1472]: https://github.com/benmosher/eslint-plugin-import/pull/1472
@@ -998,3 +1000,4 @@ for info on changes for earlier releases.
 [@TrevorBurnham]: https://github.com/TrevorBurnham
 [@benmunro]: https://github.com/benmunro
 [@tihonove]: https://github.com/tihonove
+[@brendo]: https://github.com/brendo

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -310,11 +310,18 @@ ExportMap.for = function (context) {
     return null
   }
 
+  // check for and cache ignore
+  if (isIgnored(path, context)) {
+    log('ignored path due to ignore settings:', path)
+    exportCache.set(cacheKey, null)
+    return null
+  }
+
   const content = fs.readFileSync(path, { encoding: 'utf8' })
 
-  // check for and cache ignore
-  if (isIgnored(path, context) || !unambiguous.test(content)) {
-    log('ignored path due to unambiguous regex or ignore settings:', path)
+  // check for and cache unambigious modules
+  if (!unambiguous.test(content)) {
+    log('ignored path due to unambiguous regex:', path)
     exportCache.set(cacheKey, null)
     return null
   }


### PR DESCRIPTION
I was debugging a project trying to understand better how the `import/no-deprecated` rule works. While doing this I discovered that `ExportMap.for` will do a I/O hit to read the `path` _even_ if the `path` is ignored:

https://github.com/benmosher/eslint-plugin-import/blob/112a0bf442e52b25cd7029a9905df2508e191ac1/src/ExportMap.js#L313-L320

When the `path` is ignored, the function early exits and the `content` variable is not referenced, so it's essentially a wasted I/O hit.

This PR tweaks the condition to do the ignore check in one block, and check ambiguity in another.  

In theory this should result in a performance boost for projects that ignore many paths as they will be skipped based off the ignore, rather than being loaded from the file system. It also cleans up the log a little bit because we know exactly why the path was ignored, because of the regex, or because it's ambiguous.