### PR TITLE
[Fix] `no-webpack-loader-syntax`/TypeScript: avoid crash on missing name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
 - [`order`]: ignore non-module-level requires ([#1940], thanks [@golopot])
+- [`no-webpack-loader-syntax`]/TypeScript: avoid crash on missing name ([#1947], thanks @leonardodino)
 
 ## [2.22.1] - 2020-09-27
 ### Fixed
@@ -736,6 +737,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1947]: https://github.com/benmosher/eslint-plugin-import/pull/1947
 [#1940]: https://github.com/benmosher/eslint-plugin-import/pull/1940
 [#1889]: https://github.com/benmosher/eslint-plugin-import/pull/1889
 [#1878]: https://github.com/benmosher/eslint-plugin-import/pull/1878

--- a/src/rules/no-webpack-loader-syntax.js
+++ b/src/rules/no-webpack-loader-syntax.js
@@ -2,7 +2,7 @@ import isStaticRequire from '../core/staticRequire'
 import docsUrl from '../docsUrl'
 
 function reportIfNonStandard(context, node, name) {
-  if (name.indexOf('!') !== -1) {
+  if (name && name.indexOf('!') !== -1) {
     context.report(node, `Unexpected '!' in '${name}'. ` +
       'Do not use import syntax to configure webpack loaders.'
     )

--- a/tests/src/rules/no-webpack-loader-syntax.js
+++ b/tests/src/rules/no-webpack-loader-syntax.js
@@ -1,4 +1,4 @@
-import { test } from '../utils'
+import { test, getTSParsers } from '../utils'
 
 import { RuleTester } from 'eslint'
 
@@ -71,4 +71,27 @@ ruleTester.run('no-webpack-loader-syntax', rule, {
       ],
     }),
   ],
+})
+
+context('TypeScript', function () {
+  getTSParsers().forEach((parser) => {
+    const parserConfig = {
+      parser: parser,
+      settings: {
+        'import/parsers': { [parser]: ['.ts'] },
+        'import/resolver': { 'eslint-import-resolver-typescript': true },
+      },
+    }
+    ruleTester.run('no-webpack-loader-syntax', rule, {
+      valid: [
+        test(Object.assign({
+          code: 'import { foo } from\nalert()',
+        }, parserConfig)),
+        test(Object.assign({
+          code: 'import foo from\nalert()',
+        }, parserConfig)),
+      ],
+      invalid: [],
+    })
+  })
 })


### PR DESCRIPTION
Tiny fix 😄 

Every time I was manually adding a `import` on a typescript in vscode file it would trigger this rule, because the parser interprets the code as valid, passing an incomplete AST node down.

The test case seems a bit weird, but it's what naturally happens when typing on the top part of a file, and having eslint constantly running 😄

Logs from a usual session:
```
[Error] ESLint stack trace:
[Error] TypeError: Cannot read property 'indexOf' of undefined
Occurred while linting /redacted/file.tsx:1
    at reportIfNonStandard (/redacted/node_modules/eslint-plugin-import/lib/rules/no-webpack-loader-syntax.js:5:12)
    at handleImports (/redacted/node_modules/eslint-plugin-import/lib/rules/no-webpack-loader-syntax.js:24:9)
    at /redacted/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/redacted/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/redacted/node_modules/eslint/lib/linter/node-event-generator.js:254:26)
    at NodeEventGenerator.applySelectors (/redacted/node_modules/eslint/lib/linter/node-event-generator.js:283:22)
    at NodeEventGenerator.enterNode (/redacted/node_modules/eslint/lib/linter/node-event-generator.js:297:14)
    at CodePathAnalyzer.enterNode (/redacted/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:711:23)
    at /redacted/node_modules/eslint/lib/linter/linter.js:952:32

```