### PR TITLE
[Refactor] `importType`: use `is-core-module` instead of `resolve/lib/core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-module-utils": "^2.6.0",
     "has": "^1.0.3",
+    "is-core-module": "^1.0.2",
     "minimatch": "^3.0.4",
     "object.values": "^1.1.1",
     "read-pkg-up": "^2.0.0",

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -1,4 +1,4 @@
-import coreModules from 'resolve/lib/core'
+import isCoreModule from 'is-core-module'
 
 import resolve from 'eslint-module-utils/resolve'
 
@@ -20,7 +20,7 @@ export function isBuiltIn(name, settings, path) {
   if (path || !name) return false
   const base = baseModule(name)
   const extras = (settings && settings['import/core-modules']) || []
-  return coreModules[base] || extras.indexOf(base) > -1
+  return isCoreModule(base) || extras.indexOf(base) > -1
 }
 
 function isExternalPath(path, name, settings) {


### PR DESCRIPTION
This PR replaces `resolve/lib/core` by `is-core-module` is suggested in https://github.com/browserify/resolve/commit/1222da1fc7f249d053a9ba30dbab284640f13948

**context**: Babel e2e test is failing because `resolve/lib/core` is deprecated: https://app.circleci.com/pipelines/github/babel/babel/4244/workflows/de314db0-9b52-44c8-b6a5-9ca7d4b2cfd6/jobs/30580

/cc @ljharb