### PR TITLE
utils: Uses createRequireFromPath to resolve loaders

### DIFF
--- a/tests/files/node_modules/eslint-import-resolver-foo/index.js
+++ b/tests/files/node_modules/eslint-import-resolver-foo/index.js
@@ -1,0 +1,1 @@
+../../foo-bar-resolver-v2.js

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -94,6 +94,14 @@ describe('resolve', function () {
                       )).to.equal(utils.testFilePath('./bar.jsx'))
   })
 
+  it('finds resolvers from the source files rather than eslint-module-utils', function () {
+    const testContext = utils.testContext({ 'import/resolver': { 'foo': {} } })
+
+    expect(resolve( '../files/foo'
+                      , Object.assign({}, testContext, { getFilename: function () { return utils.getFilename('foo.js') } }),
+                      )).to.equal(utils.testFilePath('./bar.jsx'))
+  })
+
   it('reports invalid import/resolver config', function () {
     const testContext = utils.testContext({ 'import/resolver': 123.456 })
     const testContextReports = []

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -343,9 +343,9 @@ ruleTester.run('no-unresolved unknown resolver', rule, {
     // logs resolver load error
     test({
       code: 'import "./malformed.js"',
-      settings: { 'import/resolver': 'foo' },
+      settings: { 'import/resolver': 'doesnt-exist' },
       errors: [
-        `Resolve error: unable to load resolver "foo".`,
+        `Resolve error: unable to load resolver "doesnt-exist".`,
         `Unable to resolve path to module './malformed.js'.`,
       ],
     }),
@@ -353,9 +353,9 @@ ruleTester.run('no-unresolved unknown resolver', rule, {
     // only logs resolver message once
     test({
       code: 'import "./malformed.js"; import "./fake.js"',
-      settings: { 'import/resolver': 'foo' },
+      settings: { 'import/resolver': 'doesnt-exist' },
       errors: [
-        `Resolve error: unable to load resolver "foo".`,
+        `Resolve error: unable to load resolver "doesnt-exist".`,
         `Unable to resolve path to module './malformed.js'.`,
         `Unable to resolve path to module './fake.js'.`,
       ],

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+- Uses createRequireFromPath to resolve loaders ([#1591], thanks [@arcanis])
+
 ## v2.5.0 - 2019-12-07
 
 ### Added
@@ -59,7 +62,7 @@ Yanked due to critical issue with cache key resulting from #839.
 - `unambiguous.test()` regex is now properly in multiline mode
 
 
-
+[#1591]: https://github.com/benmosher/eslint-plugin-import/pull/1591
 [#1551]: https://github.com/benmosher/eslint-plugin-import/pull/1551
 [#1435]: https://github.com/benmosher/eslint-plugin-import/pull/1435
 [#1409]: https://github.com/benmosher/eslint-plugin-import/pull/1409
@@ -77,3 +80,4 @@ Yanked due to critical issue with cache key resulting from #839.
 [@christophercurrie]: https://github.com/christophercurrie
 [@brettz9]: https://github.com/brettz9
 [@JounQin]: https://github.com/JounQin
+[@arcanis]: https://github.com/arcanis


### PR DESCRIPTION
The current logic uses `require.resolve` in order to locate the resolver modules. The problem is that `require.resolve` semantically operates based on the currently evaluated module. That makes the resolution incorrect, as the loaders aren't dependencies of `eslint-module-utils`. It probably works thanks to the hoisting, but hoisting is on its way out and such problems will start to reveal themselves.

To fix that, the resolution simply needs to use `createRequireFromPath` so that the loaders are located based on the dependencies of the package that contains the source file being linted - which I think was the intent.