### PR TITLE
[Fix] `order`: ignore requires in template literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
+- [`order`]: ignore non-module-level requires ([#1940], thanks [@golopot])
 
 ## [2.22.1] - 2020-09-27
 ### Fixed
@@ -735,6 +736,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1940]: https://github.com/benmosher/eslint-plugin-import/pull/1940
 [#1889]: https://github.com/benmosher/eslint-plugin-import/pull/1889
 [#1878]: https://github.com/benmosher/eslint-plugin-import/pull/1878
 [#1854]: https://github.com/benmosher/eslint-plugin-import/issues/1854

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -74,7 +74,7 @@ ruleTester.run('order', rule, {
         var result = add(1, 2);
         var _ = require('lodash');`,
     }),
-    // Ignore requires that are not at the top-level
+    // Ignore requires that are not at the top-level #1
     test({
       code: `
         var index = require('./');
@@ -85,6 +85,18 @@ ruleTester.run('order', rule, {
         if (a) {
           require('fs');
         }`,
+    }),
+    // Ignore requires that are not at the top-level #2
+    test({
+      code: `
+        const foo = [
+          require('./foo'),
+          require('fs'),
+        ]`,
+    }),
+    // Ignore requires in template literal (#1936)
+    test({
+      code: "const foo = `${require('./a')} ${require('fs')}`",
     }),
     // Ignore unknown/invalid cases
     test({


### PR DESCRIPTION
Fixes #1936.
