### PR TITLE
[import/order] Fix alphabetize bug with newlines-between

### DIFF
--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -599,15 +599,15 @@ module.exports = {
         registerNode(context, node, name, 'require', ranks, imported)
       },
       'Program:exit': function reportAndReset() {
+        if (newlinesBetweenImports !== 'ignore') {
+          makeNewlinesBetweenReport(context, imported, newlinesBetweenImports)
+        }
+
         if (alphabetize.order !== 'ignore') {
           mutateRanksToAlphabetize(imported, alphabetize.order)
         }
 
         makeOutOfOrderReport(context, imported)
-
-        if (newlinesBetweenImports !== 'ignore') {
-          makeNewlinesBetweenReport(context, imported, newlinesBetweenImports)
-        }
 
         imported = []
       },

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -560,6 +560,21 @@ ruleTester.run('order', rule, {
         alphabetize: {order: 'desc'},
       }],
     }),
+    // Option alphabetize with newlines-between: {order: 'asc', newlines-between: 'always'}
+    test({
+      code: `
+        import b from 'Bar';
+        import c from 'bar';
+        import a from 'foo';
+
+        import index from './';
+      `,
+      options: [{
+        groups: ['external', 'index'],
+        alphabetize: {order: 'asc'},
+        'newlines-between': 'always',
+      }],
+    }),
   ],
   invalid: [
     // builtin before external module (require)


### PR DESCRIPTION
Hello!

I tested the new `alphabetize` rule, and when used with `newlines-between: "always"`, the plugin mark as invalid any lines which have not newline around.

For example : 

```
import Constants from '@constants';
import Logger from '@server/tools/logger';
```

These lines are OK with this plugin configuration (1) : 

```
'import/order': [
	'error',
	{
		groups: [['builtin', 'external'], 'internal', 'parent', 'sibling'],
		'newlines-between': 'always',
	},
],
```

but are invalid with this plugin configuration (2) : 

```
'import/order': [
	'error',
	{
		alphabetize: { order: 'asc' },
		groups: [['builtin', 'external'], 'internal', 'parent', 'sibling'],
		'newlines-between': 'always',
	},
],
```

And the configuration (2) mark these lines as valid : 

```
import Constants from '@constants';

import Logger from '@server/tools/logger';
``` 

I checked the alphabetize PR, and I saw [this comment](https://github.com/benmosher/eslint-plugin-import/pull/1360#issuecomment-541590197) which is exactly the bug I have.
The [next comment](https://github.com/benmosher/eslint-plugin-import/pull/1360#issuecomment-541593412) gives a solution to the problem.

So I just implemented the solution, and I also add the associated test.

Fixes #1561.