### PR TITLE
Add import/extensions ignorePackages rule to the TypeScript plugin

### DIFF
--- a/config/typescript.js
+++ b/config/typescript.js
@@ -6,6 +6,15 @@ var allExtensions = ['.ts', '.tsx', '.d.ts', '.js', '.jsx']
 
 module.exports = {
 
+  rules: {
+    'import/extensions': ['error', 'ignorePackages', {
+      ts: 'never',
+      tsx: 'never',
+      js: 'never',
+      jsx: 'never',
+    }],
+  },
+
   settings: {
     'import/extensions': allExtensions,
     'import/external-module-folders': ['node_modules', 'node_modules/@types'],


### PR DESCRIPTION
Should prevent https://github.com/benmosher/eslint-plugin-import/issues/1615 when using `plugin:import/typescript` and others (like `airbnb-base`) which aren't TypeScript aware.

Refs https://github.com/benmosher/eslint-plugin-import/issues/1615#issuecomment-579936931.
