### PR TITLE
export: Handle function overloading in '*.d.ts'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 ### Fixed
+- [`export`]: Handle function overloading in `*.d.ts` ([#1619], thanks [@IvanGoncharov])
 - [`no-absolute-path`]: fix a crash with invalid import syntax ([#1616], thanks [@ljharb])
 - [`import/external-module-folders` setting] now correctly works with directories containing modules symlinked from `node_modules` ([#1605], thanks [@skozin])
 - [`extensions`]: for invalid code where `name` does not exist, do not crash ([#1613], thanks [@ljharb])
@@ -650,6 +651,7 @@ for info on changes for earlier releases.
 
 [#1635]: https://github.com/benmosher/eslint-plugin-import/issues/1635
 [#1620]: https://github.com/benmosher/eslint-plugin-import/pull/1620
+[#1619]: https://github.com/benmosher/eslint-plugin-import/pull/1619
 [#1616]: https://github.com/benmosher/eslint-plugin-import/issues/1616
 [#1613]: https://github.com/benmosher/eslint-plugin-import/issues/1613
 [#1612]: https://github.com/benmosher/eslint-plugin-import/pull/1612
@@ -1096,3 +1098,4 @@ for info on changes for earlier releases.
 [@bmish]: https://github.com/bmish
 [@redbugz]: https://github.com/redbugz
 [@kentcdodds]: https://github.com/kentcdodds
+[@IvanGoncharov]: https://github.com/IvanGoncharov

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -36,7 +36,13 @@ const tsTypePrefix = 'type:'
  */
 function isTypescriptFunctionOverloads(nodes) {
   const types = new Set(Array.from(nodes, node => node.parent.type))
-  return types.size === 2 && types.has('TSDeclareFunction') && types.has('FunctionDeclaration')
+  return (
+    types.has('TSDeclareFunction') &&
+    (
+      types.size === 1 ||
+      (types.size === 2 && types.has('FunctionDeclaration'))
+    )
+  )
 }
 
 module.exports = {

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -136,6 +136,13 @@ context('TypeScript', function () {
           code: `
             export function fff(a: string);
             export function fff(a: number);
+          `,
+        }, parserConfig)),
+
+        test(Object.assign({
+          code: `
+            export function fff(a: string);
+            export function fff(a: number);
             export function fff(a: string|number) {};
           `,
         }, parserConfig)),


### PR DESCRIPTION
I'm trying to use this rule to validate `*.d.ts` files and they contain only `TSDeclareFunction` and can't contain `FunctionDeclaration`.