### PR TITLE
[no-unused-rules]: Fix docs for  unused exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [readme] Remove duplicate no-unused-modules from docs ([#1690], thanks [@arvigeus])
 - [Docs] `order`: fix bad inline config ([#1788], thanks [@nickofthyme])
 - [Tests] Add fix for Windows Subsystem for Linux ([#1786], thanks [@manuth])
+- [Docs] `no-unused-rules`: Fix docs for unused exports ([#1776], thanks [@barbogast])
 
 ## [2.20.2] - 2020-03-28
 ### Fixed
@@ -687,6 +688,7 @@ for info on changes for earlier releases.
 [#1788]: https://github.com/benmosher/eslint-plugin-import/pull/1788
 [#1786]: https://github.com/benmosher/eslint-plugin-import/pull/1786
 [#1785]: https://github.com/benmosher/eslint-plugin-import/pull/1785
+[#1776]: https://github.com/benmosher/eslint-plugin-import/pull/1776
 [#1770]: https://github.com/benmosher/eslint-plugin-import/pull/1770
 [#1764]: https://github.com/benmosher/eslint-plugin-import/pull/1764
 [#1763]: https://github.com/benmosher/eslint-plugin-import/pull/1763
@@ -1180,3 +1182,4 @@ for info on changes for earlier releases.
 [@julien1619]: https://github.com/julien1619
 [@darkartur]: https://github.com/darkartur
 [@MikeyBeLike]: https://github.com/MikeyBeLike
+[@barbogast]: https://github.com/barbogast

--- a/docs/rules/no-unused-modules.md
+++ b/docs/rules/no-unused-modules.md
@@ -58,27 +58,21 @@ given file-f:
 ```js
 import { e } from 'file-a'
 import { f } from 'file-b'
-import * from  'file-c'
-export * from 'file-d'
-export { default, i0 } from 'file-e' // both will be reported
+import * as fileC from  'file-c'
+export { default, i0 } from 'file-d' // both will be reported
 
 export const j = 99 // will be reported 
 ```
-and file-e:
+and file-d:
 ```js
 export const i0 = 9 // will not be reported
 export const i1 = 9 // will be reported
 export default () => {} // will not be reported
 ```
-and file-d:
+and file-c:
 ```js
 export const h = 8 // will not be reported
 export default () => {} // will be reported, as export * only considers named exports and ignores default exports
-```
-and file-c:
-```js
-export const g = 7 // will not be reported
-export default () => {} // will not be reported
 ```
 and file-b:
 ```js


### PR DESCRIPTION
First change: 
Change 
```js
import * from  'file-c'
``` 
to 
```js
import * as fileC from  'file-c'
```
The former isn't valid javascript, right?

Second change: Remove example 'file-d', I couldn't see a difference from 'file-c'

Third change: Rename 'file-e' to 'file-d'.