### PR TITLE
[patch] `no-extraneous-dependencies`: Add package.json cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
 - [`order`]: ignore non-module-level requires ([#1940], thanks [@golopot])
 - [`no-webpack-loader-syntax`]/TypeScript: avoid crash on missing name ([#1947], thanks @leonardodino)
+- [`no-extraneous-dependencies`]: Add package.json cache ([#1948], thanks @fa93hws)
 
 ## [2.22.1] - 2020-09-27
 ### Fixed
@@ -737,6 +738,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1948]: https://github.com/benmosher/eslint-plugin-import/pull/1948
 [#1947]: https://github.com/benmosher/eslint-plugin-import/pull/1947
 [#1940]: https://github.com/benmosher/eslint-plugin-import/pull/1940
 [#1889]: https://github.com/benmosher/eslint-plugin-import/pull/1889

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -7,6 +7,8 @@ import moduleVisitor from 'eslint-module-utils/moduleVisitor'
 import importType from '../core/importType'
 import docsUrl from '../docsUrl'
 
+const depFieldCache = new Map()
+
 function hasKeys(obj = {}) {
   return Object.keys(obj).length > 0
 }
@@ -49,9 +51,14 @@ function getDependencies(context, packageDir) {
     if (paths.length > 0) {
       // use rule config to find package.json
       paths.forEach(dir => {
-        const _packageContent = extractDepFields(
-          JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'))
-        )
+        const packageJsonPath = path.join(dir, 'package.json')
+        if (!depFieldCache.has(packageJsonPath)) {
+          const depFields = extractDepFields(
+            JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+          )
+          depFieldCache.set(packageJsonPath, depFields)
+        }
+        const _packageContent = depFieldCache.get(packageJsonPath)
         Object.keys(packageContent).forEach(depsKey =>
           Object.assign(packageContent[depsKey], _packageContent[depsKey])
         )


### PR DESCRIPTION
This rule is super slow in our code base, and it seems it invoke one IO request for every single file..