### PR TITLE
[New] `order`: add option pathGroupsExcludedImportTypes to allow ordering of external import types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-extraneous-dependencies`]: ensure `node.source` is truthy ([#1589], thanks [@ljharb])
 - [`extensions`]: Ignore query strings when checking for extensions ([#1572], thanks [@pcorpet])
 
+### Added
+- [`order`]: add option pathGroupsExcludedImportTypes to allow ordering of external import types ([#1565], thanks [@Mairu])
+
 ## [2.19.1] - 2019-12-08
 ### Fixed
 - [`no-extraneous-dependencies`]: ensure `node.source` exists
@@ -789,6 +792,7 @@ for info on changes for earlier releases.
 [#211]: https://github.com/benmosher/eslint-plugin-import/pull/211
 [#164]: https://github.com/benmosher/eslint-plugin-import/pull/164
 [#157]: https://github.com/benmosher/eslint-plugin-import/pull/157
+[#1565]: https://github.com/benmosher/eslint-plugin-import/issues/1565
 [#1366]: https://github.com/benmosher/eslint-plugin-import/issues/1366
 [#1334]: https://github.com/benmosher/eslint-plugin-import/issues/1334
 [#1323]: https://github.com/benmosher/eslint-plugin-import/issues/1323

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -96,7 +96,7 @@ You can set the options like this:
 
 ### `pathGroups: [array of objects]`:
 
-To be able so group by paths mostly needed with aliases pathGroups can be defined.
+To be able to group by paths mostly needed with aliases pathGroups can be defined.
 
 Properties of the objects
 
@@ -119,6 +119,28 @@ Properties of the objects
   }]
 }
 ```
+
+### `pathGroupsExcludedImportTypes: [array]`:
+
+This defines import types that are not handled by configured pathGroups.
+This is mostly needed when you want to handle path groups that look like external imports.
+
+Example:
+```json
+{
+  "import/order": ["error", {
+    "pathGroups": [
+      {
+        "pattern": "@app/**",
+        "group": "external",
+        "position": "after"
+      }
+    ],
+    "pathGroupsExcludedImportTypes": ["builtin"]
+  }]
+}
+```
+The default value is `["builtin", "external"]`.
 
 ### `newlines-between: [ignore|always|always-and-inside-groups|never]`:
 

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -276,6 +276,28 @@ ruleTester.run('order', rule, {
         ],
       }],
     }),
+    // Using pathGroups to customize ordering for imports that are recognized as 'external'
+    // by setting pathGroupsExcludedImportTypes without 'external'
+    test({
+      code: `
+        import fs from 'fs';
+
+        import { Input } from '@app/components/Input';
+
+        import { Button } from '@app2/components/Button';
+
+        import _ from 'lodash';
+
+        import { add } from './helper';`,
+      options: [{
+        'newlines-between': 'always',
+        pathGroupsExcludedImportTypes: ['builtin'],
+        pathGroups: [
+          { pattern: '@app/**', group: 'external', position: 'before' },
+          { pattern: '@app2/**', group: 'external', position: 'before' },
+        ],
+      }],
+    }),
 
     // Option: newlines-between: 'always'
     test({


### PR DESCRIPTION
… ordering of external import types

To fix the issue https://github.com/benmosher/eslint-plugin-import/issues/1565 and have no BC break I added a new option to also allow sorting of external imports.

Fixes #1565.