### PR TITLE
Disable import/named in the TypeScript configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
 - [`order`]: Recognize pathGroup config for first group ([#1719], [#1724], thanks [@forivall], [@xpl])
 
+### Changed
+- TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
+
 ## [2.20.2] - 2020-03-28
 ### Fixed
 - [`order`]: fix `isExternalModule` detect on windows ([#1651], thanks [@fisker])
@@ -664,6 +667,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1726]: https://github.com/benmosher/eslint-plugin-import/issues/1726
 [#1724]: https://github.com/benmosher/eslint-plugin-import/issues/1724
 [#1719]: https://github.com/benmosher/eslint-plugin-import/issues/1719
 [#1702]: https://github.com/benmosher/eslint-plugin-import/issues/1702
@@ -1133,3 +1137,4 @@ for info on changes for earlier releases.
 [@ernestostifano]: https://github.com/ernestostifano
 [@forivall]: https://github.com/forivall
 [@xpl]: https://github.com/xpl
+[@astorije]: https://github.com/astorije

--- a/config/typescript.js
+++ b/config/typescript.js
@@ -19,4 +19,10 @@ module.exports = {
     },
   },
 
+  rules: {
+    // analysis/correctness
+
+    // TypeScript compilation already ensures that named imports exist in the referenced module
+    'import/named': 'off',
+  },
 }


### PR DESCRIPTION
As I was linting our projects, I noticed a few violations across them:

```ts
import { IconName } from '@fortawesome/free-solid-svg-icons';
import { GetTrackProps } from 'react-compound-slider';
import { SliderItem } from 'react-compound-slider';
import { InjectedIntl } from 'react-intl';
```

Looking around, it seems the recommendations are to either use `import type` (I haven't tried) or disabling the rule locally.
I was wondering what this rule brings when used in a TypeScript setup and realized [I am not the only one](https://github.com/typescript-eslint/typescript-eslint/issues/154#issuecomment-517037192).

Since it makes sense to disable the rule when using TypeScript, and this rule is enabled by the `recommended` preset, would it be a ridiculous idea to disable it in the `typescript` preset of this repo, and save consumers the inconvenience of doing it locally?

_(I'm sure [some of these](https://github.com/benmosher/eslint-plugin-import/blob/master/config/recommended.js#L10-L19) could also be disabled, but I figured I would ask your opinions on this one first before looking at others)_