### PR TITLE
[Refactor] `no-extraneous-dependencies`: use moduleVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-unused-modules`]: avoid order-dependence ([#1744], thanks [@darkartur])
 
 ### Changed
+- [Refactor] `no-extraneous-dependencies`: use moduleVisitor ([#1735], thanks [@adamborowski])
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
 - [readme] Remove duplicate no-unused-modules from docs ([#1690], thanks [@arvigeus])
 - [Docs] `order`: fix bad inline config ([#1788], thanks [@nickofthyme])
@@ -695,6 +696,7 @@ for info on changes for earlier releases.
 [#1751]: https://github.com/benmosher/eslint-plugin-import/pull/1751
 [#1744]: https://github.com/benmosher/eslint-plugin-import/pull/1744
 [#1736]: https://github.com/benmosher/eslint-plugin-import/pull/1736
+[#1735]: https://github.com/benmosher/eslint-plugin-import/pull/1735
 [#1726]: https://github.com/benmosher/eslint-plugin-import/pull/1726
 [#1724]: https://github.com/benmosher/eslint-plugin-import/pull/1724
 [#1722]: https://github.com/benmosher/eslint-plugin-import/issues/1722
@@ -1183,3 +1185,4 @@ for info on changes for earlier releases.
 [@darkartur]: https://github.com/darkartur
 [@MikeyBeLike]: https://github.com/MikeyBeLike
 [@barbogast]: https://github.com/barbogast
+[@adamborowski]: https://github.com/adamborowski

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -3,8 +3,8 @@ import fs from 'fs'
 import readPkgUp from 'read-pkg-up'
 import minimatch from 'minimatch'
 import resolve from 'eslint-module-utils/resolve'
+import moduleVisitor from 'eslint-module-utils/moduleVisitor'
 import importType from '../core/importType'
-import isStaticRequire from '../core/staticRequire'
 import docsUrl from '../docsUrl'
 
 function hasKeys(obj = {}) {
@@ -200,28 +200,8 @@ module.exports = {
       allowBundledDeps: testConfig(options.bundledDependencies, filename) !== false,
     }
 
-    // todo: use module visitor from module-utils core
-    return {
-      ImportDeclaration: function (node) {
-        if (node.source) {
-          reportIfMissing(context, deps, depsOptions, node, node.source.value)
-        }
-      },
-      ExportNamedDeclaration: function (node) {
-        if (node.source) {
-          reportIfMissing(context, deps, depsOptions, node, node.source.value)
-        }
-      },
-      ExportAllDeclaration: function (node) {
-        if (node.source) {
-          reportIfMissing(context, deps, depsOptions, node, node.source.value)
-        }
-      },
-      CallExpression: function handleRequires(node) {
-        if (isStaticRequire(node)) {
-          reportIfMissing(context, deps, depsOptions, node, node.arguments[0].value)
-        }
-      },
-    }
+    return moduleVisitor(node => {
+      reportIfMissing(context, deps, depsOptions, node, node.value)
+    }, {commonjs: true})
   },
 }


### PR DESCRIPTION
Hi.
I start with simple refactoring but I already have few suggestions with code changes and tests that will make no-extraneous-dependencies more flexible for monorepo projects.

This PR is a warmup. I'd like to see if our interaction goes well.

I hope you will enjoy my contribution.
Cheers,
Adam
 