### PR TITLE
[Fix] `no-duplicates`: Handle TS import type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
 - [`order`]: Recognize pathGroup config for first group ([#1719], [#1724], thanks [@forivall], [@xpl])
 - [`no-unused-modules`]: Fix re-export not counting as usage when used in combination with import ([#1722], thanks [@Ephem])
+- [`no-duplicates`]: Handle TS import type ([#1676], thanks [@kmui2])
 
 ### Changed
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
@@ -673,6 +674,7 @@ for info on changes for earlier releases.
 [#1722]: https://github.com/benmosher/eslint-plugin-import/issues/1722
 [#1719]: https://github.com/benmosher/eslint-plugin-import/issues/1719
 [#1702]: https://github.com/benmosher/eslint-plugin-import/issues/1702
+[#1676]: https://github.com/benmosher/eslint-plugin-import/pull/1676
 [#1666]: https://github.com/benmosher/eslint-plugin-import/pull/1666
 [#1664]: https://github.com/benmosher/eslint-plugin-import/pull/1664
 [#1658]: https://github.com/benmosher/eslint-plugin-import/pull/1658
@@ -1141,3 +1143,4 @@ for info on changes for earlier releases.
 [@xpl]: https://github.com/xpl
 [@astorije]: https://github.com/astorije
 [@Ephem]: https://github.com/Ephem
+[@kmui2]: https://github.com/kmui2

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
     "@test-scope/some-module": "file:./tests/files/symlinked-module",
-    "@typescript-eslint/parser": "1.10.3-alpha.13",
+    "@typescript-eslint/parser": "^2.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.6",
@@ -84,7 +84,7 @@
     "rimraf": "^2.7.1",
     "semver": "^6.3.0",
     "sinon": "^2.4.1",
-    "typescript": "~3.2.2",
+    "typescript": "~3.8.3",
     "typescript-eslint-parser": "^22.0.0"
   },
   "peerDependencies": {

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -1,5 +1,5 @@
 import * as path from 'path'
-import { test as testUtil } from '../utils'
+import { test as testUtil, getNonDefaultParsers } from '../utils'
 
 import { RuleTester } from 'eslint'
 
@@ -399,3 +399,32 @@ ruleTester.run('no-duplicates', rule, {
     }),
   ],
 })
+
+context('TypeScript', function() {
+  getNonDefaultParsers()
+  .filter((parser) => parser !== require.resolve('typescript-eslint-parser'))
+  .forEach((parser) => {
+    const parserConfig = {
+      parser: parser,
+      settings: {
+        'import/parsers': { [parser]: ['.ts'] },
+        'import/resolver': { 'eslint-import-resolver-typescript': true },
+      },
+    }
+
+    ruleTester.run('no-duplicates', rule, {
+      valid: [
+        // #1667: ignore duplicate if is a typescript type import
+        test(
+          {
+            code: "import type { x } from './foo'; import y from './foo'",
+            parser,
+          },
+          parserConfig,
+        ),
+      ],
+      invalid: [],
+    })
+  })
+})
+


### PR DESCRIPTION
Fixes #1667 

~~Don't merge yet!~~ 

This PR contains a new test for TypeScript 3.8's new `import type` syntax. However, TypeScript 3.8 is still not supported yet for TypeScript ESLint! See https://github.com/benmosher/eslint-plugin-import/issues/1667#issuecomment-594306928. 

Updates the following TypeScript packages.

```json
    "@typescript-eslint/parser": "^2.22.0",
    "eslint-import-resolver-typescript": "^2.0.0",
    "typescript": "^3.8.3",
```

As of this TypeScript ESLint package version, it will continue to produce the following error until TypeScript ESLint gains support for TypeScript 3.8 (progress can be tracked [here](https://github.com/typescript-eslint/typescript-eslint/issues/1436)):
```
AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: A fatal parsing error occurred in autofix: Parsing error: '{' expected.
```

## Update

TypeScript 3.8 import type is now supported in TypeScript ESLint v2.23.0: https://github.com/typescript-eslint/typescript-eslint/releases/tag/v2.23.0