### PR TITLE
`no-unused-modules`: add flow tests and enhance typescript tests

### DIFF
--- a/tests/files/no-unused-modules/flow/flow-0.js
+++ b/tests/files/no-unused-modules/flow/flow-0.js
@@ -1,0 +1,1 @@
+import { type FooType, type FooInterface } from './flow-2';

--- a/tests/files/no-unused-modules/flow/flow-1.js
+++ b/tests/files/no-unused-modules/flow/flow-1.js
@@ -1,0 +1,2 @@
+// @flow strict
+export type Bar = number;

--- a/tests/files/no-unused-modules/flow/flow-1.js
+++ b/tests/files/no-unused-modules/flow/flow-1.js
@@ -1,2 +1,3 @@
 // @flow strict
 export type Bar = number;
+export interface BarInterface {};

--- a/tests/files/no-unused-modules/flow/flow-2.js
+++ b/tests/files/no-unused-modules/flow/flow-2.js
@@ -1,0 +1,3 @@
+// @flow strict
+export type FooType = string;
+export interface FooInterface {};

--- a/tests/files/no-unused-modules/flow/flow-3.js
+++ b/tests/files/no-unused-modules/flow/flow-3.js
@@ -1,0 +1,1 @@
+import type { FooType, FooInterface } from './flow-4';

--- a/tests/files/no-unused-modules/flow/flow-4.js
+++ b/tests/files/no-unused-modules/flow/flow-4.js
@@ -1,0 +1,3 @@
+// @flow strict
+export type FooType = string;
+export interface FooInterface {};

--- a/tests/files/no-unused-modules/typescript/file-ts-a.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-a.ts
@@ -3,6 +3,6 @@ import {c} from './file-ts-c';
 import {d} from './file-ts-d';
 import {e} from './file-ts-e';
 
-export const a = b + 1 + e.f;
-export const a2: c = {};
-export const a3: d = {};
+const a = b + 1 + e.f;
+const a2: c = {};
+const a3: d = {};

--- a/tests/files/no-unused-modules/typescript/file-ts-b-2.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-b-2.ts
@@ -1,0 +1,1 @@
+export const b = 2;

--- a/tests/files/no-unused-modules/typescript/file-ts-b-3.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-b-3.ts
@@ -1,0 +1,1 @@
+export const b = 2;

--- a/tests/files/no-unused-modules/typescript/file-ts-c-2.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-c-2.ts
@@ -1,0 +1,1 @@
+export interface c {};

--- a/tests/files/no-unused-modules/typescript/file-ts-c-3.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-c-3.ts
@@ -1,0 +1,1 @@
+export interface c {};

--- a/tests/files/no-unused-modules/typescript/file-ts-d-2.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-d-2.ts
@@ -1,0 +1,1 @@
+export type d = {};

--- a/tests/files/no-unused-modules/typescript/file-ts-d-3.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-d-3.ts
@@ -1,0 +1,1 @@
+export type d = {};

--- a/tests/files/no-unused-modules/typescript/file-ts-e-2.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-e-2.ts
@@ -1,0 +1,1 @@
+export enum e { f };

--- a/tests/files/no-unused-modules/typescript/file-ts-e-3.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-e-3.ts
@@ -1,0 +1,1 @@
+export enum e { f };

--- a/tests/files/no-unused-modules/typescript/file-ts-f.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-f.ts
@@ -1,0 +1,9 @@
+import type {b} from './file-ts-b-3';
+import type {c} from './file-ts-c-3';
+import type {d} from './file-ts-d-3';
+import type {e} from './file-ts-e-3';
+
+const a: typeof b = 2;
+const a2: c = {};
+const a3: d = {};
+const a4: typeof e = undefined;

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -932,11 +932,14 @@ describe('correctly report flow types', () => {
       test({
         options: unusedExportsOptions,
         code: `// @flow strict
-               export type Bar = number;`,
+               export type Bar = number;
+               export interface BarInterface {};
+               `,
         parser: require.resolve('babel-eslint'),
         filename: testFilePath('./no-unused-modules/flow/flow-1.js'),
         errors: [
           error(`exported declaration 'Bar' not used within other modules`),
+          error(`exported declaration 'BarInterface' not used within other modules`),
         ],
       }),
     ],

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -744,57 +744,88 @@ describe('Avoid errors if re-export all from umd compiled library', () => {
   })
 })
 
-describe('correctly work with Typescript only files', () => {
-  typescriptRuleTester.run('no-unused-modules', rule, {
-    valid: [
-      test({
-        options: unusedExportsTypescriptOptions,
-        code: 'import a from "file-ts-a";',
-        parser: require.resolve('babel-eslint'),
-        filename: testFilePath('./no-unused-modules/typescript/file-ts-a.ts'),
-      }),
-    ],
-    invalid: [
-      test({
-        options: unusedExportsTypescriptOptions,
-        code: `export const b = 2;`,
-        parser: require.resolve('babel-eslint'),
-        filename: testFilePath('./no-unused-modules/typescript/file-ts-b.ts'),
-        errors: [
-          error(`exported declaration 'b' not used within other modules`),
-        ],
-      }),
-      test({
-        options: unusedExportsTypescriptOptions,
-        code: `export interface c {};`,
-        parser: require.resolve('babel-eslint'),
-        filename: testFilePath('./no-unused-modules/typescript/file-ts-c.ts'),
-        errors: [
-          error(`exported declaration 'c' not used within other modules`),
-        ],
-      }),
-      test({
-        options: unusedExportsTypescriptOptions,
-        code: `export type d = {};`,
-        parser: require.resolve('babel-eslint'),
-        filename: testFilePath('./no-unused-modules/typescript/file-ts-d.ts'),
-        errors: [
-          error(`exported declaration 'd' not used within other modules`),
-        ],
-      }),
-    ],
-  })
-})
-
 context('TypeScript', function () {
   getTSParsers().forEach((parser) => {
     typescriptRuleTester.run('no-unused-modules', rule, {
       valid: [
         test({
           options: unusedExportsTypescriptOptions,
-          code: 'import a from "file-ts-a";',
+          code: `
+          import {b} from './file-ts-b';
+          import {c} from './file-ts-c';
+          import {d} from './file-ts-d';
+          import {e} from './file-ts-e';
+
+          const a = b + 1 + e.f;
+          const a2: c = {};
+          const a3: d = {};
+          `,
           parser: parser,
           filename: testFilePath('./no-unused-modules/typescript/file-ts-a.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export const b = 2;`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-b.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export interface c {};`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-c.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export type d = {};`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-d.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export enum e { f };`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-e.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `
+          import type {b} from './file-ts-b-3';
+          import type {c} from './file-ts-c-3';
+          import type {d} from './file-ts-d-3';
+          import type {e} from './file-ts-e-3';
+
+          const a: typeof b = 2;
+          const a2: c = {};
+          const a3: d = {};
+          const a4: typeof e = undefined;
+          `,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-f.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export const b = 2;`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-b-3.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export interface c {};`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-c-3.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export type d = {};`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-d-3.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export enum e { f };`,
+          parser: parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-e-3.ts'),
         }),
       ],
       invalid: [
@@ -802,7 +833,7 @@ context('TypeScript', function () {
           options: unusedExportsTypescriptOptions,
           code: `export const b = 2;`,
           parser: parser,
-          filename: testFilePath('./no-unused-modules/typescript/file-ts-b.ts'),
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-b-2.ts'),
           errors: [
             error(`exported declaration 'b' not used within other modules`),
           ],
@@ -811,7 +842,7 @@ context('TypeScript', function () {
           options: unusedExportsTypescriptOptions,
           code: `export interface c {};`,
           parser: parser,
-          filename: testFilePath('./no-unused-modules/typescript/file-ts-c.ts'),
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-c-2.ts'),
           errors: [
             error(`exported declaration 'c' not used within other modules`),
           ],
@@ -820,7 +851,7 @@ context('TypeScript', function () {
           options: unusedExportsTypescriptOptions,
           code: `export type d = {};`,
           parser: parser,
-          filename: testFilePath('./no-unused-modules/typescript/file-ts-d.ts'),
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-d-2.ts'),
           errors: [
             error(`exported declaration 'd' not used within other modules`),
           ],
@@ -829,7 +860,7 @@ context('TypeScript', function () {
           options: unusedExportsTypescriptOptions,
           code: `export enum e { f };`,
           parser: parser,
-          filename: testFilePath('./no-unused-modules/typescript/file-ts-e.ts'),
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-e-2.ts'),
           errors: [
             error(`exported declaration 'e' not used within other modules`),
           ],
@@ -862,3 +893,53 @@ describe('correctly work with JSX only files', () => {
     ],
   })
 })
+
+describe('correctly report flow types', () => {
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({
+        options: unusedExportsOptions,
+        code: 'import { type FooType, type FooInterface } from "./flow-2";',
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/flow/flow-0.js'),
+      }),
+      test({
+        options: unusedExportsOptions,
+        code: `// @flow strict
+               export type FooType = string;
+               export interface FooInterface {};
+               `,
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/flow/flow-2.js'),
+      }),
+      test({
+        options: unusedExportsOptions,
+        code: 'import type { FooType, FooInterface } from "./flow-4";',
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/flow/flow-3.js'),
+      }),
+      test({
+        options: unusedExportsOptions,
+        code: `// @flow strict
+               export type FooType = string;
+               export interface FooInterface {};
+               `,
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/flow/flow-4.js'),
+      }),
+    ],
+    invalid: [
+      test({
+        options: unusedExportsOptions,
+        code: `// @flow strict
+               export type Bar = number;`,
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/flow/flow-1.js'),
+        errors: [
+          error(`exported declaration 'Bar' not used within other modules`),
+        ],
+      }),
+    ],
+  })
+})
+


### PR DESCRIPTION
Try to reproduce https://github.com/benmosher/eslint-plugin-import/issues/1564 :
- Add tests for flow type imports
- Remove typescript tests using "babel-eslint" (because resulting types seems to be flow types)
- Add some missing cases in typescript tests
- Add some tests for typescript type imports