### PR TITLE
[Fix] `dynamic-import-chunkname`: allow single quotes to match Webpack support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`default`]/TypeScript: avoid crash on `export =` with a MemberExpression ([#1841], thanks [@ljharb])
 - [`extensions`]/importType: Fix @/abc being treated as scoped module ([#1854], thanks [@3nuc])
 - allow using rest operator in named export ([#1878], thanks [@foray1010])
+- [`dynamic-import-chunkname`]: allow single quotes to match Webpack support ([#1848], thanks [@straub])
 
 ### Changed
 - [`export`]: add tests for a name collision with `export * from` ([#1704], thanks @tomprats)
@@ -732,6 +733,7 @@ for info on changes for earlier releases.
 
 [#1878]: https://github.com/benmosher/eslint-plugin-import/pull/1878
 [#1854]: https://github.com/benmosher/eslint-plugin-import/issues/1854
+[#1848]: https://github.com/benmosher/eslint-plugin-import/pull/1848
 [#1841]: https://github.com/benmosher/eslint-plugin-import/issues/1841
 [#1836]: https://github.com/benmosher/eslint-plugin-import/pull/1836
 [#1835]: https://github.com/benmosher/eslint-plugin-import/pull/1835
@@ -1271,3 +1273,4 @@ for info on changes for earlier releases.
 [@3nuc]: https://github.com/3nuc
 [@foray1010]: https://github.com/foray1010
 [@tomprats]: https://github.com/tomprats
+[@straub]: https://github.com/straub

--- a/docs/rules/dynamic-import-chunkname.md
+++ b/docs/rules/dynamic-import-chunkname.md
@@ -39,12 +39,6 @@ import(
   'someModule',
 );
 
-// using single quotes instead of double quotes
-import(
-  /* webpackChunkName: 'someModule' */
-  'someModule',
-);
-
 // invalid syntax for webpack comment
 import(
   /* totally not webpackChunkName: "someModule" */
@@ -76,6 +70,12 @@ The following patterns are valid:
   );
   import(
     /* webpackChunkName: "someModule", webpackPrefetch: true */
+    'someModule',
+  );
+
+  // using single quotes instead of double quotes
+  import(
+    /* webpackChunkName: 'someModule' */
     'someModule',
   );
 ```

--- a/src/rules/dynamic-import-chunkname.js
+++ b/src/rules/dynamic-import-chunkname.js
@@ -30,8 +30,8 @@ module.exports = {
     const { webpackChunknameFormat = '[0-9a-zA-Z-_/.]+' } = config || {}
 
     const paddedCommentRegex = /^ (\S[\s\S]+\S) $/
-    const commentStyleRegex = /^( \w+: ("[^"]*"|\d+|false|true),?)+ $/
-    const chunkSubstrFormat = ` webpackChunkName: "${webpackChunknameFormat}",? `
+    const commentStyleRegex = /^( \w+: (["'][^"']*["']|\d+|false|true),?)+ $/
+    const chunkSubstrFormat = ` webpackChunkName: ["']${webpackChunknameFormat}["'],? `
     const chunkSubstrRegex = new RegExp(chunkSubstrFormat)
 
     function run(node, arg) {

--- a/tests/src/rules/dynamic-import-chunkname.js
+++ b/tests/src/rules/dynamic-import-chunkname.js
@@ -21,8 +21,8 @@ const noLeadingCommentError = 'dynamic imports require a leading comment with th
 const nonBlockCommentError = 'dynamic imports require a /* foo */ style comment, not a // foo comment'
 const noPaddingCommentError = 'dynamic imports require a block comment padded with spaces - /* foo */'
 const invalidSyntaxCommentError = 'dynamic imports require a "webpack" comment with valid syntax'
-const commentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: "${commentFormat}",? */`
-const pickyCommentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: "${pickyCommentFormat}",? */`
+const commentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: ["']${commentFormat}["'],? */`
+const pickyCommentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: ["']${pickyCommentFormat}["'],? */`
 
 ruleTester.run('dynamic-import-chunkname', rule, {
   valid: [
@@ -134,6 +134,14 @@ ruleTester.run('dynamic-import-chunkname', rule, {
     },
     {
       code: `import(
+        /* webpackChunkName: 'someModule' */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
         /* webpackChunkName: "someModule" */
         'someModule'
       )`,
@@ -192,17 +200,33 @@ ruleTester.run('dynamic-import-chunkname', rule, {
     },
     {
       code: `import(
-        /* webpackChunkName: 'someModule' */
+        /* webpackChunkName: "someModule' */
         'someModule'
       )`,
       options,
       parser,
       output: `import(
-        /* webpackChunkName: 'someModule' */
+        /* webpackChunkName: "someModule' */
         'someModule'
       )`,
       errors: [{
-        message: commentFormatError,
+        message: invalidSyntaxCommentError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackChunkName: 'someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackChunkName: 'someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: invalidSyntaxCommentError,
         type: 'CallExpression',
       }],
     },
@@ -423,21 +447,6 @@ ruleTester.run('dynamic-import-chunkname', rule, {
     },
     {
       code: `dynamicImport(
-        /* webpackChunkName: 'someModule' */
-        'someModule'
-      )`,
-      options,
-      output: `dynamicImport(
-        /* webpackChunkName: 'someModule' */
-        'someModule'
-      )`,
-      errors: [{
-        message: commentFormatError,
-        type: 'CallExpression',
-      }],
-    },
-    {
-      code: `dynamicImport(
         /* webpackChunkName "someModule" */
         'someModule'
       )`,
@@ -578,6 +587,14 @@ context('TypeScript', () => {
             type: nodeType,
           }],
         },
+        {
+          code: `import(
+            /* webpackChunkName: 'someModule' */
+            'test'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
       ],
       invalid: [
         {
@@ -624,17 +641,33 @@ context('TypeScript', () => {
         },
         {
           code: `import(
-            /* webpackChunkName: 'someModule' */
+            /* webpackChunkName "someModule' */
             'someModule'
           )`,
           options,
           parser: typescriptParser,
           output: `import(
-            /* webpackChunkName: 'someModule' */
+            /* webpackChunkName "someModule' */
             'someModule'
           )`,
           errors: [{
-            message: commentFormatError,
+            message: invalidSyntaxCommentError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackChunkName 'someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackChunkName 'someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: invalidSyntaxCommentError,
             type: nodeType,
           }],
         },


### PR DESCRIPTION
Single quotes are supported by Webpack at least in v4.43.0, which is the
version I'm currently using. Since my eslint style prefers single 
quotes, I naturally wrote my Webpack magic comments to match, which 
worked w/o issue until I tried to enable this rule.

Implemented as a non-breaking relaxation of the existing rule to avoid 
complexity per
https://github.com/benmosher/eslint-plugin-import/issues/1130#issuecomment-464365363
but please let me know if you prefer a different approach!

Fixes #1130.