### PR TITLE
Fix linting errors.

### DIFF
--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -23,7 +23,7 @@ function extractDepFields(pkg) {
     peerDependencies: pkg.peerDependencies || {},
     // BundledDeps should be in the form of an array, but object notation is also supported by
     // `npm`, so we convert it to an array if it is an object
-    bundledDependencies: arrayOrKeys(pkg.bundleDependencies || pkg.bundledDependencies || [])
+    bundledDependencies: arrayOrKeys(pkg.bundleDependencies || pkg.bundledDependencies || []),
   }
 }
 

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -85,7 +85,7 @@ describe('ExportMap', function () {
     var imports = ExportMap.parse(
       path,
       contents,
-      { parserPath: 'babel-eslint', settings: {} }
+      { parserPath: 'babel-eslint', settings: {} },
     )
 
     expect(imports, 'imports').to.exist

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -16,15 +16,15 @@ describe('resolve', function () {
     const testContext = utils.testContext({ 'import/resolver': './foo-bar-resolver-v1' })
 
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                       )).to.equal(utils.testFilePath('./bar.jsx'))
 
     expect(resolve( '../files/exception'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } }),
                     )).to.equal(undefined)
 
     expect(resolve( '../files/not-found'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('not-found.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('not-found.js') } }),
                     )).to.equal(undefined)
   })
 
@@ -32,15 +32,15 @@ describe('resolve', function () {
     const testContext = utils.testContext({ 'import/resolver': './foo-bar-resolver-no-version' })
 
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                       )).to.equal(utils.testFilePath('./bar.jsx'))
 
     expect(resolve( '../files/exception'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } }),
                     )).to.equal(undefined)
 
     expect(resolve( '../files/not-found'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('not-found.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('not-found.js') } }),
                     )).to.equal(undefined)
   })
 
@@ -52,12 +52,12 @@ describe('resolve', function () {
     }
 
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                       )).to.equal(utils.testFilePath('./bar.jsx'))
 
     testContextReports.length = 0
     expect(resolve( '../files/exception'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } }),
                     )).to.equal(undefined)
     expect(testContextReports[0]).to.be.an('object')
     expect(testContextReports[0].message).to.equal('Resolve error: foo-bar-resolver-v2 resolve test exception')
@@ -65,7 +65,7 @@ describe('resolve', function () {
 
     testContextReports.length = 0
     expect(resolve( '../files/not-found'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('not-found.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('not-found.js') } }),
                     )).to.equal(undefined)
     expect(testContextReports.length).to.equal(0)
   })
@@ -74,7 +74,7 @@ describe('resolve', function () {
     const testContext = utils.testContext({ 'import/resolver': [ './foo-bar-resolver-v2', './foo-bar-resolver-v1' ] })
 
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                       )).to.equal(utils.testFilePath('./bar.jsx'))
   })
 
@@ -82,7 +82,7 @@ describe('resolve', function () {
     const testContext = utils.testContext({ 'import/resolver': { './foo-bar-resolver-v2': {} } })
 
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                       )).to.equal(utils.testFilePath('./bar.jsx'))
   })
 
@@ -90,7 +90,7 @@ describe('resolve', function () {
     const testContext = utils.testContext({ 'import/resolver': [ { './foo-bar-resolver-v2': {} }, { './foo-bar-resolver-v1': {} } ] })
 
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                       )).to.equal(utils.testFilePath('./bar.jsx'))
   })
 
@@ -103,7 +103,7 @@ describe('resolve', function () {
 
     testContextReports.length = 0
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                     )).to.equal(undefined)
     expect(testContextReports[0]).to.be.an('object')
     expect(testContextReports[0].message).to.equal('Resolve error: invalid resolver config')
@@ -119,7 +119,7 @@ describe('resolve', function () {
     }
     testContextReports.length = 0
     expect(resolve( '../files/foo'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
                     )).to.equal(undefined)
     expect(testContextReports[0]).to.be.an('object')
     expect(testContextReports[0].message).to.equal(`Resolve error: ${resolverName} with invalid interface loaded as resolver`)
@@ -130,7 +130,7 @@ describe('resolve', function () {
     const testContext = utils.testContext({ 'import/resolve': { 'extensions': ['.jsx'] }})
 
     expect(resolve( './jsx/MyCoolComponent'
-                      , testContext
+                      , testContext,
                       )).to.equal(utils.testFilePath('./jsx/MyCoolComponent.jsx'))
   })
 
@@ -142,7 +142,7 @@ describe('resolve', function () {
     }
 
     expect(resolve( '../files/exception'
-                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } })
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('exception.js') } }),
                     )).to.equal(undefined)
     expect(testContextReports[0]).to.be.an('object')
     expect(testContextReports[0].message).to.equal('Resolve error: TEST ERROR')

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -45,7 +45,7 @@ ruleTester.run('no-duplicates', rule, {
       output: "import { x , y } from './bar'; ",
       settings: { 'import/resolve': {
         paths: [path.join( process.cwd()
-                         , 'tests', 'files'
+                         , 'tests', 'files',
                          )] }},
       errors: 2, // path ends up hardcoded
      }),

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -15,7 +15,7 @@ function runResolverTests(resolver) {
   function rest(specs) {
     specs.settings = Object.assign({},
       specs.settings,
-      { 'import/resolver': resolver }
+      { 'import/resolver': resolver },
     )
 
     return test(specs)


### PR DESCRIPTION
Run `eslint . --fix`. There are still 11 warnings. Not entirely sure if they were already there before. Happy to fix those too.