### PR TITLE
fix [import/named] for importing from a module which re-exports `*` from node_modules or commonjs module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`extentions`]: Fix scope regex ([#1611], thanks [@yordis])
 - [`no-duplicates`]: allow duplicate imports if one is a namespace and the other not ([#1612], thanks [@sveyret])
 - Add some missing rule meta schemas and types ([#1620], thanks [@bmish])
+- [`named`]: for importing from a module which re-exports named exports from a `node_modules` module ([#1569], [#1447], thanks [@redbugz], [@kentcdodds])
 
 ### Changed
 - [`import/external-module-folders` setting] behavior is more strict now: it will only match complete path segments ([#1605], thanks [@skozin])
@@ -655,6 +656,7 @@ for info on changes for earlier releases.
 [#1589]: https://github.com/benmosher/eslint-plugin-import/issues/1589
 [#1586]: https://github.com/benmosher/eslint-plugin-import/pull/1586
 [#1572]: https://github.com/benmosher/eslint-plugin-import/pull/1572
+[#1569]: https://github.com/benmosher/eslint-plugin-import/pull/1569
 [#1563]: https://github.com/benmosher/eslint-plugin-import/pull/1563
 [#1560]: https://github.com/benmosher/eslint-plugin-import/pull/1560
 [#1551]: https://github.com/benmosher/eslint-plugin-import/pull/1551
@@ -670,6 +672,7 @@ for info on changes for earlier releases.
 [#1493]: https://github.com/benmosher/eslint-plugin-import/pull/1493
 [#1472]: https://github.com/benmosher/eslint-plugin-import/pull/1472
 [#1470]: https://github.com/benmosher/eslint-plugin-import/pull/1470
+[#1447]: https://github.com/benmosher/eslint-plugin-import/pull/1447
 [#1439]: https://github.com/benmosher/eslint-plugin-import/pull/1439
 [#1436]: https://github.com/benmosher/eslint-plugin-import/pull/1436
 [#1435]: https://github.com/benmosher/eslint-plugin-import/pull/1435
@@ -1089,3 +1092,5 @@ for info on changes for earlier releases.
 [@yordis]: https://github.com/yordis
 [@sveyret]: https://github.com/sveyret
 [@bmish]: https://github.com/bmish
+[@redbugz]: https://github.com/redbugz
+[@kentcdodds]: https://github.com/kentcdodds

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -106,6 +106,7 @@ export default class ExportMap {
     if (name !== 'default') {
       for (let dep of this.dependencies) {
         let innerMap = dep()
+        if (innerMap == null) return { found: true, path: [this] }
         // todo: report as unresolved?
         if (!innerMap) continue
 

--- a/tests/files/re-export-common-star.js
+++ b/tests/files/re-export-common-star.js
@@ -1,0 +1,1 @@
+export * from './common'

--- a/tests/files/re-export-node_modules.js
+++ b/tests/files/re-export-node_modules.js
@@ -1,0 +1,1 @@
+export * from 'eslint'

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -26,6 +26,7 @@ ruleTester.run('named', rule, {
     test({code: 'import { destructingRenamedAssign } from "./named-exports"'}),
     test({code: 'import { ActionTypes } from "./qc"'}),
     test({code: 'import {a, b, c, d} from "./re-export"'}),
+    test({code: 'import {RuleTester} from "./re-export-node_modules"'}),
 
     test({ code: 'import { jsxFoo } from "./jsx/AnotherComponent"'
          , settings: { 'import/resolve': { 'extensions': ['.js', '.jsx'] } } }),

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -26,6 +26,7 @@ ruleTester.run('named', rule, {
     test({code: 'import { destructingRenamedAssign } from "./named-exports"'}),
     test({code: 'import { ActionTypes } from "./qc"'}),
     test({code: 'import {a, b, c, d} from "./re-export"'}),
+    test({code: 'import {a, b, c} from "./re-export-common-star"'}),
     test({code: 'import {RuleTester} from "./re-export-node_modules"'}),
 
     test({ code: 'import { jsxFoo } from "./jsx/AnotherComponent"'


### PR DESCRIPTION
Fixes #1446 
Based on #1447 

When re-exporting `*` from a commonjs module, or a module in node_modules which comes through as a commonjs module, do not error since the commonjs exports cannot be evaluated. Treat with similar logic to ignored modules or directly importing from a commonjs module.

When re-exporting `*`, the module is listed in dependencies instead of `reexports`. There is similar logic for when re-exporting a named export, to check for a null from the exportCache, which I understand to mean an ignored or unparseable es5/commonjs module:
https://github.com/benmosher/eslint-plugin-import/blob/master/src/ExportMap.js#L91

There is a todo in this location, and I'm not sure if this code satisfies that todo and it can be removed or not.
Also, when logging the value of `innerMap`, I never it saw it be undefined. So it's possible the `continue` line is also no longer needed, but I am not sure.

This fixes `hasDeep`, but there is similar logic in `has` and `get`:
https://github.com/benmosher/eslint-plugin-import/blob/master/src/ExportMap.js#L68
https://github.com/benmosher/eslint-plugin-import/blob/master/src/ExportMap.js#L146
I'm not sure if those should get similar treatment, or if those are not relevant for this issue.