### PR TITLE
Fix Object-Import Errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [ "es2015-argon" ],
   "sourceMaps": "inline",
+  "retainLines": true,
   "env": {
     "test": {
       "plugins": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-unused-modules`]: consider exported TypeScript interfaces, types and enums ([#1819], thanks [@nicolashenry])
 
 ### Fixed
+- [`order`]/TypeScript: properly support `import = object` expressions ([#1823], thanks [@manuth])
 - [`no-extraneous-dependencies`]/TypeScript: do not error when importing type from dev dependencies ([#1820], thanks [@fernandopasik])
 - [`default`]: avoid crash with `export =` ([#1822], thanks [@AndrewLeedham])
 
@@ -712,6 +713,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#1824]: https://github.com/benmosher/eslint-plugin-import/pull/1824
+[#1823]: https://github.com/benmosher/eslint-plugin-import/pull/1823
 [#1822]: https://github.com/benmosher/eslint-plugin-import/pull/1822
 [#1820]: https://github.com/benmosher/eslint-plugin-import/pull/1820
 [#1819]: https://github.com/benmosher/eslint-plugin-import/pull/1819

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -22,6 +22,8 @@ import bar from './bar';
 import baz from './bar/baz';
 // 6. "index" of the current directory
 import main from './';
+// 7. "object"-imports (only available in TypeScript)
+import log = console.log;
 ```
 
 Unassigned imports are ignored, as the order they are imported in may be important.
@@ -77,12 +79,15 @@ This rule supports the following options:
 
 ### `groups: [array]`:
 
-How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are: `"builtin"`, `"external"`, `"internal"`, `"unknown"`, `"parent"`, `"sibling"`, `"index"`. The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
+How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are:
+`"builtin"`, `"external"`, `"internal"`, `"unknown"`, `"parent"`, `"sibling"`, `"index"`, `"object"`.
+The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
 ```js
 [
   'builtin', // Built-in types are first
   ['sibling', 'parent'], // Then sibling and parent types. They can be mingled together
   'index', // Then the index file
+  'object',
   // Then the rest: internal and external type
 ]
 ```
@@ -91,7 +96,7 @@ The default value is `["builtin", "external", "parent", "sibling", "index"]`.
 You can set the options like this:
 
 ```js
-"import/order": ["error", {"groups": ["index", "sibling", "parent", "internal", "external", "builtin"]}]
+"import/order": ["error", {"groups": ["index", "sibling", "parent", "internal", "external", "builtin", "object"]}]
 ```
 
 ### `pathGroups: [array of objects]`:

--- a/tests/src/cli.js
+++ b/tests/src/cli.js
@@ -58,14 +58,14 @@ describe('CLI regression tests', function () {
                 nodeType: results.results[0].messages[0].nodeType, // we don't care about this one
                 ruleId: 'json/*',
                 severity: 2,
-                source: '\n',
+                source: results.results[0].messages[0].source, // NewLine-characters might differ depending on git-settings
               },
             ],
             errorCount: 1,
             warningCount: 0,
             fixableErrorCount: 0,
             fixableWarningCount: 0,
-            source: ',\n',
+            source: results.results[0].source, // NewLine-characters might differ depending on git-settings
           },
         ],
         errorCount: 1,

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -711,6 +711,49 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+    ...flatMap(getTSParsers, parser => [
+      // Order of the `import ... = require(...)` syntax
+      test({
+        code: `
+          import blah = require('./blah');
+          import { hello } from './hello';`,
+        parser,
+        options: [
+          {
+            alphabetize: {
+              order: 'asc',
+            },
+          },
+        ],
+      }),
+      // Order of object-imports
+      test({
+        code: `
+          import blah = require('./blah');
+          import log = console.log;`,
+        parser,
+        options: [
+          {
+            alphabetize: {
+              order: 'asc',
+            },
+          },
+        ],
+      }),
+      test({
+        code: `
+          import debug = console.debug;
+          import log = console.log;`,
+        parser,
+        options: [
+          {
+            alphabetize: {
+              order: 'asc',
+            },
+          },
+        ],
+      }),
+    ]),
   ],
   invalid: [
     // builtin before external module (require)
@@ -1167,6 +1210,7 @@ ruleTester.run('order', rule, {
       }],
     }),
     ...flatMap(getTSParsers(), parser => [
+      // Order of the `import ... = require(...)` syntax
       test({
         code: `
           var fs = require('fs');
@@ -1183,7 +1227,7 @@ ruleTester.run('order', rule, {
           message: '`fs` import should occur after import of `../foo/bar`',
         }],
       }),
-      {
+      test({
         code: `
           var async = require('async');
           var fs = require('fs');
@@ -1196,7 +1240,7 @@ ruleTester.run('order', rule, {
         errors: [{
           message: '`fs` import should occur before import of `async`',
         }],
-      },
+      }),
       test({
         code: `
           import sync = require('sync');
@@ -1218,6 +1262,33 @@ ruleTester.run('order', rule, {
         errors: [{
           message: '`async` import should occur before import of `sync`',
         }],
+      }),
+      // Order of object-imports
+      test({
+        code: `
+          import log = console.log;
+          import blah = require('./blah');`,
+        parser,
+        errors: [{
+          message: '`./blah` import should occur before import of `console.log`',
+        }],
+      }),
+      // Alphabetization of object-imports
+      test({
+        code: `
+          import log = console.log;
+          import debug = console.debug;`,
+        parser,
+        errors: [{
+          message: '`console.debug` import should occur before import of `console.log`',
+        }],
+        options: [
+          {
+            alphabetize: {
+              order: 'asc',
+            },
+          },
+        ],
       }),
     ]),
     // Default order using import with custom import alias


### PR DESCRIPTION
The changes I've made in PR #1785 caused object-imports to fail.
This happened because the `order`-rule is not able to handle `null` as an import-name and I totally forgot to add tests for object-imports.

This PR will fix the support of object-imports by introducing a new import-type in addition to `require` and `import`: The `import:object`-type.

In order to match the `order`-rule's behavior perfectly, the object-literal being imported acts as the name which means following:
```ts
import log = console.log; // name: "console.log"
import debug = console.debug; // name: "console.debug"
```

Additionally there is a new import-`group` you can set for the `order`-rule called `"object"`, which includes all object-imports.

This new `"object"` group is in the `pathGroupsExcludedImportTypes`-array by default.

This PR will fix #1821 and will fix #1808 
Sorry for causing trouble 😅 