### PR TITLE
[Fix] `dynamic-import-chunkname`/TypeScript: support `@typescript-eslint/parser`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
   include:
   - env: LINT=true
     node_js: lts/*
+  - env: TS_PARSER=2 ESLINT_VERSION=7
+    node_js: lts/*
+    before_script: 'npm install --no-save @typescript-eslint/parser@2'
   - env: PACKAGE=resolvers/node
     node_js: 14
   - env: PACKAGE=resolvers/node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-extraneous-dependencies`]/TypeScript: do not error when importing type from dev dependencies ([#1820], thanks [@fernandopasik])
 - [`default`]: avoid crash with `export =` ([#1822], thanks [@AndrewLeedham])
 - [`order`]/[`newline-after-import`]: ignore TypeScript's "export import object" ([#1830], thanks [@be5invis])
+- [`dynamic-import-chunkname`]/TypeScript: supports `@typescript-eslint/parser` ([#1833], thanks [@noelebrun])
 
 ### Changed
 - [`no-extraneous-dependencies`]: add tests for importing types ([#1824], thanks [@taye])
@@ -713,6 +714,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1833]: https://github.com/benmosher/eslint-plugin-import/pull/1833
 [#1830]: https://github.com/benmosher/eslint-plugin-import/pull/1830
 [#1824]: https://github.com/benmosher/eslint-plugin-import/pull/1824
 [#1823]: https://github.com/benmosher/eslint-plugin-import/pull/1823
@@ -1238,3 +1240,4 @@ for info on changes for earlier releases.
 [@taye]: https://github.com/taye
 [@AndrewLeedham]: https://github.com/AndrewLeedham
 [@be5invis]: https://github.com/be5invis
+[@noelebrun]: https://github.com/noelebrun

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
     "@test-scope/some-module": "file:./tests/files/symlinked-module",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/parser": "^2.23.0 || ^3.3.0",
     "array.prototype.flatmap": "^1.2.3",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",


### PR DESCRIPTION
This PR add supports for the `@typescript-eslint/parser` parser to the `dynamic-import-chunkname` rule. This parser use newer ES Tree spec `ImportExpression` from dynamic imports instead of `CallExpressions`.

This might fix #1771 but I haven't tried bumping `babel-eslint` to try it.

cc @ljharb 