### PR TITLE
`first`: Allow reexports before imports

### DIFF
--- a/src/rules/first.js
+++ b/src/rules/first.js
@@ -1,5 +1,16 @@
 import docsUrl from '../docsUrl'
 
+function isReexport(node) {
+  switch (node.type) {
+    case 'ExportAllDeclaration':
+      return true
+    case 'ExportNamedDeclaration':
+      return !!node.source
+    default:
+      return false
+  }
+}
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -69,7 +80,7 @@ module.exports = {
             } else {
               lastLegalImp = node
             }
-          } else {
+          } else if (!isReexport(node)) {
             nonImportCount++
           }
         })

--- a/tests/src/rules/first.js
+++ b/tests/src/rules/first.js
@@ -13,6 +13,10 @@ ruleTester.run('first', rule, {
   , test({ code: "import { x } from './foo'; import { y } from 'bar'" })
   , test({ code: "'use directive';\
                   import { x } from 'foo';" })
+  , test({ code: "export { y } from 'bar';\
+                  import { x } from 'foo';" })
+  , test({ code: "export * from 'bar';\
+                  import { x } from 'foo';" })
   ,
   ],
   invalid: [


### PR DESCRIPTION
Reexports are also kinda imports and they don't even create local bindings so I believe this should be allowed.