### PR TITLE
[Fix] `order`: fix `isExternalModule` detect on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Fixed
+- [`order`]: fix `isExternalModule` detect on windows ([#1651], thanks [@fisker])
 
 ## [2.20.1] - 2020-02-01
 ### Fixed
@@ -652,6 +654,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1651]: https://github.com/benmosher/eslint-plugin-import/pull/1651
 [#1635]: https://github.com/benmosher/eslint-plugin-import/issues/1635
 [#1625]: https://github.com/benmosher/eslint-plugin-import/pull/1625
 [#1620]: https://github.com/benmosher/eslint-plugin-import/pull/1620
@@ -1105,3 +1108,4 @@ for info on changes for earlier releases.
 [@kentcdodds]: https://github.com/kentcdodds
 [@IvanGoncharov]: https://github.com/IvanGoncharov
 [@wschurman]: https://github.com/wschurman
+[@fisker]: https://github.com/fisker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
   # - nodejs_version: "4"
 
 matrix:
-  fast_finish: true
+  fast_finish: false
 
   # allow_failures:
   #   - nodejs_version: "4" # for eslint 5
@@ -26,6 +26,9 @@ install:
   - ps: >-
       if ($env:nodejs_version -eq "4") {
         npm install -g npm@3;
+      }
+      if ($env:nodejs_version -in @("8", "10", "12")) {
+        npm install -g npm@6.10.3;
       }
   - npm install
 

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -29,15 +29,16 @@ function isExternalPath(path, name, settings) {
 }
 
 function isSubpath(subpath, path) {
-  const normSubpath = subpath.replace(/[/]$/, '')
+  const normPath = path.replace(/\\/g, '/')
+  const normSubpath = subpath.replace(/\\/g, '/').replace(/\/$/, '')
   if (normSubpath.length === 0) {
     return false
   }
-  const left = path.indexOf(normSubpath)
+  const left = normPath.indexOf(normSubpath)
   const right = left + normSubpath.length
   return left !== -1 &&
-        (left === 0 || normSubpath[0] !== '/' && path[left - 1] === '/') &&
-        (right >= path.length || path[right] === '/')
+        (left === 0 || normSubpath[0] !== '/' && normPath[left - 1] === '/') &&
+        (right >= normPath.length || normPath[right] === '/')
 }
 
 const externalModuleRegExp = /^\w/

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import * as path from 'path'
 
-import importType from 'core/importType'
+import importType, {isExternalModule} from 'core/importType'
 
 import { testContext, testFilePath } from '../utils'
 
@@ -180,6 +180,12 @@ describe('importType(name)', function () {
   })
 
   it('returns "external" for a scoped module from a symlinked directory which partial path is contained in "external-module-folders" (webpack resolver)', function() {
+    const originalFoldersContext = testContext({
+      'import/resolver': 'webpack',
+      'import/external-module-folders': [],
+    })
+    expect(importType('@test-scope/some-module', originalFoldersContext)).to.equal('internal')
+
     const foldersContext = testContext({
       'import/resolver': 'webpack',
       'import/external-module-folders': ['files/symlinked-module'],
@@ -223,5 +229,12 @@ describe('importType(name)', function () {
       'import/external-module-folders': [testFilePath('symlinked-module')],
     })
     expect(importType('@test-scope/some-module', foldersContext)).to.equal('external')
+  })
+
+  it('`isExternalModule` works with windows directory separator', function() {
+    expect(isExternalModule('foo', {}, 'E:\\path\\to\\node_modules\\foo')).to.equal(true)
+    expect(isExternalModule('foo', {
+      'import/external-module-folders': ['E:\\path\\to\\node_modules'],
+    }, 'E:\\path\\to\\node_modules\\foo')).to.equal(true)
   })
 })


### PR DESCRIPTION
`isExternalModule` is not right, when use `\` as separator.

This cause external module detected as `internal`.

Seems we are not running test on windows. I add a test on `isExternalModule`