### PR TITLE
`order`/`newline-after-import`: Add support for TypeScript's "export import"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`order`]/TypeScript: properly support `import = object` expressions ([#1823], thanks [@manuth])
 - [`no-extraneous-dependencies`]/TypeScript: do not error when importing type from dev dependencies ([#1820], thanks [@fernandopasik])
 - [`default`]: avoid crash with `export =` ([#1822], thanks [@AndrewLeedham])
+- [`order`]/[`newline-after-import`]: ignore TypeScript's "export import object" ([#1830], thanks [@be5invis])
 
 ### Changed
 - [`no-extraneous-dependencies`]: add tests for importing types ([#1824], thanks [@taye])
@@ -712,6 +713,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1830]: https://github.com/benmosher/eslint-plugin-import/pull/1830
 [#1824]: https://github.com/benmosher/eslint-plugin-import/pull/1824
 [#1823]: https://github.com/benmosher/eslint-plugin-import/pull/1823
 [#1822]: https://github.com/benmosher/eslint-plugin-import/pull/1822
@@ -1235,3 +1237,4 @@ for info on changes for earlier releases.
 [@fernandopasik]: https://github.com/fernandopasik
 [@taye]: https://github.com/taye
 [@AndrewLeedham]: https://github.com/AndrewLeedham
+[@be5invis]: https://github.com/be5invis

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -119,8 +119,13 @@ after ${type} statement not followed by another ${type}.`,
         const { parent } = node
         const nodePosition = parent.body.indexOf(node)
         const nextNode = parent.body[nodePosition + 1]
+        
+        // skip "export import"s
+        if (node.type === 'TSImportEqualsDeclaration' && node.isExport) {
+          return
+        }
 
-        if (nextNode && nextNode.type !== 'ImportDeclaration' && nextNode.type !== 'TSImportEqualsDeclaration') {
+        if (nextNode && nextNode.type !== 'ImportDeclaration' && (nextNode.type !== 'TSImportEqualsDeclaration' || nextNode.isExport)) {
           checkForNewLine(node, nextNode, 'import')
         }
     }

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -615,6 +615,10 @@ module.exports = {
       TSImportEqualsDeclaration: function handleImports(node) {
         let name
         let type
+        // skip "export import"s
+        if (node.isExport) {
+          return
+        }
         if (node.moduleReference.type === 'TSExternalModuleReference') {
           name = node.moduleReference.expression.value
           type = 'import'

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -213,6 +213,24 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         parser: parser,
         parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       },
+      {
+        code: `
+          export import a = obj;\nf(a);
+        `,
+        parser: parser,
+        parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      },
+      {
+        code: `
+          import { a } from "./a";
+
+          export namespace SomeNamespace {
+              export import a2 = a;
+              f(a);
+          }`,
+        parser: parser,
+        parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      },
     ]),
   ],
 

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -753,6 +753,21 @@ ruleTester.run('order', rule, {
           },
         ],
       }),
+      test({
+        code: `
+          import { a } from "./a";
+          export namespace SomeNamespace {
+              export import a2 = a;
+          }
+        `,
+        parser,
+        options: [
+          {
+            groups: ['external', 'index'],
+            alphabetize: { order: 'asc' },
+          },
+        ],
+      }),
     ]),
   ],
   invalid: [


### PR DESCRIPTION
This PR adds support for TypeScript's "export import", typically used to re-export things.
In current `eslint-plugin-import` they are treated as imports rather than exports.
Related: #1829.
cc. @ljharb 