### PR TITLE
Fix import type determination for monorepo setup w/ webpack resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- [`import/external-module-folders` setting] now correctly works with directories containing modules symlinked from `node_modules` ([#1605], thanks [@skozin])
+
+### Changed
+- [`import/external-module-folders` setting] behavior is more strict now: it will only match complete path segments ([#1605], thanks [@skozin])
 
 ## [2.20.0] - 2020-01-10
 ### Added
@@ -636,6 +641,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1605]: https://github.com/benmosher/eslint-plugin-import/pull/1605
 [#1589]: https://github.com/benmosher/eslint-plugin-import/issues/1589
 [#1586]: https://github.com/benmosher/eslint-plugin-import/pull/1586
 [#1572]: https://github.com/benmosher/eslint-plugin-import/pull/1572
@@ -1069,3 +1075,4 @@ for info on changes for earlier releases.
 [@rsolomon]: https://github.com/rsolomon
 [@joaovieira]: https://github.com/joaovieira
 [@ivo-stefchev]: https://github.com/ivo-stefchev
+[@skozin]: https://github.com/skozin

--- a/README.md
+++ b/README.md
@@ -339,7 +339,19 @@ Contribution of more such shared configs for other platforms are welcome!
 
 #### `import/external-module-folders`
 
-An array of folders. Resolved modules only from those folders will be considered as "external". By default - `["node_modules"]`. Makes sense if you have configured your path or webpack to handle your internal paths differently and want to considered modules from some folders, for example `bower_components` or `jspm_modules`, as "external".
+An array of folders. Resolved modules only from those folders will be considered as "external". By default - `["node_modules"]`. Makes sense if you have configured your path or webpack to handle your internal paths differently and want to consider modules from some folders, for example `bower_components` or `jspm_modules`, as "external".
+
+This option is also useful in a monorepo setup: list here all directories that contain monorepo's packages and they will be treated as external ones no matter which resolver is used.
+
+Each item in this array is either a folder's name, its subpath, or its absolute prefix path:
+
+- `jspm_modules` will match any file or folder named `jspm_modules` or which has a direct or non-direct parent named `jspm_modules`, e.g. `/home/me/project/jspm_modules` or `/home/me/project/jspm_modules/some-pkg/index.js`.
+
+- `packages/core` will match any path that contains these two segments, for example `/home/me/project/packages/core/src/utils.js`.
+
+- `/home/me/project/packages` will only match files and directories inside this directory, and the directory itself.
+
+Please note that incomplete names are not allowed here so `components` won't match `bower_components` and `packages/ui` won't match `packages/ui-utils` (but will match `packages/ui/utils`).
 
 #### `import/parsers`
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "homepage": "https://github.com/benmosher/eslint-plugin-import",
   "devDependencies": {
     "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
+    "@test-scope/some-module": "file:./tests/files/symlinked-module",
     "@typescript-eslint/parser": "1.10.3-alpha.13",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -1,5 +1,4 @@
 import coreModules from 'resolve/lib/core'
-import { join } from 'path'
 
 import resolve from 'eslint-module-utils/resolve'
 
@@ -26,11 +25,19 @@ export function isBuiltIn(name, settings, path) {
 
 function isExternalPath(path, name, settings) {
   const folders = (settings && settings['import/external-module-folders']) || ['node_modules']
+  return !path || folders.some(folder => isSubpath(folder, path))
+}
 
-  // extract the part before the first / (redux-saga/effects => redux-saga)
-  const packageName = name.match(/([^/]+)/)[0]
-
-  return !path || folders.some(folder => -1 < path.indexOf(join(folder, packageName)))
+function isSubpath(subpath, path) {
+  const normSubpath = subpath.replace(/[/]$/, '')
+  if (normSubpath.length === 0) {
+    return false
+  }
+  const left = path.indexOf(normSubpath)
+  const right = left + normSubpath.length
+  return left !== -1 &&
+        (left === 0 || normSubpath[0] !== '/' && path[left - 1] === '/') &&
+        (right >= path.length || path[right] === '/')
 }
 
 const externalModuleRegExp = /^\w/

--- a/tests/files/symlinked-module/index.js
+++ b/tests/files/symlinked-module/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/tests/files/symlinked-module/package.json
+++ b/tests/files/symlinked-module/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@test-scope/some-module",
+  "version": "1.0.0",
+  "private": true
+}

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -48,7 +48,7 @@ describe('importType(name)', function () {
     expect(importType('importType', pathContext)).to.equal('internal')
   })
 
-  it.skip("should return 'internal' for scoped packages resolved outside of node_modules", function () {
+  it("should return 'internal' for scoped packages resolved outside of node_modules", function () {
     const pathContext = testContext({ 'import/resolver': { node: { paths: [pathToTestFiles] } } })
     expect(importType('@importType/index', pathContext)).to.equal('internal')
   })

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -298,7 +298,55 @@ ruleTester.run('order', rule, {
         ],
       }],
     }),
+    // Monorepo setup, using Webpack resolver, workspace folder name in external-module-folders
+    test({
+      code: `
+        import _ from 'lodash';
+        import m from '@test-scope/some-module';
 
+        import bar from './bar';
+      `,
+      options: [{
+        'newlines-between': 'always',
+      }],
+      settings: {
+        'import/resolver': 'webpack',
+        'import/external-module-folders': ['node_modules', 'symlinked-module'],
+      },
+    }),
+    // Monorepo setup, using Webpack resolver, partial workspace folder path
+    // in external-module-folders
+    test({
+      code: `
+        import _ from 'lodash';
+        import m from '@test-scope/some-module';
+
+        import bar from './bar';
+      `,
+      options: [{
+        'newlines-between': 'always',
+      }],
+      settings: {
+        'import/resolver': 'webpack',
+        'import/external-module-folders': ['node_modules', 'files/symlinked-module'],
+      },
+    }),
+    // Monorepo setup, using Node resolver (doesn't resolve symlinks)
+    test({
+      code: `
+        import _ from 'lodash';
+        import m from '@test-scope/some-module';
+
+        import bar from './bar';
+      `,
+      options: [{
+        'newlines-between': 'always',
+      }],
+      settings: {
+        'import/resolver': 'node',
+        'import/external-module-folders': ['node_modules', 'files/symlinked-module'],
+      },
+    }),
     // Option: newlines-between: 'always'
     test({
       code: `


### PR DESCRIPTION
Fixes #1597.

This PR changes the logic of [`isExternalPath`] function so that it doesn't consider the import name. For a path to be external, it's now sufficient that it matches one of the items in the `import/external-module-folders` array specified in settings.

This is to support a setup where some of the modules are symlinked from `node_modules` into directories elsewhere in the project (called ["workspaces"] in Yarn terminology). For example, it's common to have a monorepo setup like this:

```
node_modules
  @my-scope
    core -> ../../packages/core
    utils -> ../../packages/utils
packages
  core
    package.json
    index.js
  utils
    package.json
    index.js
package.json
```

Usually, one wants these packages to be treated as external since they're normally installed from a registry. Intuitively, this should be achieved by adding `packages` to `import/external-module-folders` array. However, this didn't work in a project that uses the `webpack` resolver.

The reason is that `webpack` resolver returns a fully resolved path to the module's main file, e.g. for `@my-scope/core` it would be something like `/home/me/project/packages/core/index.js`. This path doesn't contain the package name, `@my-scope/core`, as a substring, so [`isExternalPath`] would consider this path as internal prior to the changes proposed in this PR. This led to the import itself being considered as internal, as after merging #1294 a scoped import is determined as external only if its path is external too.

Apart from removing the import name check from [`isExternalPath`], this PR also makes `import/external-module-folders` more strict. It won't match incomplete path segments anymore, so `some/path` won't match `/my/awesome/path` but will still match `/my/some/path` and `/my/some/path/index.js`. Also, if an item starts with a forward slash, it will be treated as an absolute path prefix, so `/home/me/project/packages` will only match the directory itself and everything inside it.

This PR doesn't break any existing tests, and I believe that it shouldn't break any existing setups either.

[`isExternalPath`]: https://github.com/benmosher/eslint-plugin-import/blob/cd25d9d/src/core/importType.js#L27
["workspaces"]: https://yarnpkg.com/lang/en/docs/workspaces/