### PR TITLE
[Fix] `group-exports`: Flow type export awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+### Fixed
+- [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
+
 ## [2.20.2] - 2020-03-28
 ### Fixed
 - [`order`]: fix `isExternalModule` detect on windows ([#1651], thanks [@fisker])
@@ -660,6 +663,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1702]: https://github.com/benmosher/eslint-plugin-import/issues/1702
 [#1666]: https://github.com/benmosher/eslint-plugin-import/pull/1666
 [#1664]: https://github.com/benmosher/eslint-plugin-import/pull/1664
 [#1658]: https://github.com/benmosher/eslint-plugin-import/pull/1658
@@ -988,6 +992,7 @@ for info on changes for earlier releases.
 [0.12.1]: https://github.com/benmosher/eslint-plugin-import/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/benmosher/eslint-plugin-import/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/benmosher/eslint-plugin-import/compare/v0.10.1...v0.11.0
+
 [@mathieudutour]: https://github.com/mathieudutour
 [@gausie]: https://github.com/gausie
 [@singles]: https://github.com/singles
@@ -1122,3 +1127,4 @@ for info on changes for earlier releases.
 [@fisker]: https://github.com/fisker
 [@richardxia]: https://github.com/richardxia
 [@TheCrueltySage]: https://github.com/TheCrueltySage
+[@ernestostifano]: https://github.com/ernestostifano

--- a/docs/rules/group-exports.md
+++ b/docs/rules/group-exports.md
@@ -60,6 +60,15 @@ test.another = true
 module.exports = test
 ```
 
+```flow js
+const first = true;
+type firstType = boolean
+
+// A single named export declaration (type exports handled separately) -> ok
+export {first}
+export type {firstType}
+```
+
 
 ### Invalid
 
@@ -92,6 +101,15 @@ module.exports.first = true
 module.exports = () => {}
 module.exports.first = true
 module.exports.second = true
+```
+
+```flow js
+type firstType = boolean
+type secondType = any
+
+// Multiple named type export statements -> not ok!
+export type {firstType}
+export type {secondType}
 ```
 
 ## When Not To Use It

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-plugin-istanbul": "^4.1.6",
     "babel-plugin-module-resolver": "^2.7.1",
     "babel-preset-es2015-argon": "latest",
+    "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.26.0",
     "babylon": "^6.18.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
Fix for [#1702].

Now `export` and `export type` statements are handled separately with the same logic.