### PR TITLE
Fix @/abc being treated as scoped module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - [`default`]/TypeScript: avoid crash on `export =` with a MemberExpression ([#1841], thanks [@ljharb])
+- [`extensions`]/importType: Fix @/abc being treated as scoped module ([#1854], thanks [@3nuc])
 
 ## [2.22.0] - 2020-06-26
 ### Added
@@ -725,6 +726,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1854]: https://github.com/benmosher/eslint-plugin-import/issues/1854
 [#1841]: https://github.com/benmosher/eslint-plugin-import/issues/1841
 [#1836]: https://github.com/benmosher/eslint-plugin-import/pull/1836
 [#1835]: https://github.com/benmosher/eslint-plugin-import/pull/1835
@@ -1260,3 +1262,4 @@ for info on changes for earlier releases.
 [@be5invis]: https://github.com/be5invis
 [@noelebrun]: https://github.com/noelebrun
 [@beatrizrezener]: https://github.com/beatrizrezener
+[@3nuc]: https://github.com/3nuc

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -93,7 +93,7 @@ function typeTest(name, settings, path) {
 }
 
 export function isScopedModule(name) {
-  return name.indexOf('@') === 0
+  return name.indexOf('@') === 0 && !name.startsWith('@/')
 }
 
 export default function resolveImportType(name, context) {

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import * as path from 'path'
 
-import importType, {isExternalModule} from 'core/importType'
+import importType, {isExternalModule, isScopedModule} from 'core/importType'
 
 import { testContext, testFilePath } from '../utils'
 
@@ -236,5 +236,10 @@ describe('importType(name)', function () {
     expect(isExternalModule('foo', {
       'import/external-module-folders': ['E:\\path\\to\\node_modules'],
     }, 'E:\\path\\to\\node_modules\\foo')).to.equal(true)
+  })
+
+  it('correctly identifies scoped modules with `isScopedModule`', () => {
+    expect(isScopedModule('@/abc')).to.equal(false)
+    expect(isScopedModule('@a/abc')).to.equal(true)
   })
 })

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -444,5 +444,15 @@ ruleTester.run('extensions', rule, {
         },
       ],
     }),
+    test({
+      code: 'import foo from "@/ImNotAScopedModule"',
+      options: ['always'],
+      errors: [
+        {
+          message: 'Missing file extension for "@/ImNotAScopedModule"',
+          line: 1,
+        },
+      ],
+    }),
   ],
 })


### PR DESCRIPTION
Fixes #1851

Before this commit, @/abc was being wrongly detected as a scoped module.
This was a problem when somebody had a webpack alias `@`. (eg. @ -> ./src)

In general, scoped modules can't start with @/, I think they have to be like @abcd/sometext.