### PR TITLE
[no-restricted-path] Custom error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-cycle`]: add `ignoreExternal` option ([#1681], thanks [@sveyret])
 - [`order`]: Add support for TypeScript's "import equals"-expressions ([#1785], thanks [@manuth])
 - [`import/default`]: support default export in TSExportAssignment ([#1689], thanks [@Maxim-Mazurok])
+- [`no-restricted-paths`]: add custom message support ([#1802], thanks [@malykhinvi])
 
 ### Fixed
 - [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
@@ -688,6 +689,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1802]: https://github.com/benmosher/eslint-plugin-import/pull/1802
 [#1788]: https://github.com/benmosher/eslint-plugin-import/pull/1788
 [#1786]: https://github.com/benmosher/eslint-plugin-import/pull/1786
 [#1785]: https://github.com/benmosher/eslint-plugin-import/pull/1785
@@ -1192,3 +1194,4 @@ for info on changes for earlier releases.
 [@adamborowski]: https://github.com/adamborowski
 [@adjerbetian]: https://github.com/adjerbetian
 [@Maxim-Mazurok]: https://github.com/Maxim-Mazurok
+[@malykhinvi]: https://github.com/malykhinvi

--- a/docs/rules/no-restricted-paths.md
+++ b/docs/rules/no-restricted-paths.md
@@ -10,6 +10,7 @@ In order to prevent such scenarios this rule allows you to define restricted zon
 This rule has one option. The option is an object containing the definition of all restricted `zones` and the optional `basePath` which is used to resolve relative paths within.
 The default value for `basePath` is the current working directory.
 Each zone consists of the `target` path and a `from` path. The `target` is the path where the restricted imports should be applied. The `from` path defines the folder that is not allowed to be used in an import. An optional `except` may be defined for a zone, allowing exception paths that would otherwise violate the related `from`. Note that `except` is relative to `from` and cannot backtrack to a parent directory.
+You may also specify an optional `message` for a zone, which will be displayed in case of the rule violation.
 
 ### Examples
 

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -32,6 +32,7 @@ module.exports = {
                   },
                   uniqueItems: true,
                 },
+                message: { type: 'string' },
               },
               additionalProperties: false,
             },
@@ -102,7 +103,7 @@ module.exports = {
 
           context.report({
             node,
-            message: `Unexpected path "{{importPath}}" imported in restricted zone.`,
+            message: `Unexpected path "{{importPath}}" imported in restricted zone.${zone.message ? ` ${zone.message}` : ''}`,
             data: { importPath },
           })
         })

--- a/tests/src/rules/no-restricted-paths.js
+++ b/tests/src/rules/no-restricted-paths.js
@@ -152,6 +152,23 @@ ruleTester.run('no-restricted-paths', rule, {
         zones: [ {
           target: './tests/files/restricted-paths/server/one',
           from: './tests/files/restricted-paths/server',
+          except: ['./one'],
+          message: 'Custom message',
+        } ],
+      } ],
+      errors: [ {
+        message: 'Unexpected path "../two/a.js" imported in restricted zone. Custom message',
+        line: 1,
+        column: 15,
+      } ],
+    }),
+    test({
+      code: 'import b from "../two/a.js"',
+      filename: testFilePath('./restricted-paths/server/one/a.js'),
+      options: [ {
+        zones: [ {
+          target: './tests/files/restricted-paths/server/one',
+          from: './tests/files/restricted-paths/server',
           except: ['../client/a'],
         } ],
       } ],


### PR DESCRIPTION
**Main change**
Adds a `message` configuration param for every `zone`, that will be displayed in case of the rule violation. 
The logic is pretty similar to eslint's [no-restricted-imports](https://eslint.org/docs/rules/no-restricted-imports#options)

**Background**
Sometimes, it is not very clear, why you can not import certain modules in certain scenarios. This is especially the case for newcomers. To be more user friendly, we could display additional info, right in the error message. It would look something like this:

```javascript
//eslint config
'import/no-restricted-paths': [
  'error',
  {
    basePath: './src',
    zones: [ {
      target: './core',
      from: './features',
      message: '' +
        '\n\nCore should be completely isolated from features.' +
        '\nFeatures may use core but not vice versa',
    }],
  }
],
```
Then VSCode would display it like that:
<img width="648" alt="Screenshot 2020-06-06 at 13 27 11" src="https://user-images.githubusercontent.com/5537715/83942288-e8588780-a7fa-11ea-8e43-29ded49c1d63.png">
