### PR TITLE
[Tests] `no-extraneous-dependencies`: add tests for importing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - [`no-extraneous-dependencies`]/TypeScript: do not error when importing type from dev dependencies ([#1820], thanks [@fernandopasik])
 
+### Changed
+- [`no-extraneous-dependencies`]: add tests for importing types ([#1824], thanks [@taye])
+
 ## [2.21.2] - 2020-06-09
 ### Fixed
 - [`order`]: avoid a crash on TypeScript’s `export import` syntax ([#1808], thanks [@ljharb])
@@ -707,6 +710,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1824]: https://github.com/benmosher/eslint-plugin-import/pull/1824
 [#1820]: https://github.com/benmosher/eslint-plugin-import/pull/1820
 [#1819]: https://github.com/benmosher/eslint-plugin-import/pull/1819
 [#1802]: https://github.com/benmosher/eslint-plugin-import/pull/1802
@@ -1225,3 +1229,4 @@ for info on changes for earlier releases.
 [@malykhinvi]: https://github.com/malykhinvi
 [@nicolashenry]: https://github.com/nicolashenry
 [@fernandopasik]: https://github.com/fernandopasik
+[@taye]: https://github.com/taye


### PR DESCRIPTION
Thanks for your work on this plugin! :heart:

This PR extends `no-extranaeous-dependencies`' check for Flow type imports to also work with TypeScript. This should help with https://github.com/benmosher/eslint-plugin-import/issues/903#issuecomment-549942374.