### PR TITLE
Add fix for Windows Subsystem for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - TypeScript config: Disable [`named`][] ([#1726], thanks [@astorije])
 - [readme] Remove duplicate no-unused-modules from docs ([#1690], thanks [@arvigeus])
 - [Docs] `order`: fix bad inline config ([#1788], thanks [@nickofthyme])
+- [Tests] Add fix for Windows Subsystem for Linux ([#1786], thanks [@manuth])
 
 ## [2.20.2] - 2020-03-28
 ### Fixed
@@ -679,6 +680,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#1788]: https://github.com/benmosher/eslint-plugin-import/pull/1788
+[#1786]: https://github.com/benmosher/eslint-plugin-import/pull/1786
 [#1785]: https://github.com/benmosher/eslint-plugin-import/pull/1785
 [#1770]: https://github.com/benmosher/eslint-plugin-import/pull/1770
 [#1726]: https://github.com/benmosher/eslint-plugin-import/pull/1726

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+configuration:
+  - Native
+  - WSL
+
 # Test against this version of Node.js
 environment:
   matrix:
@@ -8,8 +12,12 @@ environment:
   # - nodejs_version: "6"
   # - nodejs_version: "4"
 
+image: Visual Studio 2019
 matrix:
   fast_finish: false
+  exclude:
+    - configuration: WSL
+      nodejs_version: "8"
 
   # allow_failures:
   #   - nodejs_version: "4" # for eslint 5
@@ -18,45 +26,99 @@ matrix:
 #   - x86
 #   - x64
 
-# Install scripts. (runs after repo cloning)
-install:
-  # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version
+for:
+-
+  matrix:
+    only:
+      - configuration: Native
+  # Install scripts. (runs after repo cloning)
+  install:
+    # Get the latest stable version of Node.js or io.js
+    - ps: Install-Product node $env:nodejs_version
 
-  # install modules
-  - ps: >-
-      if ($env:nodejs_version -eq "4") {
-        npm install -g npm@3;
-      }
-      if ($env:nodejs_version -in @("8", "10", "12")) {
-        npm install -g npm@6.10.3;
-      }
-  - npm install
+    # install modules
+    - ps: >-
+        if ($env:nodejs_version -eq "4") {
+          npm install -g npm@3;
+        }
+        if ($env:nodejs_version -in @("8", "10", "12")) {
+          npm install -g npm@6.10.3;
+        }
+    - npm install
 
-  # fix symlinks
-  - cmd: git config core.symlinks true
-  - cmd: git reset --hard
+    # fix symlinks
+    - git config core.symlinks true
+    - git reset --hard
 
-  # todo: learn how to do this for all .\resolvers\* on Windows
-  - cd .\resolvers\webpack && npm install && cd ..\..
-  - cd .\resolvers\node && npm install && cd ..\..
+    # todo: learn how to do this for all .\resolvers\* on Windows
+    - cd .\resolvers\webpack && npm install && cd ..\..
+    - cd .\resolvers\node && npm install && cd ..\..
 
-# Post-install test scripts.
-test_script:
+  # Post-install test scripts.
+  test_script:
 
-  # Output useful info for debugging.
-  - node --version
-  - npm --version
+    # Output useful info for debugging.
+    - node --version
+    - npm --version
 
-  # core tests
-  - npm run tests-only
+    # core tests
+    - npm run pretest
+    - npm run tests-only
 
-  # resolver tests
-  - cd .\resolvers\webpack && npm test && cd ..\..
-  - cd .\resolvers\node && npm test && cd ..\..
+    # resolver tests
+    - cd .\resolvers\webpack && npm test && cd ..\..
+    - cd .\resolvers\node && npm test && cd ..\..
 
-on_success:
-  - npm run coveralls
+  on_success:
+    - npm run coveralls
+-
+  matrix:
+    only:
+      - configuration: WSL
+  # Install scripts. (runs after repo cloning)
+  install:
+    # Get the latest stable version of Node.js or io.js
+    - ps: $env:WSLENV += ":nodejs_version"
+    - ps: wsl curl -sL 'https://deb.nodesource.com/setup_${nodejs_version}.x' `| sudo APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 -E bash -
+    - wsl sudo DEBIAN_FRONTEND=noninteractive apt install -y nodejs
+
+    # install modules
+    - ps: >-
+        if ($env:nodejs_version -eq "4") {
+          wsl sudo npm install -g npm@3;
+        }
+        if ($env:nodejs_version -in @("8", "10", "12")) {
+          wsl sudo npm install -g npm@6.10.3;
+        }
+    - wsl npm install
+
+    # fix symlinks
+    - git config core.symlinks true
+    - git reset --hard
+    # reset new-line characters
+    - wsl git reset --hard
+
+    # todo: learn how to do this for all .\resolvers\* on Windows
+    - cd .\resolvers\webpack && wsl npm install && cd ..\..
+    - cd .\resolvers\node && wsl npm install && cd ..\..
+
+  # Post-install test scripts.
+  test_script:
+
+    # Output useful info for debugging.
+    - wsl node --version
+    - wsl npm --version
+
+    # core tests
+    - wsl npm run pretest
+    - wsl npm run tests-only
+
+    # resolver tests
+    - cd .\resolvers\webpack && wsl npm test && cd ..\..
+    - cd .\resolvers\node && wsl npm test && cd ..\..
+
+  on_success:
+    - wsl npm run coveralls
 
 # Don't actually build.
 build: off

--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -10,7 +10,7 @@ const path = require('path')
 const hashObject = require('./hash').hashObject
     , ModuleCache = require('./ModuleCache').default
 
-const CASE_SENSITIVE_FS = !fs.existsSync(path.join(__dirname, 'reSOLVE.js'))
+const CASE_SENSITIVE_FS = !fs.existsSync(path.join(__dirname.toUpperCase(), 'reSOLVE.js'))
 exports.CASE_SENSITIVE_FS = CASE_SENSITIVE_FS
 
 const ERROR_NAME = 'EslintPluginImportResolveError'


### PR DESCRIPTION
This PR will add support for Windows Subsystem for Linux.

Windows Subsystem for Linux seems to have quite a weird treatment with file and directory-names.
While directories are case-sensitive (directory `./tests` exists while `./TeSts` doesn't), files don't seem to be (both `reSOLVE.js` and `resolve.js` exist).

This PR adds WSL-support by checking whether both directories and files are case-sensitive before setting `CASE_SENSITIVE_FS`.