### PR TITLE
[Typescript] Lookup for external modules in @types folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - [`no-unused-modules`]: fix usage of `import/extensions` settings ([#1560], thanks [@stekycz])
-
-### Fixed
 - [`import/extensions`]: ignore non-main modules ([#1563], thanks [@saschanaz])
+- TypeScript config: lookup for external modules in @types folder ([#1526], thanks [@joaovieira])
 
 ## [2.19.1] - 2019-12-08
 ### Fixed
@@ -634,6 +633,7 @@ for info on changes for earlier releases.
 [#1560]: https://github.com/benmosher/eslint-plugin-import/pull/1560
 [#1551]: https://github.com/benmosher/eslint-plugin-import/pull/1551
 [#1542]: https://github.com/benmosher/eslint-plugin-import/pull/1542
+[#1526]: https://github.com/benmosher/eslint-plugin-import/pull/1526
 [#1521]: https://github.com/benmosher/eslint-plugin-import/pull/1521
 [#1519]: https://github.com/benmosher/eslint-plugin-import/pull/1519
 [#1507]: https://github.com/benmosher/eslint-plugin-import/pull/1507
@@ -1054,3 +1054,4 @@ for info on changes for earlier releases.
 [@stekycz]: https://github.com/stekycz
 [@dbrewer5]: https://github.com/dbrewer5
 [@rsolomon]: https://github.com/rsolomon
+[@joaovieira]: https://github.com/joaovieira

--- a/config/typescript.js
+++ b/config/typescript.js
@@ -8,6 +8,7 @@ module.exports = {
 
   settings: {
     'import/extensions': allExtensions,
+    'import/external-module-folders': ['node_modules', 'node_modules/@types'],
     'import/parsers': {
       '@typescript-eslint/parser': ['.ts', '.tsx', '.d.ts'],
     },

--- a/tests/src/config/typescript.js
+++ b/tests/src/config/typescript.js
@@ -1,0 +1,14 @@
+import path from 'path'
+import { expect } from 'chai'
+
+const config = require(path.join(__dirname, '..', '..', '..', 'config', 'typescript'))
+
+describe('config typescript', () => {
+  // https://github.com/benmosher/eslint-plugin-import/issues/1525
+  it('should mark @types paths as external', () => {
+    const externalModuleFolders = config.settings['import/external-module-folders']
+    expect(externalModuleFolders).to.exist
+    expect(externalModuleFolders).to.contain('node_modules')
+    expect(externalModuleFolders).to.contain('node_modules/@types')
+  })
+})


### PR DESCRIPTION
### Why
When using TypeScript an external module can be resolved to its type definition file located in `node_modules/@types` from `eslint-import-resolver-typescript@2.0.0`. At the moment, that module would be marked as "internal" because the module is not found directly inside `node_modules`, but instead nested inside `@types`.

### What
This PR just adds the `node_modules/@types` folder to lookup for external modules when using the TypeScript config.

Fixes #1525. Fixes #1541.