### PR TITLE
[New] `no-unused-modules`: consider exported TypeScript interfaces, types and enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+### Added
+- [`no-unused-modules`]: consider exported TypeScript interfaces, types and enums ([#1819], thanks [@nicolashenry])
 
 ## [2.21.2] - 2020-06-09
 ### Fixed
@@ -702,6 +704,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1819]: https://github.com/benmosher/eslint-plugin-import/pull/1819
 [#1802]: https://github.com/benmosher/eslint-plugin-import/pull/1802
 [#1801]: https://github.com/benmosher/eslint-plugin-import/issues/1801
 [#1788]: https://github.com/benmosher/eslint-plugin-import/pull/1788
@@ -1216,3 +1219,4 @@ for info on changes for earlier releases.
 [@adjerbetian]: https://github.com/adjerbetian
 [@Maxim-Mazurok]: https://github.com/Maxim-Mazurok
 [@malykhinvi]: https://github.com/malykhinvi
+[@nicolashenry]: https://github.com/nicolashenry

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -63,7 +63,32 @@ const IMPORT_DEFAULT_SPECIFIER = 'ImportDefaultSpecifier'
 const VARIABLE_DECLARATION = 'VariableDeclaration'
 const FUNCTION_DECLARATION = 'FunctionDeclaration'
 const CLASS_DECLARATION = 'ClassDeclaration'
+const INTERFACE_DECLARATION = 'InterfaceDeclaration'
+const TYPE_ALIAS = 'TypeAlias'
+const TS_INTERFACE_DECLARATION = 'TSInterfaceDeclaration'
+const TS_TYPE_ALIAS_DECLARATION = 'TSTypeAliasDeclaration'
+const TS_ENUM_DECLARATION = 'TSEnumDeclaration'
 const DEFAULT = 'default'
+
+function forEachDeclarationIdentifier(declaration, cb) {
+  if (declaration) {
+    if (
+      declaration.type === FUNCTION_DECLARATION ||
+      declaration.type === CLASS_DECLARATION ||
+      declaration.type === INTERFACE_DECLARATION ||
+      declaration.type === TYPE_ALIAS ||
+      declaration.type === TS_INTERFACE_DECLARATION ||
+      declaration.type === TS_TYPE_ALIAS_DECLARATION ||
+      declaration.type === TS_ENUM_DECLARATION
+    ) {
+      cb(declaration.id.name)
+    } else if (declaration.type === VARIABLE_DECLARATION) {
+      declaration.declarations.forEach(({ id }) => {
+        cb(id.name)
+      })
+    }
+  }
+}
 
 /**
  * List of imports per file.
@@ -559,19 +584,9 @@ module.exports = {
               }
             })
           }
-          if (declaration) {
-            if (
-              declaration.type === FUNCTION_DECLARATION ||
-              declaration.type === CLASS_DECLARATION
-            ) {
-              newExportIdentifiers.add(declaration.id.name)
-            }
-            if (declaration.type === VARIABLE_DECLARATION) {
-              declaration.declarations.forEach(({ id }) => {
-                newExportIdentifiers.add(id.name)
-              })
-            }
-          }
+          forEachDeclarationIdentifier(declaration, (name) => {
+            newExportIdentifiers.add(name)
+          })
         }
       })
 
@@ -883,19 +898,9 @@ module.exports = {
         node.specifiers.forEach(specifier => {
             checkUsage(node, specifier.exported.name)
         })
-        if (node.declaration) {
-          if (
-            node.declaration.type === FUNCTION_DECLARATION ||
-            node.declaration.type === CLASS_DECLARATION
-          ) {
-            checkUsage(node, node.declaration.id.name)
-          }
-          if (node.declaration.type === VARIABLE_DECLARATION) {
-            node.declaration.declarations.forEach(declaration => {
-              checkUsage(node, declaration.id.name)
-            })
-          }
-        }
+        forEachDeclarationIdentifier(node.declaration, (name) => {
+          checkUsage(node, name)
+        })
       },
     }
   },

--- a/tests/files/no-unused-modules/typescript/file-ts-a.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-a.ts
@@ -1,3 +1,8 @@
 import {b} from './file-ts-b';
+import {c} from './file-ts-c';
+import {d} from './file-ts-d';
+import {e} from './file-ts-e';
 
-export const a = b + 1;
+export const a = b + 1 + e.f;
+export const a2: c = {};
+export const a3: d = {};

--- a/tests/files/no-unused-modules/typescript/file-ts-c.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-c.ts
@@ -1,0 +1,1 @@
+export interface c {};

--- a/tests/files/no-unused-modules/typescript/file-ts-d.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-d.ts
@@ -1,0 +1,1 @@
+export type d = {};

--- a/tests/files/no-unused-modules/typescript/file-ts-e.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-e.ts
@@ -1,0 +1,1 @@
+export enum e { f };

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -1,4 +1,4 @@
-import { test, testFilePath } from '../utils'
+import { test, testFilePath, getTSParsers } from '../utils'
 import jsxConfig from '../../../config/react'
 import typescriptConfig from '../../../config/typescript'
 
@@ -736,7 +736,78 @@ describe('correctly work with Typescript only files', () => {
           error(`exported declaration 'b' not used within other modules`),
         ],
       }),
+      test({
+        options: unusedExportsTypescriptOptions,
+        code: `export interface c {};`,
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/typescript/file-ts-c.ts'),
+        errors: [
+          error(`exported declaration 'c' not used within other modules`),
+        ],
+      }),
+      test({
+        options: unusedExportsTypescriptOptions,
+        code: `export type d = {};`,
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/typescript/file-ts-d.ts'),
+        errors: [
+          error(`exported declaration 'd' not used within other modules`),
+        ],
+      }),
     ],
+  })
+})
+
+context('TypeScript', function () {
+  getTSParsers().forEach((parser) => {
+    typescriptRuleTester.run('no-unused-modules', rule, {
+      valid: [
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: 'import a from "file-ts-a";',
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-a.ts'),
+        }),
+      ],
+      invalid: [
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export const b = 2;`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-b.ts'),
+          errors: [
+            error(`exported declaration 'b' not used within other modules`),
+          ],
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export interface c {};`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-c.ts'),
+          errors: [
+            error(`exported declaration 'c' not used within other modules`),
+          ],
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export type d = {};`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-d.ts'),
+          errors: [
+            error(`exported declaration 'd' not used within other modules`),
+          ],
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export enum e { f };`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-e.ts'),
+          errors: [
+            error(`exported declaration 'e' not used within other modules`),
+          ],
+        }),
+      ],
+    })
   })
 })
 


### PR DESCRIPTION
Fixes #1680

Note that `babel-eslint` parser does not handle typescript enums and do not produce the same declaration types as `@typescript-eslint/parser`.

`babel-eslint` => `InterfaceDeclaration`, `TypeAlias`
`@typescript-eslint/parser` => `TSInterfaceDeclaration`, `TSTypeAliasDeclaration`, `TSEnumDeclaration`