### PR TITLE
Add eslint 7 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ node_js:
 os: linux
 
 env:
+  - ESLINT_VERSION=^7.0.0-0
   - ESLINT_VERSION=6
   - ESLINT_VERSION=5
   - ESLINT_VERSION=4
@@ -65,8 +66,14 @@ matrix:
     env: ESLINT_VERSION=5
   - node_js: '4'
     env: ESLINT_VERSION=6
+  - node_js: '4'
+    env: ESLINT_VERSION=^7.0.0-0
   - node_js: '6'
     env: ESLINT_VERSION=6
+  - node_js: '6'
+    env: ESLINT_VERSION=^7.0.0-0
+  - node_js: '8'
+    env: ESLINT_VERSION=^7.0.0-0
 
   fast_finish: true
   allow_failures:

--- a/src/rules/dynamic-import-chunkname.js
+++ b/src/rules/dynamic-import-chunkname.js
@@ -42,7 +42,9 @@ module.exports = {
 
         const sourceCode = context.getSourceCode()
         const arg = node.arguments[0]
-        const leadingComments = sourceCode.getComments(arg).leading
+        const leadingComments = sourceCode.getCommentsBefore
+          ? sourceCode.getCommentsBefore(arg) // This method is available in ESLint >= 4.
+          : sourceCode.getComments(arg).leading // This method is deprecated in ESLint 7.
 
         if (!leadingComments || leadingComments.length === 0) {
           context.report({

--- a/tests/src/rules/exports-last.js
+++ b/tests/src/rules/exports-last.js
@@ -6,7 +6,6 @@ import rule from 'rules/exports-last'
 const ruleTester = new RuleTester()
 
 const error = type => ({
-  ruleId: 'exports-last',
   message: 'Export statements should appear at the end of the file',
   type,
 })

--- a/tests/src/rules/no-absolute-path.js
+++ b/tests/src/rules/no-absolute-path.js
@@ -6,7 +6,6 @@ const ruleTester = new RuleTester()
     , rule = require('rules/no-absolute-path')
 
 const error = {
-  ruleId: 'no-absolute-path',
   message: 'Do not import modules using an absolute path',
 }
 

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -5,7 +5,7 @@ import { RuleTester } from 'eslint'
 const ruleTester = new RuleTester()
     , rule = require('rules/no-cycle')
 
-const error = message => ({ ruleId: 'no-cycle', message })
+const error = message => ({ message })
 
 const test = def => _test(Object.assign(def, {
   filename: testFilePath('./cycles/depth-zero.js'),

--- a/tests/src/rules/no-default-export.js
+++ b/tests/src/rules/no-default-export.js
@@ -89,7 +89,7 @@ ruleTester.run('no-default-export', rule, {
     test({
       code: 'export default function bar() {};',
       errors: [{
-        ruleId: 'ExportDefaultDeclaration',
+        type: 'ExportDefaultDeclaration',
         message: 'Prefer named exports.',
       }],
     }),
@@ -98,14 +98,14 @@ ruleTester.run('no-default-export', rule, {
         export const foo = 'foo';
         export default bar;`,
       errors: [{
-        ruleId: 'ExportDefaultDeclaration',
+        type: 'ExportDefaultDeclaration',
         message: 'Prefer named exports.',
       }],
     }),
     test({
       code: 'let foo; export { foo as default }',
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Do not alias `foo` as `default`. Just export `foo` itself ' +
           'instead.',
       }],
@@ -114,7 +114,7 @@ ruleTester.run('no-default-export', rule, {
       code: 'export default from "foo.js"',
       parser: require.resolve('babel-eslint'),
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Prefer named exports.',
       }],
     }),

--- a/tests/src/rules/no-dynamic-require.js
+++ b/tests/src/rules/no-dynamic-require.js
@@ -6,7 +6,6 @@ const ruleTester = new RuleTester()
     , rule = require('rules/no-dynamic-require')
 
 const error = {
-  ruleId: 'no-dynamic-require',
   message: 'Calls to require() should use string literals',
 }
 

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -126,7 +126,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
       options: [{packageDir: packageDirMonoRepoRoot }],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
@@ -135,7 +134,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
       options: [{packageDir: packageDirMonoRepoRoot}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
@@ -143,28 +141,24 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "not-a-dependency"',
       options: [{packageDir: packageDirMonoRepoRoot}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
     test({
       code: 'import "not-a-dependency"',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
     test({
       code: 'var donthaveit = require("@org/not-a-dependency")',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'@org/not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S @org/not-a-dependency\' to add it',
       }],
     }),
     test({
       code: 'var donthaveit = require("@org/not-a-dependency/foo")',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'@org/not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S @org/not-a-dependency\' to add it',
       }],
     }),
@@ -172,7 +166,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "eslint"',
       options: [{devDependencies: false, peerDependencies: false}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'eslint\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
@@ -180,14 +173,12 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "lodash.isarray"',
       options: [{optionalDependencies: false}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'lodash.isarray\' should be listed in the project\'s dependencies, not optionalDependencies.',
       }],
     }),
     test({
       code: 'var foo = require("not-a-dependency")',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
@@ -195,7 +186,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'var glob = require("glob")',
       options: [{devDependencies: false}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'glob\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
@@ -204,7 +194,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{devDependencies: ['*.test.js']}],
       filename: 'foo.tes.js',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
@@ -213,7 +202,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{devDependencies: ['*.test.js']}],
       filename: path.join(process.cwd(), 'foo.tes.js'),
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
@@ -222,7 +210,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{devDependencies: ['*.test.js', '*.spec.js']}],
       filename: 'foo.tes.js',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
@@ -231,7 +218,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       options: [{devDependencies: ['*.test.js', '*.spec.js']}],
       filename: path.join(process.cwd(), 'foo.tes.js'),
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'chai\' should be listed in the project\'s dependencies, not devDependencies.',
       }],
     }),
@@ -239,7 +225,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'var eslint = require("lodash.isarray")',
       options: [{optionalDependencies: false}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'lodash.isarray\' should be listed in the project\'s dependencies, not optionalDependencies.',
       }],
     }),
@@ -247,7 +232,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "not-a-dependency"',
       options: [{packageDir: path.join(__dirname, '../../../')}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
@@ -255,7 +239,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "bar"',
       options: [{packageDir: path.join(__dirname, './doesn-exist/')}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: 'The package.json file could not be found.',
       }],
     }),
@@ -263,7 +246,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import foo from "foo"',
       options: [{packageDir: packageDirWithSyntaxError}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: 'The package.json file could not be parsed: ' + packageFileWithSyntaxErrorMessage,
       }],
     }),
@@ -272,7 +254,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
       options: [{packageDir: packageDirMonoRepoWithNested}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: "'left-pad' should be listed in the project's dependencies. Run 'npm i -S left-pad' to add it",
       }],
     }),
@@ -280,7 +261,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import react from "react";',
       filename: path.join(packageDirMonoRepoRoot, 'foo.js'),
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: "'react' should be listed in the project's dependencies. Run 'npm i -S react' to add it",
       }],
     }),
@@ -289,7 +269,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       filename: path.join(packageDirMonoRepoWithNested, 'foo.js'),
       options: [{packageDir: packageDirMonoRepoRoot}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: "'react' should be listed in the project's dependencies. Run 'npm i -S react' to add it",
       }],
     }),
@@ -298,7 +277,6 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       filename: path.join(packageDirWithEmpty, 'index.js'),
       options: [{packageDir: packageDirWithEmpty}],
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: "'react' should be listed in the project's dependencies. Run 'npm i -S react' to add it",
       }],
     }),
@@ -319,14 +297,12 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'export { foo } from "not-a-dependency";',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),
     test({
       code: 'export * from "not-a-dependency";',
       errors: [{
-        ruleId: 'no-extraneous-dependencies',
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],
     }),

--- a/tests/src/rules/no-named-export.js
+++ b/tests/src/rules/no-named-export.js
@@ -35,10 +35,10 @@ ruleTester.run('no-named-export', rule, {
         export const bar = 'bar';
       `,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }, {
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -47,7 +47,7 @@ ruleTester.run('no-named-export', rule, {
         export const foo = 'foo';
         export default bar;`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -57,17 +57,17 @@ ruleTester.run('no-named-export', rule, {
         export function bar() {};
       `,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }, {
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `export const foo = 'foo';`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -77,35 +77,35 @@ ruleTester.run('no-named-export', rule, {
         export { foo };
       `,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `let foo, bar; export { foo, bar }`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `export const { foo, bar } = item;`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `export const { foo, bar: baz } = item;`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `export const { foo: { bar, baz } } = item;`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -116,31 +116,31 @@ ruleTester.run('no-named-export', rule, {
         export { item };
       `,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }, {
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `export * from './foo';`,
       errors: [{
-        ruleId: 'ExportAllDeclaration',
+        type: 'ExportAllDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `export const { foo } = { foo: "bar" };`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
     test({
       code: `export const { foo: { bar } } = { foo: { bar: "baz" } };`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -148,7 +148,7 @@ ruleTester.run('no-named-export', rule, {
       code: 'export { a, b } from "foo.js"',
       parser: require.resolve('babel-eslint'),
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -156,7 +156,7 @@ ruleTester.run('no-named-export', rule, {
       code: `export type UserId = number;`,
       parser: require.resolve('babel-eslint'),
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -164,7 +164,7 @@ ruleTester.run('no-named-export', rule, {
       code: 'export foo from "foo.js"',
       parser: require.resolve('babel-eslint'),
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),
@@ -172,7 +172,7 @@ ruleTester.run('no-named-export', rule, {
       code: `export Memory, { MemoryValue } from './Memory'`,
       parser: require.resolve('babel-eslint'),
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Named exports are not allowed.',
       }],
     }),

--- a/tests/src/rules/no-nodejs-modules.js
+++ b/tests/src/rules/no-nodejs-modules.js
@@ -6,7 +6,6 @@ const ruleTester = new RuleTester()
     , rule = require('rules/no-nodejs-modules')
 
 const error = message => ({
-  ruleId: 'no-nodejs-modules',
   message,
 })
 

--- a/tests/src/rules/no-self-import.js
+++ b/tests/src/rules/no-self-import.js
@@ -6,7 +6,6 @@ const ruleTester = new RuleTester()
     , rule = require('rules/no-self-import')
 
 const error = {
-  ruleId: 'no-self-import',
   message: 'Module imports itself.',
 }
 

--- a/tests/src/rules/no-unassigned-import.js
+++ b/tests/src/rules/no-unassigned-import.js
@@ -7,7 +7,6 @@ const ruleTester = new RuleTester()
     , rule = require('rules/no-unassigned-import')
 
 const error = {
-  ruleId: 'no-unassigned-import',
   message: 'Imported module should be assigned',
 }
 

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -10,7 +10,7 @@ const ruleTester = new RuleTester()
     , jsxRuleTester = new RuleTester(jsxConfig)
     , rule = require('rules/no-unused-modules')
 
-const error = message => ({ ruleId: 'no-unused-modules', message })
+const error = message => ({ message })
 
 const missingExportsOptions = [{
   missingExports: true,

--- a/tests/src/rules/no-useless-path-segments.js
+++ b/tests/src/rules/no-useless-path-segments.js
@@ -40,41 +40,49 @@ function runResolverTests(resolver) {
       // CommonJS modules
       test({
         code: 'require("./../files/malformed.js")',
+        output: 'require("../files/malformed.js")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "./../files/malformed.js", should be "../files/malformed.js"'],
       }),
       test({
         code: 'require("./../files/malformed")',
+        output: 'require("../files/malformed")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "./../files/malformed", should be "../files/malformed"'],
       }),
       test({
         code: 'require("../files/malformed.js")',
+        output: 'require("./malformed.js")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "../files/malformed.js", should be "./malformed.js"'],
       }),
       test({
         code: 'require("../files/malformed")',
+        output: 'require("./malformed")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "../files/malformed", should be "./malformed"'],
       }),
       test({
         code: 'require("./test-module/")',
+        output: 'require("./test-module")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "./test-module/", should be "./test-module"'],
       }),
       test({
         code: 'require("./")',
+        output: 'require(".")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "./", should be "."'],
       }),
       test({
         code: 'require("../")',
+        output: 'require("..")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "../", should be ".."'],
       }),
       test({
         code: 'require("./deep//a")',
+        output: 'require("./deep/a")',
         options: [{ commonjs: true }],
         errors: [ 'Useless path segments for "./deep//a", should be "./deep/a"'],
       }),
@@ -82,41 +90,49 @@ function runResolverTests(resolver) {
       // CommonJS modules + noUselessIndex
       test({
         code: 'require("./bar/index.js")',
+        output: 'require("./bar/")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "./bar/index.js", should be "./bar/"'], // ./bar.js exists
       }),
       test({
         code: 'require("./bar/index")',
+        output: 'require("./bar/")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "./bar/index", should be "./bar/"'], // ./bar.js exists
       }),
       test({
         code: 'require("./importPath/")',
+        output: 'require("./importPath")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "./importPath/", should be "./importPath"'], // ./importPath.js does not exist
       }),
       test({
         code: 'require("./importPath/index.js")',
+        output: 'require("./importPath")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "./importPath/index.js", should be "./importPath"'], // ./importPath.js does not exist
       }),
       test({
         code: 'require("./importType/index")',
+        output: 'require("./importType")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "./importType/index", should be "./importType"'], // ./importPath.js does not exist
       }),
       test({
         code: 'require("./index")',
+        output: 'require(".")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "./index", should be "."'],
       }),
       test({
         code: 'require("../index")',
+        output: 'require("..")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "../index", should be ".."'],
       }),
       test({
         code: 'require("../index.js")',
+        output: 'require("..")',
         options: [{ commonjs: true, noUselessIndex: true }],
         errors: ['Useless path segments for "../index.js", should be ".."'],
       }),
@@ -124,90 +140,109 @@ function runResolverTests(resolver) {
       // ES modules
       test({
         code: 'import "./../files/malformed.js"',
+        output: 'import "../files/malformed.js"',
         errors: [ 'Useless path segments for "./../files/malformed.js", should be "../files/malformed.js"'],
       }),
       test({
         code: 'import "./../files/malformed"',
+        output: 'import "../files/malformed"',
         errors: [ 'Useless path segments for "./../files/malformed", should be "../files/malformed"'],
       }),
       test({
         code: 'import "../files/malformed.js"',
+        output: 'import "./malformed.js"',
         errors: [ 'Useless path segments for "../files/malformed.js", should be "./malformed.js"'],
       }),
       test({
         code: 'import "../files/malformed"',
+        output: 'import "./malformed"',
         errors: [ 'Useless path segments for "../files/malformed", should be "./malformed"'],
       }),
       test({
         code: 'import "./test-module/"',
+        output: 'import "./test-module"',
         errors: [ 'Useless path segments for "./test-module/", should be "./test-module"'],
       }),
       test({
         code: 'import "./"',
+        output: 'import "."',
         errors: [ 'Useless path segments for "./", should be "."'],
       }),
       test({
         code: 'import "../"',
+        output: 'import ".."',
         errors: [ 'Useless path segments for "../", should be ".."'],
       }),
       test({
         code: 'import "./deep//a"',
+        output: 'import "./deep/a"',
         errors: [ 'Useless path segments for "./deep//a", should be "./deep/a"'],
       }),
 
       // ES modules + noUselessIndex
       test({
         code: 'import "./bar/index.js"',
+        output: 'import "./bar/"',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "./bar/index.js", should be "./bar/"'], // ./bar.js exists
       }),
       test({
         code: 'import "./bar/index"',
+        output: 'import "./bar/"',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "./bar/index", should be "./bar/"'], // ./bar.js exists
       }),
       test({
         code: 'import "./importPath/"',
+        output: 'import "./importPath"',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "./importPath/", should be "./importPath"'], // ./importPath.js does not exist
       }),
       test({
         code: 'import "./importPath/index.js"',
+        output: 'import "./importPath"',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "./importPath/index.js", should be "./importPath"'], // ./importPath.js does not exist
       }),
       test({
         code: 'import "./importPath/index"',
+        output: 'import "./importPath"',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "./importPath/index", should be "./importPath"'], // ./importPath.js does not exist
       }),
       test({
         code: 'import "./index"',
+        output: 'import "."',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "./index", should be "."'],
       }),
       test({
         code: 'import "../index"',
+        output: 'import ".."',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "../index", should be ".."'],
       }),
       test({
         code: 'import "../index.js"',
+        output: 'import ".."',
         options: [{ noUselessIndex: true }],
         errors: ['Useless path segments for "../index.js", should be ".."'],
       }),
       test({
         code: 'import("./")',
+        output: 'import(".")',
         errors: [ 'Useless path segments for "./", should be "."'],
         parser: require.resolve('babel-eslint'),
       }),
       test({
         code: 'import("../")',
+        output: 'import("..")',
         errors: [ 'Useless path segments for "../", should be ".."'],
         parser: require.resolve('babel-eslint'),
       }),
       test({
         code: 'import("./deep//a")',
+        output: 'import("./deep/a")',
         errors: [ 'Useless path segments for "./deep//a", should be "./deep/a"'],
         parser: require.resolve('babel-eslint'),
       }),

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -681,7 +681,6 @@ ruleTester.run('order', rule, {
         var async = require('async');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -696,7 +695,6 @@ ruleTester.run('order', rule, {
         var async = require('async');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -711,7 +709,6 @@ ruleTester.run('order', rule, {
         var async = require('async');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -726,7 +723,6 @@ ruleTester.run('order', rule, {
         /* comment1 */  var async = require('async'); /* comment2 */
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -741,7 +737,6 @@ ruleTester.run('order', rule, {
         /* comment0 */  /* comment1 */  var async = require('async'); /* comment2 */
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -756,7 +751,6 @@ ruleTester.run('order', rule, {
         `/* comment0 */  /* comment1 */  var async = require('async'); /* comment2 */` + `\r\n`
       ,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -776,7 +770,6 @@ ruleTester.run('order', rule, {
           comment3 */
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -791,7 +784,6 @@ ruleTester.run('order', rule, {
         var {b} = require('async');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -808,7 +800,6 @@ ruleTester.run('order', rule, {
         var async = require('async');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -821,7 +812,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
         var async = require('async');` + '\n',
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -836,7 +826,6 @@ ruleTester.run('order', rule, {
         import async from 'async';
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -851,7 +840,6 @@ ruleTester.run('order', rule, {
         var async = require('async');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     }),
@@ -866,7 +854,6 @@ ruleTester.run('order', rule, {
         var parent = require('../parent');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`async` import should occur before import of `../parent`',
       }],
     }),
@@ -881,7 +868,6 @@ ruleTester.run('order', rule, {
         var sibling = require('./sibling');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`../parent` import should occur before import of `./sibling`',
       }],
     }),
@@ -896,7 +882,6 @@ ruleTester.run('order', rule, {
         var index = require('./');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./sibling` import should occur before import of `./`',
       }],
     }),
@@ -908,10 +893,8 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`async` import should occur before import of `./sibling`',
       }, {
-        ruleId: 'order',
         message: '`fs` import should occur before import of `./sibling`',
       }],
     }),
@@ -934,7 +917,6 @@ ruleTester.run('order', rule, {
         var index = require('./');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./` import should occur after import of `bar`',
       }],
     }),
@@ -950,7 +932,6 @@ ruleTester.run('order', rule, {
       `,
       options: [{groups: ['index', 'sibling', 'parent', 'external', 'builtin']}],
       errors: [{
-        ruleId: 'order',
         message: '`./` import should occur before import of `fs`',
       }],
     }),
@@ -961,7 +942,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `./foo`',
       }],
     })),
@@ -972,7 +952,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `./foo`',
       }],
     })),
@@ -985,7 +964,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `./foo`',
       }],
     })),
@@ -998,7 +976,6 @@ ruleTester.run('order', rule, {
           .bar;
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `./foo`',
       }],
     })),
@@ -1021,7 +998,6 @@ ruleTester.run('order', rule, {
         ['sibling', 'parent', 'external'],
       ]}],
       errors: [{
-        ruleId: 'order',
         message: '`path` import should occur before import of `./foo`',
       }],
     }),
@@ -1041,7 +1017,6 @@ ruleTester.run('order', rule, {
         // missing 'builtin'
       ]}],
       errors: [{
-        ruleId: 'order',
         message: '`async` import should occur before import of `path`',
       }],
     }),
@@ -1057,7 +1032,6 @@ ruleTester.run('order', rule, {
         ['sibling', 'parent', 'UNKNOWN', 'internal'],
       ]}],
       errors: [{
-        ruleId: 'order',
         message: 'Incorrect configuration of the rule: Unknown type `"UNKNOWN"`',
       }],
     }),
@@ -1072,7 +1046,6 @@ ruleTester.run('order', rule, {
         ['sibling', 'parent', ['builtin'], 'internal'],
       ]}],
       errors: [{
-        ruleId: 'order',
         message: 'Incorrect configuration of the rule: Unknown type `["builtin"]`',
       }],
     }),
@@ -1087,7 +1060,6 @@ ruleTester.run('order', rule, {
         ['sibling', 'parent', 2, 'internal'],
       ]}],
       errors: [{
-        ruleId: 'order',
         message: 'Incorrect configuration of the rule: Unknown type `2`',
       }],
     }),
@@ -1102,7 +1074,6 @@ ruleTester.run('order', rule, {
         ['sibling', 'parent', 'parent', 'internal'],
       ]}],
       errors: [{
-        ruleId: 'order',
         message: 'Incorrect configuration of the rule: `parent` is duplicated',
       }],
     }),
@@ -1127,7 +1098,6 @@ ruleTester.run('order', rule, {
         var index = require('./');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./foo` import should occur before import of `fs`',
       }],
     }),
@@ -1143,7 +1113,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur after import of `../foo/bar`',
       }],
     }),
@@ -1510,7 +1479,6 @@ ruleTester.run('order', rule, {
         fn_call();
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./local` import should occur after import of `global2`',
       }],
     }),
@@ -1533,7 +1501,6 @@ ruleTester.run('order', rule, {
         fn_call();
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./local` import should occur after import of `global2`',
       }],
     }),
@@ -1584,7 +1551,6 @@ ruleTester.run('order', rule, {
         fn_call();
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./local` import should occur after import of `global3`',
       }],
     })),
@@ -1639,7 +1605,6 @@ ruleTester.run('order', rule, {
         ],
       }],
       errors: [{
-        ruleId: 'order',
         message: '`~/components/Input` import should occur before import of `./helper`',
       }],
     }),
@@ -1665,7 +1630,6 @@ ruleTester.run('order', rule, {
         ],
       }],
       errors: [{
-        ruleId: 'order',
         message: '`./helper` import should occur after import of `async`',
       }],
     }),
@@ -1689,7 +1653,6 @@ ruleTester.run('order', rule, {
         ],
       }],
       errors: [{
-        ruleId: 'order',
         message: '`~/components/Input` import should occur before import of `lodash`',
       }],
     }),
@@ -1723,7 +1686,6 @@ ruleTester.run('order', rule, {
       }],
       errors: [
         {
-          ruleId: 'order',
           message: '`-/components/Export` import should occur before import of `$/components/Import`',
         },
       ],
@@ -1759,7 +1721,6 @@ ruleTester.run('order', rule, {
       }],
       errors: [
         {
-          ruleId: 'order',
           message: '`~/components/Output` import should occur before import of `#/components/Input`',
         },
       ],
@@ -1773,7 +1734,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1800,7 +1760,6 @@ ruleTester.run('order', rule, {
         http.createServer(express());
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./config` import should occur after import of `express`',
       }],
     }),
@@ -1812,7 +1771,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1823,7 +1781,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs')(a);
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1834,7 +1791,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1846,7 +1802,6 @@ ruleTester.run('order', rule, {
         var fs = require('fs');
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1858,7 +1813,6 @@ ruleTester.run('order', rule, {
         import fs from 'fs';
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1870,7 +1824,6 @@ ruleTester.run('order', rule, {
         import fs from 'fs';
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1882,7 +1835,6 @@ ruleTester.run('order', rule, {
         import fs from 'fs';
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1894,7 +1846,6 @@ ruleTester.run('order', rule, {
         import fs from 'fs';
       `,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1909,7 +1860,6 @@ ruleTester.run('order', rule, {
       `,
       parser,
       errors: [{
-        ruleId: 'order',
         message: '`fs` import should occur before import of `async`',
       }],
     })),
@@ -1934,7 +1884,6 @@ ruleTester.run('order', rule, {
         alphabetize: {order: 'asc'},
       }],
       errors: [{
-        ruleID: 'order',
         message: '`Bar` import should occur before import of `bar`',
       }],
     }),
@@ -1959,7 +1908,6 @@ ruleTester.run('order', rule, {
         alphabetize: {order: 'desc'},
       }],
       errors: [{
-        ruleID: 'order',
         message: '`bar` import should occur before import of `Bar`',
       }],
     }),
@@ -1982,7 +1930,6 @@ ruleTester.run('order', rule, {
         alphabetize: {order: 'asc', caseInsensitive: true},
       }],
       errors: [{
-        ruleID: 'order',
         message: '`Bar` import should occur before import of `foo`',
       }],
     }),
@@ -2005,7 +1952,6 @@ ruleTester.run('order', rule, {
         alphabetize: {order: 'desc', caseInsensitive: true},
       }],
       errors: [{
-        ruleID: 'order',
         message: '`foo` import should occur before import of `Bar`',
       }],
     }),
@@ -2024,7 +1970,6 @@ ruleTester.run('order', rule, {
         alphabetize: {order: 'asc'},
       }],
       errors: [{
-        ruleID: 'order',
         message: '`..` import should occur before import of `../a`',
       }],
     }),
@@ -2037,10 +1982,8 @@ ruleTester.run('order', rule, {
         import { hello } from './hello';
       `,
       errors: [{
-        ruleId: 'order',
         message: '`./int` import should occur before import of `./cello`',
       }, {
-        ruleId: 'order',
         message: '`./hello` import should occur before import of `./cello`',
       }],
     }),

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -94,7 +94,7 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         export function bar() {};`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Prefer default export.',
       }],
     }),
@@ -102,7 +102,7 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         export const foo = 'foo';`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Prefer default export.',
       }],
     }),
@@ -111,7 +111,7 @@ ruleTester.run('prefer-default-export', rule, {
         const foo = 'foo';
         export { foo };`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportSpecifier',
         message: 'Prefer default export.',
       }],
     }),
@@ -119,7 +119,7 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         export const { foo } = { foo: "bar" };`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Prefer default export.',
       }],
     }),
@@ -127,7 +127,7 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         export const { foo: { bar } } = { foo: { bar: "baz" } };`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Prefer default export.',
       }],
     }),
@@ -135,7 +135,7 @@ ruleTester.run('prefer-default-export', rule, {
       code: `
         export const [a] = ["foo"]`,
       errors: [{
-        ruleId: 'ExportNamedDeclaration',
+        type: 'ExportNamedDeclaration',
         message: 'Prefer default export.',
       }],
     }),


### PR DESCRIPTION
The relevant breaking changes in eslint 7 are:
1. Test cases that contains unrecognized properties are now failed.
2. Test cases that have fixed code but missing `output` are now failed.
3. The method `sourceCode.getComments` is deprecated.
