### PR TITLE
Add a way to disable absolute-first option explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`order`]: recognize ".." as a "parent" path ([#1658], thanks [@golopot])
 - [`no-duplicates`]: fix fixer on cases with default import ([#1666], thanks [@golopot])
 - [`no-unused-modules`]: Handle `export { default } from` syntax ([#1631], thanks [@richardxia])
+- [`first`]: Add a way to disable `absolute-first` explicitly ([#1664], thanks [@TheCrueltySage])
 
 ## [2.20.1] - 2020-02-01
 ### Fixed
@@ -658,6 +659,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#1666]: https://github.com/benmosher/eslint-plugin-import/pull/1666
+[#1664]: https://github.com/benmosher/eslint-plugin-import/pull/1664
 [#1658]: https://github.com/benmosher/eslint-plugin-import/pull/1658
 [#1651]: https://github.com/benmosher/eslint-plugin-import/pull/1651
 [#1635]: https://github.com/benmosher/eslint-plugin-import/issues/1635
@@ -1116,3 +1118,4 @@ for info on changes for earlier releases.
 [@wschurman]: https://github.com/wschurman
 [@fisker]: https://github.com/fisker
 [@richardxia]: https://github.com/richardxia
+[@TheCrueltySage]: https://github.com/TheCrueltySage

--- a/src/rules/first.js
+++ b/src/rules/first.js
@@ -10,7 +10,7 @@ module.exports = {
     schema: [
       {
         type: 'string',
-        enum: ['absolute-first'],
+        enum: ['absolute-first', 'disable-absolute-first'],
       },
     ],
   },

--- a/tests/src/rules/first.js
+++ b/tests/src/rules/first.js
@@ -11,6 +11,9 @@ ruleTester.run('first', rule, {
                   export { x, y }" })
   , test({ code: "import { x } from 'foo'; import { y } from './bar'" })
   , test({ code: "import { x } from './foo'; import { y } from 'bar'" })
+  , test({ code: "import { x } from './foo'; import { y } from 'bar'"
+         , options: ['disable-absolute-first'],
+         })
   , test({ code: "'use directive';\
                   import { x } from 'foo';" })
   ,


### PR DESCRIPTION
Fixes #1661 .
Not sure if the alternative should be just an empty string or an explicit disable option. Went for the second for now.