### PR TITLE
[Refactor] Avoid superfluous calls and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Added
 - [`internal-regex`]: regex pattern for marking packages "internal"  ([#1491], thanks [@Librazy])
-
-### Added
 - [`group-exports`]: make aggregate module exports valid ([#1472], thanks [@atikenny])
 - [`no-namespace`]: Make rule fixable ([#1401], thanks [@TrevorBurnham])
 - support `parseForESLint` from custom parser ([#1435], thanks [@JounQin])
@@ -24,6 +22,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Docs
 - [`no-useless-path-segments`]: add docs for option `commonjs` ([#1507], thanks [@golopot])
+
+### Changed
+- [`no-unused-modules`]/`eslint-module-utils`: Avoid superfluous calls and code ([#1551], thanks [@brettz9])
 
 ## [2.18.2] - 2019-07-19
 - Skip warning on type interfaces ([#1425], thanks [@lencioni])
@@ -618,6 +619,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1551]: https://github.com/benmosher/eslint-plugin-import/pull/1551
 [#1521]: https://github.com/benmosher/eslint-plugin-import/pull/1521
 [#1519]: https://github.com/benmosher/eslint-plugin-import/pull/1519
 [#1507]: https://github.com/benmosher/eslint-plugin-import/pull/1507
@@ -1011,3 +1013,4 @@ for info on changes for earlier releases.
 [@tihonove]: https://github.com/tihonove
 [@brendo]: https://github.com/brendo
 [@saschanaz]: https://github.com/saschanaz
+[@brettz9]: https://github.com/brettz9

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -355,7 +355,7 @@ module.exports = {
 
       exportCount.delete(EXPORT_ALL_DECLARATION)
       exportCount.delete(IMPORT_NAMESPACE_SPECIFIER)
-      if (missingExports && exportCount.size < 1) {
+      if (exportCount.size < 1) {
         // node.body[0] === 'undefined' only happens, if everything is commented out in the file
         // being linted
         context.report(node.body[0] ? node.body[0] : node, 'No exports found')

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -340,7 +340,7 @@ function makeNewlinesBetweenReport (context, imported, newlinesBetweenImports) {
         context.report({
           node: previousImport.node,
           message: 'There should be at least one empty line between import groups',
-          fix: fixNewLineAfterImport(context, previousImport, currentImport),
+          fix: fixNewLineAfterImport(context, previousImport),
         })
       } else if (currentImport.rank === previousImport.rank
         && emptyLinesBetween > 0

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Changed
+ - Avoid superfluous calls and code ([#1551], thanks [@brettz9])
+
 ## v2.4.1 - 2019-07-19
 
 ### Fixed
@@ -52,6 +55,7 @@ Yanked due to critical issue with cache key resulting from #839.
 
 
 
+[#1551]: https://github.com/benmosher/eslint-plugin-import/pull/1551
 [#1409]: https://github.com/benmosher/eslint-plugin-import/pull/1409
 [#1356]: https://github.com/benmosher/eslint-plugin-import/pull/1356
 [#1290]: https://github.com/benmosher/eslint-plugin-import/pull/1290
@@ -65,3 +69,4 @@ Yanked due to critical issue with cache key resulting from #839.
 [@vikr01]: https://github.com/vikr01
 [@bradzacher]: https://github.com/bradzacher
 [@christophercurrie]: https://github.com/christophercurrie
+[@brettz9]: https://github.com/brettz9

--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -64,7 +64,7 @@ function relative(modulePath, sourceFile, settings) {
 function fullResolve(modulePath, sourceFile, settings) {
   // check if this is a bonus core module
   const coreSet = new Set(settings['import/core-modules'])
-  if (coreSet != null && coreSet.has(modulePath)) return { found: true, path: null }
+  if (coreSet.has(modulePath)) return { found: true, path: null }
 
   const sourceDir = path.dirname(sourceFile)
       , cacheKey = sourceDir + hashObject(settings).digest('hex') + modulePath


### PR DESCRIPTION
LGTM.com often identifies some issues not found by ESLint; this PR fixes the issues found at https://lgtm.com/projects/g/benmosher/eslint-plugin-import/?mode=list . In this case, they are just some harmless superfluous arguments and redundant checks, but helpful to fix both for clarity and to reduce noise among the lgtm alerts.

(The site has a [Github integration](https://lgtm.com/help/lgtm/github-apps-integration) which I find worth adding to check PRs.)