### PR TITLE
[Fix] `order`: Fix alphabetize for mixed requires and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-duplicates`]: allow duplicate imports if one is a namespace and the other not ([#1612], thanks [@sveyret])
 - Add some missing rule meta schemas and types ([#1620], thanks [@bmish])
 - [`named`]: for importing from a module which re-exports named exports from a `node_modules` module ([#1569], [#1447], thanks [@redbugz], [@kentcdodds])
+- [`order`]: Fix alphabetize for mixed requires and imports ([#5625], thanks [@wschurman])
 
 ### Changed
 - [`import/external-module-folders` setting] behavior is more strict now: it will only match complete path segments ([#1605], thanks [@skozin])
@@ -650,6 +651,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#1635]: https://github.com/benmosher/eslint-plugin-import/issues/1635
+[#1625]: https://github.com/benmosher/eslint-plugin-import/pull/1625
 [#1620]: https://github.com/benmosher/eslint-plugin-import/pull/1620
 [#1619]: https://github.com/benmosher/eslint-plugin-import/pull/1619
 [#1616]: https://github.com/benmosher/eslint-plugin-import/issues/1616
@@ -1099,3 +1101,4 @@ for info on changes for earlier releases.
 [@redbugz]: https://github.com/redbugz
 [@kentcdodds]: https://github.com/kentcdodds
 [@IvanGoncharov]: https://github.com/IvanGoncharov
+[@wschurman]: https://github.com/wschurman

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -289,7 +289,7 @@ function mutateRanksToAlphabetize(imported, alphabetizeOptions) {
   let newRank = 0
   const alphabetizedRanks = groupRanks.sort().reduce(function(acc, groupRank) {
     groupedByRanks[groupRank].forEach(function(importedItemName) {
-      acc[importedItemName] = newRank
+      acc[importedItemName] = parseInt(groupRank, 10) + newRank
       newRank += 1
     })
     return acc

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -645,6 +645,22 @@ ruleTester.run('order', rule, {
         'newlines-between': 'always',
       }],
     }),
+    // Alphabetize with require
+    test({
+      code: `
+        import { hello } from './hello';
+        import { int } from './int';
+        const blah = require('./blah');
+        const { cello } = require('./cello');
+      `,
+      options: [
+        {
+          alphabetize: {
+            order: 'asc',
+          },
+        },
+      ],
+    }),
   ],
   invalid: [
     // builtin before external module (require)
@@ -1984,6 +2000,22 @@ ruleTester.run('order', rule, {
       errors: [{
         ruleID: 'order',
         message: '`foo` import should occur before import of `Bar`',
+      }],
+    }),
+    // Alphabetize with require
+    test({
+      code: `
+        const { cello } = require('./cello');
+        import { int } from './int';
+        const blah = require('./blah');
+        import { hello } from './hello';
+      `,
+      errors: [{
+        ruleId: 'order',
+        message: '`./int` import should occur before import of `./cello`',
+      }, {
+        ruleId: 'order',
+        message: '`./hello` import should occur before import of `./cello`',
       }],
     }),
   ].filter((t) => !!t),


### PR DESCRIPTION
Fixes #1625

## Overview

The ranks of require items (which are +100) were being lost due to the algorithm not using the group rank when recalculating the alphabetized ranks.

To fix this, make the alphabetized rank of the item the group rank plus the alphabetization rank.

### Test Plan

Run new unit tests. Before the change the tests would fail. After the change the tests pass.