### PR TITLE
no-duplicates: allow duplicate if one is namespace and other not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`import/external-module-folders` setting] now correctly works with directories containing modules symlinked from `node_modules` ([#1605], thanks [@skozin])
 - [`extensions`]: for invalid code where `name` does not exist, do not crash ([#1613], thanks [@ljharb])
 - [`extentions`]: Fix scope regex ([#1611], thanks [@yordis])
+- [`no-duplicates`]: allow duplicate imports if one is a namespace and the other not ([#1612], thanks [@sveyret])
 
 ### Changed
 - [`import/external-module-folders` setting] behavior is more strict now: it will only match complete path segments ([#1605], thanks [@skozin])
@@ -644,6 +645,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#1613]: https://github.com/benmosher/eslint-plugin-import/issues/1613
+[#1612]: https://github.com/benmosher/eslint-plugin-import/pull/1612
 [#1611]: https://github.com/benmosher/eslint-plugin-import/pull/1611
 [#1605]: https://github.com/benmosher/eslint-plugin-import/pull/1605
 [#1589]: https://github.com/benmosher/eslint-plugin-import/issues/1589
@@ -1081,3 +1083,4 @@ for info on changes for earlier releases.
 [@ivo-stefchev]: https://github.com/ivo-stefchev
 [@skozin]: https://github.com/skozin
 [@yordis]: https://github.com/yordis
+[@sveyret]: https://github.com/sveyret

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -257,12 +257,14 @@ module.exports = {
     }) : defaultResolver
 
     const imported = new Map()
+    const nsImported = new Map()
     const typesImported = new Map()
     return {
       'ImportDeclaration': function (n) {
         // resolved path will cover aliased duplicates
         const resolvedPath = resolver(n.source.value)
-        const importMap = n.importKind === 'type' ? typesImported : imported
+        const importMap = n.importKind === 'type' ? typesImported :
+          (hasNamespace(n) ? nsImported : imported)
 
         if (importMap.has(resolvedPath)) {
           importMap.get(resolvedPath).push(n)
@@ -273,6 +275,7 @@ module.exports = {
 
       'Program:exit': function () {
         checkImports(imported, context)
+        checkImports(nsImported, context)
         checkImports(typesImported, context)
       },
     }


### PR DESCRIPTION
It is a syntax error to put both namespace and non namespace import on the same line, so allow it.
Fix issue #1538