### PR TITLE
Revert "[flow] `no-unused-modules`: add flow type support"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`order`]: Recognize pathGroup config for first group ([#1719], [#1724], thanks [@forivall], [@xpl])
 - [`no-unused-modules`]: Fix re-export not counting as usage when used in combination with import ([#1722], thanks [@Ephem])
 - [`no-duplicates`]: Handle TS import type ([#1676], thanks [@kmui2])
-- [``newline-after-import`: recognize decorators ([#1139], thanks [@atos1990])
+- [`newline-after-import`]: recognize decorators ([#1139], thanks [@atos1990])
+- [`no-unused-modules`]: Revert "[flow] `no-unused-modules`: add flow type support" ([#1770], thanks [@Hypnosphi])
 
 ### Changed
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
@@ -675,6 +676,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1770]: https://github.com/benmosher/eslint-plugin-import/issues/1770
 [#1726]: https://github.com/benmosher/eslint-plugin-import/issues/1726
 [#1724]: https://github.com/benmosher/eslint-plugin-import/issues/1724
 [#1722]: https://github.com/benmosher/eslint-plugin-import/issues/1722
@@ -1156,3 +1158,4 @@ for info on changes for earlier releases.
 [@kmui2]: https://github.com/kmui2
 [@arvigeus]: https://github.com/arvigeus
 [@atos1990]: https://github.com/atos1990
+[@Hypnosphi]: https://github.com/Hypnosphi

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -64,7 +64,6 @@ const VARIABLE_DECLARATION = 'VariableDeclaration'
 const FUNCTION_DECLARATION = 'FunctionDeclaration'
 const CLASS_DECLARATION = 'ClassDeclaration'
 const DEFAULT = 'default'
-const TYPE_ALIAS = 'TypeAlias'
 
 /**
  * List of imports per file.
@@ -563,8 +562,7 @@ module.exports = {
           if (declaration) {
             if (
               declaration.type === FUNCTION_DECLARATION ||
-              declaration.type === CLASS_DECLARATION ||
-              declaration.type === TYPE_ALIAS
+              declaration.type === CLASS_DECLARATION
             ) {
               newExportIdentifiers.add(declaration.id.name)
             }
@@ -889,8 +887,7 @@ module.exports = {
         if (node.declaration) {
           if (
             node.declaration.type === FUNCTION_DECLARATION ||
-            node.declaration.type === CLASS_DECLARATION ||
-            node.declaration.type === TYPE_ALIAS
+            node.declaration.type === CLASS_DECLARATION
           ) {
             checkUsage(node, node.declaration.id.name)
           }

--- a/tests/files/no-unused-modules/flow-0.js
+++ b/tests/files/no-unused-modules/flow-0.js
@@ -1,1 +1,0 @@
-import { type FooType } from './flow-2';

--- a/tests/files/no-unused-modules/flow-1.js
+++ b/tests/files/no-unused-modules/flow-1.js
@@ -1,2 +1,0 @@
-// @flow strict
-export type Bar = number;

--- a/tests/files/no-unused-modules/flow-2.js
+++ b/tests/files/no-unused-modules/flow-2.js
@@ -1,2 +1,0 @@
-// @flow strict
-export type FooType = string;

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -680,38 +680,6 @@ describe('do not report unused export for files mentioned in package.json', () =
   })
 })
 
-describe('correctly report flow types', () => {
-  ruleTester.run('no-unused-modules', rule, {
-    valid: [
-      test({
-        options: unusedExportsOptions,
-        code: 'import { type FooType } from "./flow-2";',
-        parser: require.resolve('babel-eslint'),
-        filename: testFilePath('./no-unused-modules/flow-0.js'),
-      }),
-      test({
-        options: unusedExportsOptions,
-        code: `// @flow strict
-               export type FooType = string;`,
-        parser: require.resolve('babel-eslint'),
-        filename: testFilePath('./no-unused-modules/flow-2.js'),
-      }),
-    ],
-    invalid: [
-      test({
-        options: unusedExportsOptions,
-        code: `// @flow strict
-               export type Bar = string;`,
-        parser: require.resolve('babel-eslint'),
-        filename: testFilePath('./no-unused-modules/flow-1.js'),
-        errors: [
-          error(`exported declaration 'Bar' not used within other modules`),
-        ],
-      }),
-    ],
-  })
-})
-
 describe('Avoid errors if re-export all from umd compiled library', () => {
   ruleTester.run('no-unused-modules', rule, {
     valid: [


### PR DESCRIPTION
#1542 was intended to fix issue #1540 but introduced a more critical issue, #1564. In my case, it blocks upgrading to the latest version with all the fancy features like alphabetical sorting.

This PR just reverts it

Fixes #1564. Reopens #1540.