### PR TITLE
[New] `no-commonjs`: Allow expressionless template literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+### Added
+- [`no-commonjs`]: Also detect require calls with expressionless template literals: ``` require(`x`) ``` ([#1958], thanks [@FloEdelmann])
+
 ### Fixed
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
 - [`order`]: ignore non-module-level requires ([#1940], thanks [@golopot])
@@ -752,6 +755,7 @@ for info on changes for earlier releases.
 [#1944]: https://github.com/benmosher/eslint-plugin-import/pull/1944
 [#1924]: https://github.com/benmosher/eslint-plugin-import/issues/1924
 [#1965]: https://github.com/benmosher/eslint-plugin-import/issues/1965
+[#1958]: https://github.com/benmosher/eslint-plugin-import/pull/1958
 [#1948]: https://github.com/benmosher/eslint-plugin-import/pull/1948
 [#1947]: https://github.com/benmosher/eslint-plugin-import/pull/1947
 [#1940]: https://github.com/benmosher/eslint-plugin-import/pull/1940
@@ -1314,3 +1318,4 @@ for info on changes for earlier releases.
 [@fsmaia]: https://github.com/fsmaia
 [@MatthiasKunnen]: https://github.com/MatthiasKunnen
 [@paztis]: https://github.com/paztis
+[@FloEdelmann]: https://github.com/FloEdelmann

--- a/src/rules/no-commonjs.js
+++ b/src/rules/no-commonjs.js
@@ -45,6 +45,11 @@ function isConditional(node) {
   return false;
 }
 
+function isLiteralString(node) {
+  return (node.type === 'Literal' && typeof node.value === 'string') ||
+    (node.type === 'TemplateLiteral' && node.expressions.length === 0);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -114,10 +119,7 @@ module.exports = {
         if (call.callee.name !== 'require') return;
 
         if (call.arguments.length !== 1) return;
-        const module = call.arguments[0];
-
-        if (module.type !== 'Literal') return;
-        if (typeof module.value !== 'string') return;
+        if (!isLiteralString(call.arguments[0])) return;
 
         if (allowRequire(call, options)) return;
 

--- a/tests/src/rules/no-commonjs.js
+++ b/tests/src/rules/no-commonjs.js
@@ -37,6 +37,7 @@ ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
     { code: "var bar = require('./bar', true);" },
     { code: "var bar = proxyquire('./bar');" },
     { code: "var bar = require('./ba' + 'r');" },
+    { code: 'var bar = require(`x${1}`);', parserOptions: { ecmaVersion: 2015 } },
     { code: 'var zero = require(0);' },
     { code: 'require("x")', options: [{ allowRequire: true }] },
 
@@ -71,6 +72,11 @@ ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
       { code: 'var x = require("x")', output: 'var x = require("x")', errors: [ { message: IMPORT_MESSAGE }] },
       { code: 'x = require("x")', output: 'x = require("x")', errors: [ { message: IMPORT_MESSAGE }] },
       { code: 'require("x")', output: 'require("x")', errors: [ { message: IMPORT_MESSAGE }] },
+      { code: 'require(`x`)',
+        parserOptions: { ecmaVersion: 2015 },
+        output: 'require(`x`)',
+        errors: [ { message: IMPORT_MESSAGE }],
+      },
 
       { code: 'if (typeof window !== "undefined") require("x")',
         options: [{ allowConditionalRequire: false }],

--- a/tests/src/rules/no-dynamic-require.js
+++ b/tests/src/rules/no-dynamic-require.js
@@ -44,5 +44,13 @@ ruleTester.run('no-dynamic-require', rule, {
       code: 'require(name + "foo", "bar")',
       errors: [error],
     }),
+    test({
+      code: 'require(`foo${x}`)',
+      errors: [error],
+    }),
+    test({
+      code: 'var foo = require(`foo${x}`)',
+      errors: [error],
+    }),
   ],
 });


### PR DESCRIPTION
Detect require calls with expressionless template literals: ``require(`x`)``

Those are also not detected by the `no-dynamic-require` rule:

https://github.com/benmosher/eslint-plugin-import/blob/bdda0691cf703f13f6472b6e824d5168343dd52e/src/rules/no-dynamic-require.js#L11-L14