### PR TITLE
Fix interface declarations for Typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`newline-after-import`]: recognize decorators ([#1139], thanks [@atos1990])
 - [`no-unused-modules`]: Revert "[flow] `no-unused-modules`: add flow type support" ([#1770], thanks [@Hypnosphi])
 - TypeScript: Add nested namespace handling ([#1763], thanks [@julien1619])
+- [`namespace`]/`ExportMap`: Fix interface declarations for TypeScript ([#1764], thanks [@julien1619])
 
 ### Changed
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
@@ -685,6 +686,7 @@ for info on changes for earlier releases.
 [#1786]: https://github.com/benmosher/eslint-plugin-import/pull/1786
 [#1785]: https://github.com/benmosher/eslint-plugin-import/pull/1785
 [#1770]: https://github.com/benmosher/eslint-plugin-import/pull/1770
+[#1764]: https://github.com/benmosher/eslint-plugin-import/pull/1764
 [#1763]: https://github.com/benmosher/eslint-plugin-import/pull/1763
 [#1736]: https://github.com/benmosher/eslint-plugin-import/pull/1736
 [#1726]: https://github.com/benmosher/eslint-plugin-import/pull/1726

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -543,7 +543,10 @@ ExportMap.parse = function (path, content, context) {
       ]
       const exportedDecls = ast.body.filter(({ type, id, declarations }) => 
         declTypes.includes(type) && 
-        (id && id.name === exportedName || declarations.find(d => d.id.name === exportedName))
+        (
+          (id && id.name === exportedName) ||
+          (declarations && declarations.find(d => d.id.name === exportedName))
+        )
       )
       if (exportedDecls.length === 0) {
         // Export is not referencing any local declaration, must be re-exporting

--- a/tests/files/typescript-declare-interface.d.ts
+++ b/tests/files/typescript-declare-interface.d.ts
@@ -1,0 +1,11 @@
+declare interface foo {
+  a: string;
+}
+
+declare namespace SomeNamespace {
+  type foobar = foo & {
+    b: string;
+  }
+}
+
+export = SomeNamespace

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -133,6 +133,15 @@ const valid = [
     },
   })),
 
+  ...getTSParsers().map((parser) => test({
+    code: `import { foobar } from "./typescript-declare-interface"`,
+    parser: parser,
+    settings: {
+      'import/parsers': { [parser]: ['.ts'] },
+      'import/resolver': { 'eslint-import-resolver-typescript': true },
+    },
+  })),
+
   ...SYNTAX_CASES,
 ]
 


### PR DESCRIPTION
Relates to https://github.com/benmosher/eslint-plugin-import/pull/1528#discussion_r424564412

With #1528, in some cases, interface declaration crashed this plugin. This PR fixes it.