### PR TITLE
[patch] `order`/TypeScript: ignore ordering of object imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`default`]: avoid crash with `export =` ([#1822], thanks [@AndrewLeedham])
 - [`order`]/[`newline-after-import`]: ignore TypeScript's "export import object" ([#1830], thanks [@be5invis])
 - [`dynamic-import-chunkname`]/TypeScript: supports `@typescript-eslint/parser` ([#1833], thanks [@noelebrun])
+- [`order`]/TypeScript: ignore ordering of object imports ([#1831], thanks [@manuth])
 
 ### Changed
 - [`no-extraneous-dependencies`]: add tests for importing types ([#1824], thanks [@taye])
@@ -716,6 +717,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#1833]: https://github.com/benmosher/eslint-plugin-import/pull/1833
+[#1831]: https://github.com/benmosher/eslint-plugin-import/pull/1831
 [#1830]: https://github.com/benmosher/eslint-plugin-import/pull/1830
 [#1824]: https://github.com/benmosher/eslint-plugin-import/pull/1824
 [#1823]: https://github.com/benmosher/eslint-plugin-import/pull/1823

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -740,10 +740,24 @@ ruleTester.run('order', rule, {
           },
         ],
       }),
+      // Object-imports should not be forced to be alphabetized
       test({
         code: `
           import debug = console.debug;
           import log = console.log;`,
+        parser,
+        options: [
+          {
+            alphabetize: {
+              order: 'asc',
+            },
+          },
+        ],
+      }),
+      test({
+        code: `
+          import log = console.log;
+          import debug = console.debug;`,
         parser,
         options: [
           {
@@ -1287,23 +1301,6 @@ ruleTester.run('order', rule, {
         errors: [{
           message: '`./blah` import should occur before import of `console.log`',
         }],
-      }),
-      // Alphabetization of object-imports
-      test({
-        code: `
-          import log = console.log;
-          import debug = console.debug;`,
-        parser,
-        errors: [{
-          message: '`console.debug` import should occur before import of `console.log`',
-        }],
-        options: [
-          {
-            alphabetize: {
-              order: 'asc',
-            },
-          },
-        ],
       }),
     ]),
     // Default order using import with custom import alias


### PR DESCRIPTION
Forcing object-imports to be alphabetized might lead to issues as they might depend on each other.

***Example:***
```ts
import { ESLint } from "eslint";
// Object-imports
import A = ESLint;
import OutputFixes = A.outputFixes;

OutputFixes([]);
```

Currently, this piece of code will report an error because `A.LintResult` has a lower rank than `ESLint`.
Alphabetizing these imports would cause this code to fail:
```ts
import { ESLint } from "eslint";
// Object-imports
import OutputFixes = A.outputFixes;
import A = ESLint;

OutputFixes([]);
```
```
Cannot read property 'outputFixes' of undefined
```

I see three different approaches to fix this:
* ~~Sort object-imports with following conditions:~~
  1. ~~Number of dots (e.g. `ts` comes before `ts.protocol` and `ts.protocol` comes before `ts.protocol.Request`)~~
  2. ~~Import-Name~~
* Allow any sorting by setting names of all object-imports to `''`
* Ignore object-imports

Though I'd like the first approach the most as it definitely would work and even would fix code like the one above, the second approach is ways easier to implement which is why I just went for it.

### Remarks
The first approach won't work as, for example, this code still would cause an error:
```ts
import { ESLint } from "eslint";
import B = ESLint;
import A = B;
```

Therefore I'd recommend to go for the second approach as done in this PR.
Feedback is welcome - do you guys think it's possible to implement the first mentioned approach at some point?