### PR TITLE
Use createRequire instead of createRequireFromPath if available

### DIFF
--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+- Use `createRequire` instead of `createRequireFromPath` if available ([#1602], thanks [@iamnapo])
+
+## v2.5.1 - 2020-01-11
+
 ### Fixed
 - Uses createRequireFromPath to resolve loaders ([#1591], thanks [@arcanis])
 - report the error stack on a resolution error ([#599], thanks [@sompylasar])
@@ -62,7 +66,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
-
+[#1602]: https://github.com/benmosher/eslint-plugin-import/pull/1602
 [#1591]: https://github.com/benmosher/eslint-plugin-import/pull/1591
 [#1551]: https://github.com/benmosher/eslint-plugin-import/pull/1551
 [#1435]: https://github.com/benmosher/eslint-plugin-import/pull/1435
@@ -84,3 +88,4 @@ Yanked due to critical issue with cache key resulting from #839.
 [@JounQin]: https://github.com/JounQin
 [@arcanis]: https://github.com/arcanis
 [@sompylasar]: https://github.com/sompylasar
+[@iamnapo]: https://github.com/iamnapo

--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -18,7 +18,8 @@ const ERROR_NAME = 'EslintPluginImportResolveError'
 const fileExistsCache = new ModuleCache()
 
 // Polyfill Node's `Module.createRequireFromPath` if not present (added in Node v10.12.0)
-const createRequireFromPath = Module.createRequireFromPath || function (filename) {
+// Use `Module.createRequire` if available (added in Node v12.2.0)
+const createRequire = Module.createRequire || Module.createRequireFromPath || function (filename) {
   const mod = new Module(filename, null)
   mod.filename = filename
   mod.paths = Module._nodeModulePaths(path.dirname(filename))
@@ -33,7 +34,7 @@ function tryRequire(target, sourceFile) {
   try {
     // Check if the target exists
     if (sourceFile != null) {
-      resolved = createRequireFromPath(sourceFile).resolve(target)
+      resolved = createRequire(path.resolve(sourceFile)).resolve(target)
     } else {
       resolved = require.resolve(target)
     }


### PR DESCRIPTION
In order to avoid: `DeprecationWarning: Module.createRequireFromPath() is deprecated. Use Module.createRequire() instead.` when using Node >= `v12.2.0`.