### PR TITLE
[New] `import/default`: support default export in TSExportAssignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`import/default`]: support default export in TSExportAssignment ([#1528], thanks [@joaovieira])
 - [`no-cycle`]: add `ignoreExternal` option ([#1681], thanks [@sveyret])
 - [`order`]: Add support for TypeScript's "import equals"-expressions ([#1785], thanks [@manuth])
+- [`import/default`]: support default export in TSExportAssignment ([#1689], thanks [@Maxim-Mazurok])
 
 ### Fixed
 - [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
@@ -705,6 +706,7 @@ for info on changes for earlier releases.
 [#1702]: https://github.com/benmosher/eslint-plugin-import/issues/1702
 [#1691]: https://github.com/benmosher/eslint-plugin-import/pull/1691
 [#1690]: https://github.com/benmosher/eslint-plugin-import/pull/1690
+[#1689]: https://github.com/benmosher/eslint-plugin-import/pull/1689
 [#1681]: https://github.com/benmosher/eslint-plugin-import/pull/1681
 [#1676]: https://github.com/benmosher/eslint-plugin-import/pull/1676
 [#1666]: https://github.com/benmosher/eslint-plugin-import/pull/1666
@@ -1189,3 +1191,4 @@ for info on changes for earlier releases.
 [@barbogast]: https://github.com/barbogast
 [@adamborowski]: https://github.com/adamborowski
 [@adjerbetian]: https://github.com/adjerbetian
+[@Maxim-Mazurok]: https://github.com/Maxim-Mazurok

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "minimatch": "^3.0.4",
     "object.values": "^1.1.0",
     "read-pkg-up": "^2.0.0",
-    "resolve": "^1.12.0"
+    "resolve": "^1.12.0",
+    "tsconfig-paths": "^3.9.0"
   },
   "nyc": {
     "require": [

--- a/tests/files/typescript-export-as-default-namespace/index.d.ts
+++ b/tests/files/typescript-export-as-default-namespace/index.d.ts
@@ -1,0 +1,3 @@
+export as namespace Foo
+
+export function bar(): void

--- a/tests/files/typescript-export-as-default-namespace/tsconfig.json
+++ b/tests/files/typescript-export-as-default-namespace/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true
+    }
+}

--- a/tests/files/typescript-export-assign-default-namespace/index.d.ts
+++ b/tests/files/typescript-export-assign-default-namespace/index.d.ts
@@ -1,0 +1,3 @@
+export = FooBar;
+
+declare namespace FooBar {}

--- a/tests/files/typescript-export-assign-default-namespace/tsconfig.json
+++ b/tests/files/typescript-export-assign-default-namespace/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true
+    }
+}

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -1,3 +1,4 @@
+import path from 'path'
 import { test, SYNTAX_CASES, getTSParsers } from '../utils'
 import { RuleTester } from 'eslint'
 
@@ -189,6 +190,28 @@ context('TypeScript', function () {
               'import/resolver': { 'eslint-import-resolver-typescript': true },
             },
           }),
+          test({
+            code: `import React from "./typescript-export-assign-default-namespace"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+            parserOptions: {
+              tsconfigRootDir: path.resolve(__dirname, '../../files/typescript-export-assign-default-namespace/'),
+            },
+          }),
+          test({
+            code: `import Foo from "./typescript-export-as-default-namespace"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+            parserOptions: {
+              tsconfigRootDir: path.resolve(__dirname, '../../files/typescript-export-as-default-namespace/'),
+            },
+          }),
         ],
 
         invalid: [
@@ -200,6 +223,24 @@ context('TypeScript', function () {
               'import/resolver': { 'eslint-import-resolver-typescript': true },
             },
             errors: ['No default export found in imported module "./typescript".'],
+          }),
+          test({
+            code: `import React from "./typescript-export-assign-default-namespace"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+            errors: ['No default export found in imported module "./typescript-export-assign-default-namespace".'],
+          }),
+          test({
+            code: `import FooBar from "./typescript-export-as-default-namespace"`,
+            parser: parser,
+            settings: {
+              'import/parsers': { [parser]: ['.ts'] },
+              'import/resolver': { 'eslint-import-resolver-typescript': true },
+            },
+            errors: ['No default export found in imported module "./typescript-export-as-default-namespace".'],
           }),
         ],
       })


### PR DESCRIPTION
Possible duplicate of #1528 (but uses `tsconfig.json`)
Aims to fix #1527

For example, I want to import React as `import React from "react"`. I can do this by using `esModuleInterop: true` in `tsconfig.json`, but eslint doesn't know about that.

This is a draft PR as I'm not really familiar with the codebase. I want to share my approach and receive feedback.