### PR TITLE
[Deps] update 'eslint-module-utils'

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "debug": "^2.6.9",
     "doctrine": "1.5.0",
     "eslint-import-resolver-node": "^0.3.2",
-    "eslint-module-utils": "^2.4.1",
+    "eslint-module-utils": "^2.5.1",
     "has": "^1.0.3",
     "minimatch": "^3.0.4",
     "object.values": "^1.1.0",


### PR DESCRIPTION
- update eslint-module-utils to '2.5.1'

> (node:63421) [DEP0130] DeprecationWarning: Module.createRequireFromPath() is deprecated. Use Module.createRequire() instead.

This update resolve above warning which caused by `createRequireFromPath` which used in  eslint-module-utils@2.4.1