### PR TITLE
[Fix] allow using rest operator in named export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - [`default`]/TypeScript: avoid crash on `export =` with a MemberExpression ([#1841], thanks [@ljharb])
 - [`extensions`]/importType: Fix @/abc being treated as scoped module ([#1854], thanks [@3nuc])
+- allow using rest operator in named export ([#1878], thanks [@foray1010])
 
 ## [2.22.0] - 2020-06-26
 ### Added
@@ -726,6 +727,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1878]: https://github.com/benmosher/eslint-plugin-import/pull/1878
 [#1854]: https://github.com/benmosher/eslint-plugin-import/issues/1854
 [#1841]: https://github.com/benmosher/eslint-plugin-import/issues/1841
 [#1836]: https://github.com/benmosher/eslint-plugin-import/pull/1836
@@ -1263,3 +1265,4 @@ for info on changes for earlier releases.
 [@noelebrun]: https://github.com/noelebrun
 [@beatrizrezener]: https://github.com/beatrizrezener
 [@3nuc]: https://github.com/3nuc
+[@foray1010]: https://github.com/foray1010

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -650,6 +650,10 @@ export function recursivePatternCapture(pattern, callback) {
 
     case 'ObjectPattern':
       pattern.properties.forEach(p => {
+        if (p.type === 'ExperimentalRestProperty' || p.type === 'RestElement') {
+          callback(p.argument)
+          return
+        }
         recursivePatternCapture(p.value, callback)
       })
       break
@@ -657,6 +661,10 @@ export function recursivePatternCapture(pattern, callback) {
     case 'ArrayPattern':
       pattern.elements.forEach((element) => {
         if (element == null) return
+        if (element.type === 'ExperimentalRestProperty' || element.type === 'RestElement') {
+          callback(element.argument)
+          return
+        }
         recursivePatternCapture(element, callback)
       })
       break

--- a/tests/files/named-exports.js
+++ b/tests/files/named-exports.js
@@ -13,9 +13,9 @@ export class ExportedClass {
 
 // destructuring exports
 
-export var { destructuredProp } = {}
+export var { destructuredProp, ...restProps } = {}
          , { destructingAssign = null } = {}
          , { destructingAssign: destructingRenamedAssign = null } = {}
-         , [ arrayKeyProp ] = []
+         , [ arrayKeyProp, ...arrayRestKeyProps ] = []
          , [ { deepProp } ] = []
          , { arr: [ ,, deepSparseElement ] } = {}

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -295,7 +295,7 @@ describe('ExportMap', function () {
     context('#size', function () {
 
       it('counts the names', () => expect(ExportMap.get('./named-exports', fakeContext))
-        .to.have.property('size', 10))
+        .to.have.property('size', 12))
 
       it('includes exported namespace size', () => expect(ExportMap.get('./export-all', fakeContext))
         .to.have.property('size', 1))

--- a/tests/src/utils.js
+++ b/tests/src/utils.js
@@ -37,7 +37,7 @@ export function test(t) {
   }, t, {
     parserOptions: Object.assign({
       sourceType: 'module',
-      ecmaVersion: 6,
+      ecmaVersion: 9,
     }, t.parserOptions),
   })
 }


### PR DESCRIPTION
Named export supports rest operator, but when using with eslint-plugin-import, it throws `TypeError: Cannot read property 'type' of undefined` because `RestElement` is not handled and the value is treated as a `ObjectProperty` type