### PR TITLE
Remove duplicate no-unused-modules from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Changed
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
+- [readme] Remove duplicate no-unused-modules from docs ([#1690], thanks [@arvigeus])
 
 ## [2.20.2] - 2020-03-28
 ### Fixed
@@ -677,6 +678,7 @@ for info on changes for earlier releases.
 [#1722]: https://github.com/benmosher/eslint-plugin-import/issues/1722
 [#1719]: https://github.com/benmosher/eslint-plugin-import/issues/1719
 [#1702]: https://github.com/benmosher/eslint-plugin-import/issues/1702
+[#1690]: https://github.com/benmosher/eslint-plugin-import/pull/1690
 [#1676]: https://github.com/benmosher/eslint-plugin-import/pull/1676
 [#1666]: https://github.com/benmosher/eslint-plugin-import/pull/1666
 [#1664]: https://github.com/benmosher/eslint-plugin-import/pull/1664
@@ -1148,3 +1150,4 @@ for info on changes for earlier releases.
 [@astorije]: https://github.com/astorije
 [@Ephem]: https://github.com/Ephem
 [@kmui2]: https://github.com/kmui2
+[@arvigeus]: https://github.com/arvigeus

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 * Forbid a module from importing a module with a dependency path back to itself ([`no-cycle`])
 * Prevent unnecessary path segments in import and require statements ([`no-useless-path-segments`])
 * Forbid importing modules from parent directories ([`no-relative-parent-imports`])
-* Forbid modules without any export, and exports not imported by any modules. ([`no-unused-modules`])
 
 [`no-unresolved`]: ./docs/rules/no-unresolved.md
 [`named`]: ./docs/rules/named.md
@@ -42,7 +41,6 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 [`no-cycle`]: ./docs/rules/no-cycle.md
 [`no-useless-path-segments`]: ./docs/rules/no-useless-path-segments.md
 [`no-relative-parent-imports`]: ./docs/rules/no-relative-parent-imports.md
-[`no-unused-modules`]: ./docs/rules/no-unused-modules.md
 
 ### Helpful warnings
 


### PR DESCRIPTION
Remove no-unused-modules from Static analysis because it is already mentioned in Helpful warnings