### PR TITLE
Fix counting re-export as usage when used in combination with import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
 - [`order`]: Recognize pathGroup config for first group ([#1719], [#1724], thanks [@forivall], [@xpl])
+- [`no-unused-modules`]: Fix re-export not counting as usage when used in combination with import ([#1722], thanks [@Ephem])
 
 ### Changed
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
@@ -669,6 +670,7 @@ for info on changes for earlier releases.
 
 [#1726]: https://github.com/benmosher/eslint-plugin-import/issues/1726
 [#1724]: https://github.com/benmosher/eslint-plugin-import/issues/1724
+[#1722]: https://github.com/benmosher/eslint-plugin-import/issues/1722
 [#1719]: https://github.com/benmosher/eslint-plugin-import/issues/1719
 [#1702]: https://github.com/benmosher/eslint-plugin-import/issues/1702
 [#1666]: https://github.com/benmosher/eslint-plugin-import/pull/1666
@@ -1138,3 +1140,4 @@ for info on changes for earlier releases.
 [@forivall]: https://github.com/forivall
 [@xpl]: https://github.com/xpl
 [@astorije]: https://github.com/astorije
+[@Ephem]: https://github.com/Ephem

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -196,7 +196,13 @@ const prepareImportsAndExports = (srcFiles, context) => {
         if (isNodeModule(key)) {
           return
         }
-        imports.set(key, value.importedSpecifiers)
+        let localImport = imports.get(key)
+        if (typeof localImport !== 'undefined') {
+          localImport = new Set([...localImport, ...value.importedSpecifiers])
+        } else {
+          localImport = value.importedSpecifiers
+        }
+        imports.set(key, localImport)
       })
       importList.set(file, imports)
 

--- a/tests/files/no-unused-modules/import-export-1.js
+++ b/tests/files/no-unused-modules/import-export-1.js
@@ -1,0 +1,2 @@
+export const a = 5;
+export const b = 'b';

--- a/tests/files/no-unused-modules/import-export-2.js
+++ b/tests/files/no-unused-modules/import-export-2.js
@@ -1,0 +1,2 @@
+import { a } from './import-export-1';
+export { b } from './import-export-1';

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -427,6 +427,17 @@ ruleTester.run('no-unused-modules', rule, {
   ],
 })
 
+// Test that import and export in the same file both counts as usage
+ruleTester.run('no-unused-modules', rule, {
+  valid: [
+    test({ options: unusedExportsOptions,
+          code: `export const a = 5;export const b = 't1'`,
+          filename: testFilePath('./no-unused-modules/import-export-1.js'),
+        }),
+  ],
+  invalid: [],
+})
+
 describe('test behaviour for new file', () => {
   before(() => {
     fs.writeFileSync(testFilePath('./no-unused-modules/file-added-0.js'), '', {encoding: 'utf8'})


### PR DESCRIPTION
Closes #1722 

This PR makes sure `aa` below is correctly counted as usage:

```js
import { a } from './a';
export { aa } from './a';
```

In addition to the attached test, this fix was tested against a previous false negative in a private project which now worked.

I found the existing tests quite hard to read and understand, so I went a bit off the beaten path and tried to isolate this test in new files to avoid coupling them too much to the existing ones. I also named the files descriptively as opposed to following the existing standard of letters. This was just best effort after finally grokking what was going on, so I'm happy to take any pointers on how to improve or tweak!