### PR TITLE
Makes the loader resolution more tolerant

### DIFF
--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+- Makes the loader resolution more tolerant ([#1606], thanks [@arcanis])
 - Use `createRequire` instead of `createRequireFromPath` if available ([#1602], thanks [@iamnapo])
 
 ## v2.5.1 - 2020-01-11
@@ -66,6 +67,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#1606]: https://github.com/benmosher/eslint-plugin-import/pull/1606
 [#1602]: https://github.com/benmosher/eslint-plugin-import/pull/1602
 [#1591]: https://github.com/benmosher/eslint-plugin-import/pull/1591
 [#1551]: https://github.com/benmosher/eslint-plugin-import/pull/1551

--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -34,7 +34,11 @@ function tryRequire(target, sourceFile) {
   try {
     // Check if the target exists
     if (sourceFile != null) {
-      resolved = createRequire(path.resolve(sourceFile)).resolve(target)
+      try {
+        resolved = createRequire(path.resolve(sourceFile)).resolve(target)
+      } catch (e) {
+        resolved = require.resolve(target)
+      }
     } else {
       resolved = require.resolve(target)
     }


### PR DESCRIPTION
(Sorry @iamnapo, it was very late at night and I initially opened this PR against your repo ... 😅)

Assuming that the repro provided by https://github.com/benmosher/eslint-plugin-import/issues/1604#issuecomment-573364743 will be valid, a simple solution would be to be too laxist for now and just fallback to the hoisting resolution if the file-relative one doesn't find the loader - while still using the expected resolution as primary code path.

And then the next time eslint-import-utils receives a major bump, revert the try/catch block and go back to using exclusively createRequire.

cc @ljharb, fixes #1604, fixes #1603 