### PR TITLE
[New] Add no-indexes Rule

### DIFF
--- a/docs/rules/no-indexes.md
+++ b/docs/rules/no-indexes.md
@@ -1,0 +1,22 @@
+# import/no-indexes
+
+This rule prevents files from being named `index`.
+
+For example, with the `no-indexes` rule enabled, files named `index.js`, `index.jsx`, `index.ts`, and `index.tsx` would all be considered invalid.
+
+## Ignore
+
+The rule accepts an optional `ignore` setting, which can be used to ignore files whose path matches one of the given regular expression string patterns.
+
+For example, the following would allow `index` files in the `allowed` directory:
+
+```
+{
+  rules: {
+    'import/no-indexes': [
+      'error',
+      { ignore: ['\/allowed\/'] }
+    ]
+  }
+}
+```

--- a/docs/rules/no-indexes.md
+++ b/docs/rules/no-indexes.md
@@ -10,7 +10,7 @@ The rule accepts an optional `ignore` setting, which can be used to ignore any f
 
 For example, the following would allow `index` files in the `allowed` directory:
 
-```
+```javascript
 {
   rules: {
     'import/no-indexes': [

--- a/docs/rules/no-indexes.md
+++ b/docs/rules/no-indexes.md
@@ -6,7 +6,7 @@ For example, with the `no-indexes` rule enabled, files named `index.js`, `index.
 
 ## Ignore
 
-The rule accepts an optional `ignore` setting, which can be used to ignore files whose path matches one of the given regular expression string patterns.
+The rule accepts an optional `ignore` setting, which can be used to ignore any file whose path matches one of the given regular expression patterns.
 
 For example, the following would allow `index` files in the `allowed` directory:
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export const rules = {
 
   'no-self-import': require('./rules/no-self-import'),
   'no-cycle': require('./rules/no-cycle'),
+  'no-indexes': require('./rules/no-indexes'),
   'no-named-default': require('./rules/no-named-default'),
   'no-named-as-default': require('./rules/no-named-as-default'),
   'no-named-as-default-member': require('./rules/no-named-as-default-member'),

--- a/src/rules/no-indexes.js
+++ b/src/rules/no-indexes.js
@@ -1,0 +1,56 @@
+import { basename } from 'path';
+import docsUrl from '../docsUrl';
+
+function getIgnoreList(options) {
+  return options && options[0] && options[0].ignore;
+}
+
+function getFilenameWithoutExtension(path) {
+  return basename(path).split('.')[0];
+}
+
+function shouldIgnore(path, ignoreList) {
+  if (!ignoreList) {
+    return false;
+  }
+
+  return ignoreList.some((pattern) => new RegExp(pattern).test(path));
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      category: 'Best Practices',
+      description: 'Disallow index files',
+      url: docsUrl('no-indexes'),
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignore: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create: function (context) {
+    return {
+      Program(node) {
+        const path = context.getFilename();
+        const name = getFilenameWithoutExtension(path);
+        const ignoreList = getIgnoreList(context.options);
+
+        if (name === 'index' && !shouldIgnore(path, ignoreList)) {
+          context.report(node, 'Index files are not allowed.');
+        }
+      },
+    };
+  },
+};

--- a/tests/src/rules/no-indexes.js
+++ b/tests/src/rules/no-indexes.js
@@ -1,0 +1,32 @@
+import { RuleTester } from 'eslint';
+import rule from 'rules/no-indexes';
+
+import { test } from '../utils';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-indexes', rule, {
+  valid: [
+    test({
+      code: '',
+      filename: 'non-index.js',
+    }),
+    test({
+      code: '',
+      filename: '/path-to-ignore/index.js',
+      options: [{ ignore: ['path-to-ignore'] }],
+    }),
+    test({
+      code: '',
+      filename: '/path-to-ignore/index.js',
+      options: [{ ignore: ['\/path\-to\-ignore\/'] }],
+    }),
+  ],
+  invalid: [
+    test({
+      code: '',
+      filename: 'index.js',
+      errors: ['Index files are not allowed.'],
+    }),
+  ],
+});


### PR DESCRIPTION
As per the documentation:


This rule prevents files from being named `index`.

For example, with the `no-indexes` rule enabled, files named `index.js`, `index.jsx`, `index.ts`, and `index.tsx` would all be considered invalid.

## Ignore

The rule accepts an optional `ignore` setting, which can be used to ignore any file whose path matches one of the given regular expression patterns.

For example, the following would allow `index` files in the `allowed` directory:

```javascript
{
  rules: {
    'import/no-indexes': [
      'error',
      { ignore: ['\/allowed\/'] }
    ]
  }
}
```