### PR TITLE
Added allow and forbid options to no-namespace rule

### DIFF
--- a/docs/rules/no-namespace.md
+++ b/docs/rules/no-namespace.md
@@ -13,6 +13,12 @@ Valid:
 import defaultExport from './foo'
 import { a, b }  from './bar'
 import defaultExport, { a, b }  from './foobar'
+
+// { allow: ['foo'] }
+import * as foo from 'foo';
+
+// { forbid: ['foo'] }
+import * as bar from 'bar';
 ```
 
 Invalid:
@@ -24,6 +30,22 @@ import * as foo from 'foo';
 ```js
 import defaultExport, * as foo from 'foo';
 ```
+
+```js
+// { allow: ['foo'] }
+import * as bar from 'bar';
+
+// { forbid: ['foo'] }
+import * as foo from 'foo';
+```
+
+### Options
+
+This rule takes the following options:
+
+`allow`: an array of namespaces the rule allows
+
+`forbid`: an array of namespaces the rule forbids
 
 ## When Not To Use It
 

--- a/tests/src/rules/no-namespace.js
+++ b/tests/src/rules/no-namespace.js
@@ -78,6 +78,8 @@ ruleTester.run('no-namespace', require('rules/no-namespace'), {
     { code: 'import { a, b } from \'./foo\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
     { code: 'import bar from \'bar\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
     { code: 'import bar from \'./bar\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: 'import * as bar from \'bar\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' }, options: [{ allow: ['bar']}] },
+    { code: 'import bar from \'bar\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' }, options: [{ forbid: ['bar']}] },
   ],
 
   invalid: [
@@ -102,6 +104,34 @@ ruleTester.run('no-namespace', require('rules/no-namespace'), {
     test({
       code: 'import * as foo from \'./foo\';',
       output: 'import * as foo from \'./foo\';',
+      errors: [ {
+        line: 1,
+        column: 8,
+        message: ERROR_MESSAGE,
+      } ],
+    }),
+    test({
+      code: 'import * as foo from \'./foo\';',
+      output: 'import * as foo from \'./foo\';',
+      options: [
+        {
+          forbid: ['foo']
+        }
+      ],
+      errors: [ {
+        line: 1,
+        column: 8,
+        message: ERROR_MESSAGE,
+      } ],
+    }),
+    test({
+      code: 'import * as foo from \'./foo\';',
+      output: 'import * as foo from \'./foo\';',
+      options: [
+        {
+          allow: ['bar']
+        }
+      ],
       errors: [ {
         line: 1,
         column: 8,


### PR DESCRIPTION
I've added `allow` and `forbid` options, so this rule can be used for certain namespaces, instead for all