### PR TITLE
[importType] Fix core modules can be typed as `internal` when using webpack resolver.

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -133,7 +133,7 @@ exports.resolve = function (source, file, settings) {
     return { found: true, path: resolveSync(path.dirname(file), source) }
   } catch (err) {
     if (source in coreLibs) {
-      return { found: true, path: coreLibs[source] }
+      return { found: true, path: null }
     }
 
     log('Error during module resolution:', err)

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -20,6 +20,12 @@ describe('importType(name)', function () {
     expect(importType('path', context)).to.equal('builtin')
   })
 
+  it("should return 'builtin' for node.js modules (webpack resolver)", function() {
+    const webpackContext = testContext({ 'import/resolver': 'webpack' })
+    expect(importType('fs', webpackContext)).to.equal('builtin')
+    expect(importType('path', webpackContext)).to.equal('builtin')
+  })
+
   it("should return 'external' for non-builtin modules without a relative path", function() {
     expect(importType('lodash', context)).to.equal('external')
     expect(importType('async', context)).to.equal('external')


### PR DESCRIPTION
with .eslintrc as below

```js
{
  ...,
  settings: { 'import/resolver': 'webpack' },
  ...,
  rules: {
    'import/order': [
      'error',
      {
        'newlines-between': 'always'
      }
    ],
  },
  ...
}
```

then occur the error as below

```js
import fs from 'fs'; // <- error  There should be at least one empty line between import groups  import/order
import path from 'path';
```
I think the error is false positive because of both `fs` and `path` are `builtin` modules.

But actually `path` is typed as `external` module because it seems that webpack resolve some of core modules to [node-libs-browser](https://github.com/webpack/node-libs-browser). Then resolved path end up being found and the module is not typed as `builtin`. ([code](https://github.com/benmosher/eslint-plugin-import/blob/v2.20.1/src/core/importType.js#L18-L20)). 

I found that 
* node resolver return path of core modules as `null`.
  https://github.com/benmosher/eslint-plugin-import/blob/v2.20.1/resolvers/node/index.js#L12-L15
* resolved path is referred whether `undefined` or not, but not `null`. 
https://github.com/benmosher/eslint-plugin-import/blob/v2.20.1/src/rules/no-unresolved.js#L31-L34

My modify is aligned to above design.

