### PR TITLE
[fix] `order`: recognize ".." as a "parent" path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 ### Fixed
 - [`order`]: fix `isExternalModule` detect on windows ([#1651], thanks [@fisker])
+- [`order`]: recognize ".." as a "parent" path ([#1658], thanks [@golopot])
 
 ## [2.20.1] - 2020-02-01
 ### Fixed
@@ -654,6 +655,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1658]: https://github.com/benmosher/eslint-plugin-import/pull/1658
 [#1651]: https://github.com/benmosher/eslint-plugin-import/pull/1651
 [#1635]: https://github.com/benmosher/eslint-plugin-import/issues/1635
 [#1625]: https://github.com/benmosher/eslint-plugin-import/pull/1625

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -68,7 +68,7 @@ function isInternalModule(name, settings, path) {
 }
 
 function isRelativeToParent(name) {
-  return /^\.\.[\\/]/.test(name)
+  return/^\.\.$|^\.\.[\\/]/.test(name)
 }
 
 const indexFiles = ['.', './', './index', './index.js']

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -19,6 +19,7 @@ ruleTester.run('order', rule, {
         var relParent1 = require('../foo');
         var relParent2 = require('../foo/bar');
         var relParent3 = require('../');
+        var relParent4 = require('..');
         var sibling = require('./foo');
         var index = require('./');`,
       }),
@@ -196,7 +197,13 @@ ruleTester.run('order', rule, {
         import { Input } from '-/components/Input';
         import { Button } from '-/components/Button';
 
-        import { add } from './helper';`,
+        import p from '..';
+        import q from '../';
+
+        import { add } from './helper';
+
+        import i from '.';
+        import j from './';`,
       options: [
         {
           'newlines-between': 'always',
@@ -2000,6 +2007,25 @@ ruleTester.run('order', rule, {
       errors: [{
         ruleID: 'order',
         message: '`foo` import should occur before import of `Bar`',
+      }],
+    }),
+    // Alphabetize with parent paths
+    test({
+      code: `
+        import a from '../a';
+        import p from '..';
+      `,
+      output: `
+        import p from '..';
+        import a from '../a';
+      `,
+      options: [{
+        groups: ['external', 'index'],
+        alphabetize: {order: 'asc'},
+      }],
+      errors: [{
+        ruleID: 'order',
+        message: '`..` import should occur before import of `../a`',
       }],
     }),
     // Alphabetize with require


### PR DESCRIPTION
fixes #1405