### PR TITLE
Fix development-environment to work for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,12 +39,17 @@ for:
     # install modules
     - ps: >-
         if ($env:nodejs_version -eq "4") {
-          npm install -g npm@3;
+          cmd /c npm install -g npm@3;
         }
         if ($env:nodejs_version -in @("8", "10", "12")) {
-          npm install -g npm@6.10.3;
+          cmd /c npm install -g npm@6.14.5;
         }
     - npm install
+
+    - ps: >-
+        if ([int]$env:nodejs_version -le 8) {
+          cmd /c npm i eslint@6 2`>`&1;
+        }
 
     # fix symlinks
     - git config core.symlinks true
@@ -53,6 +58,20 @@ for:
     # todo: learn how to do this for all .\resolvers\* on Windows
     - cd .\resolvers\webpack && npm install && cd ..\..
     - cd .\resolvers\node && npm install && cd ..\..
+
+    # Upgrade nyc
+    - npm i --no-save nyc@15.0.1
+    - ps: >-
+        $resolverDir = "./resolvers";
+        Get-ChildItem -Directory $resolverDir |
+        ForEach-Object {
+          Push-Location $(Resolve-Path $(Join-Path $resolverDir $_));
+          cmd /c npm ls nyc 2`>`&1;
+          if ($?) {
+            cmd /c npm i --no-save nyc@15.0.1 2`>`&1;
+          }
+          Pop-Location;
+        }
 
   # Post-install test scripts.
   test_script:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test-compiled": "npm run prepublish && BABEL_ENV=testCompiled mocha --compilers js:babel-register tests/src",
     "test-all": "node --require babel-register ./scripts/testAll",
     "prepublish": "not-in-publish || npm run build",
-    "coveralls": "nyc report --reporter lcovonly && cat ./coverage/lcov.info | coveralls"
+    "coveralls": "nyc report --reporter lcovonly && coveralls < ./coverage/lcov.info"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "glob": "^7.1.6",
     "in-publish": "^2.0.0",
     "linklocal": "^2.8.2",
+    "lodash.isarray": "^4.0.0",
     "mocha": "^3.5.3",
     "npm-which": "^3.0.1",
     "nyc": "^11.9.0",


### PR DESCRIPTION
~Babel~ `nyc` caused some errors on its currently installed version as seen in the AppVeyor history logs.
Some key modules of the development-environment have been updated:
- `nyc` ("on the fly"-update in AppVeyor-script)
- ~`babel`-modules~
- ~`mocha`~

~Though, applying this PR won't cause any issues when using with older versions of `nodeJS` (unless babel is configured correctly (see below)), after applying this PR, a nodeJS `>=8` is required to develop this project.
As mentioned this should have no impact to the usage of the module, but to the development of the module which then will be performed with more modern module-versions.~

~To ensure, the built module also works for NodeJS `argon`, setting [this option (`targets.node`)](https://babeljs.io/docs/en/babel-preset-env#targetsnode) to the appropriate version-number might be necessary.~

This PR fixes #1780 and fixes #1781 