### PR TITLE
[Fix] `order`: Recognize pathGroup config for first group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
+- [`order`]: Recognize pathGroup config for first group ([#1719], [#1724], thanks [@forivall], [@xpl])
 
 ## [2.20.2] - 2020-03-28
 ### Fixed
@@ -663,6 +664,8 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1724]: https://github.com/benmosher/eslint-plugin-import/issues/1724
+[#1719]: https://github.com/benmosher/eslint-plugin-import/issues/1719
 [#1702]: https://github.com/benmosher/eslint-plugin-import/issues/1702
 [#1666]: https://github.com/benmosher/eslint-plugin-import/pull/1666
 [#1664]: https://github.com/benmosher/eslint-plugin-import/pull/1664
@@ -1128,3 +1131,5 @@ for info on changes for earlier releases.
 [@richardxia]: https://github.com/richardxia
 [@TheCrueltySage]: https://github.com/TheCrueltySage
 [@ernestostifano]: https://github.com/ernestostifano
+[@forivall]: https://github.com/forivall
+[@xpl]: https://github.com/xpl

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -318,7 +318,7 @@ function computeRank(context, ranks, name, type, excludedImportTypes) {
   if (!excludedImportTypes.has(impType)) {
     rank = computePathRank(ranks.groups, ranks.pathGroups, name, ranks.maxPosition)
   }
-  if (!rank) {
+  if (typeof rank === 'undefined') {
     rank = ranks.groups[impType]
   }
   if (type !== 'import') {

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -307,6 +307,23 @@ ruleTester.run('order', rule, {
         ],
       }],
     }),
+    // Using pathGroups (a test case for https://github.com/benmosher/eslint-plugin-import/pull/1724)
+    test({
+      code: `
+        import fs from 'fs';
+        import external from 'external';
+        import externalTooPlease from './make-me-external';
+
+        import sibling from './sibling';`,
+      options: [{
+        'newlines-between': 'always',
+        pathGroupsExcludedImportTypes: [],
+        pathGroups: [
+          { pattern: './make-me-external', group: 'external' },
+        ],
+        groups: [['builtin', 'external'], 'internal', 'parent', 'sibling', 'index'],
+      }],
+    }),
     // Monorepo setup, using Webpack resolver, workspace folder name in external-module-folders
     test({
       code: `


### PR DESCRIPTION
With the config
```js
  'import/order': [
    'warn',
    {
      groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
      alphabetize: {
        order: 'asc',
      },
      pathGroups: [{ pattern: 'react', group: 'builtin' }],
      pathGroupsExcludedImportTypes: ['builtin'],
    },
  ],
```
, react wasn't being recognized as a part of the "builtin" group, since the rank would end up being `0`, which is a falsy value. The fix here, is to check for `undefined` instead.

My current workaround is to define
```
      pathGroups: [{ pattern: 'react', group: 'builtin', position: 'before' }],
```
instead, (which results in a rank `-0.1`, so it's not falsy).