### PR TITLE
[Fix] `export`/TypeScript: properly detect export specifiers as children of a TS module block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+### Fixed
+- [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
+
 ## [2.22.1] - 2020-09-27
 ### Fixed
 - [`default`]/TypeScript: avoid crash on `export =` with a MemberExpression ([#1841], thanks [@ljharb])
@@ -732,6 +735,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1889]: https://github.com/benmosher/eslint-plugin-import/pull/1889
 [#1878]: https://github.com/benmosher/eslint-plugin-import/pull/1878
 [#1854]: https://github.com/benmosher/eslint-plugin-import/issues/1854
 [#1848]: https://github.com/benmosher/eslint-plugin-import/pull/1848
@@ -1276,3 +1280,4 @@ for info on changes for earlier releases.
 [@foray1010]: https://github.com/foray1010
 [@tomprats]: https://github.com/tomprats
 [@straub]: https://github.com/straub
+[@andreubotella]: https://github.com/andreubotella

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -87,7 +87,11 @@ module.exports = {
     return {
       'ExportDefaultDeclaration': (node) => addNamed('default', node, getParent(node)),
 
-      'ExportSpecifier': (node) => addNamed(node.exported.name, node.exported, getParent(node)),
+      'ExportSpecifier': (node) => addNamed(
+        node.exported.name,
+        node.exported,
+        getParent(node.parent)
+      ),
 
       'ExportNamedDeclaration': function (node) {
         if (node.declaration == null) return

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -221,6 +221,30 @@ context('TypeScript', function () {
             parser: parser,
           }),
         ]),
+
+        // Exports in ambient modules
+        test(Object.assign({
+          code: `
+            declare module "a" {
+              const Foo = 1;
+              export {Foo as default};
+            }
+            declare module "b" {
+              const Bar = 2;
+              export {Bar as default};
+            }
+          `,
+        }, parserConfig)),
+        test(Object.assign({
+          code: `
+            declare module "a" {
+              const Foo = 1;
+              export {Foo as default};
+            }
+            const Bar = 2;
+            export {Bar as default};
+          `,
+        }, parserConfig)),
       ],
       invalid: [
         // type/value name clash
@@ -308,6 +332,30 @@ context('TypeScript', function () {
             },
             {
               message: `Multiple exports of name 'Bar'.`,
+              line: 9,
+            },
+          ],
+        }, parserConfig)),
+
+        // Exports in ambient modules
+        test(Object.assign({
+          code: `
+            declare module "a" {
+              const Foo = 1;
+              export {Foo as default};
+            }
+            const Bar = 2;
+            export {Bar as default};
+            const Baz = 3;
+            export {Baz as default};
+          `,
+          errors: [
+            {
+              message: 'Multiple default exports.',
+              line: 7,
+            },
+            {
+              message: 'Multiple default exports.',
               line: 9,
             },
           ],


### PR DESCRIPTION
Fixes #1773