### PR TITLE
[Fix] first's handling of import = require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`prefer-default-export`]: handle empty array destructuring ([#1965], thanks [@ljharb])
 - [`no-unused-modules`]: make type imports mark a module as used (fixes #1924) ([#1974], thanks [@cherryblossom000])
 - [`no-cycle`]: fix perf regression ([#1944], thanks [@Blasz])
+- [`first`]: fix handling of `import = require` ([#1963], thanks [@MatthiasKunnen])
 
 ### Changed
 - [Generic Import Callback] Make callback for all imports once in rules ([#1237], thanks [@ljqx])
@@ -1308,3 +1309,4 @@ for info on changes for earlier releases.
 [@Librazy]: https://github.com/Librazy
 [@swernerx]: https://github.com/swernerx
 [@fsmaia]: https://github.com/fsmaia
+[@MatthiasKunnen]: https://github.com/MatthiasKunnen

--- a/src/rules/first.js
+++ b/src/rules/first.js
@@ -1,5 +1,11 @@
 import docsUrl from '../docsUrl';
 
+function getImportValue(node) {
+  return node.type === 'ImportDeclaration'
+    ? node.source.value
+    : node.moduleReference.expression.value;
+}
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -43,13 +49,13 @@ module.exports = {
 
           anyExpressions = true;
 
-          if (node.type === 'ImportDeclaration') {
+          if (node.type === 'ImportDeclaration' || node.type === 'TSImportEqualsDeclaration') {
             if (absoluteFirst) {
-              if (/^\./.test(node.source.value)) {
+              if (/^\./.test(getImportValue(node))) {
                 anyRelative = true;
               } else if (anyRelative) {
                 context.report({
-                  node: node.source,
+                  node: node.type === 'ImportDeclaration' ? node.source : node.moduleReference,
                   message: 'Absolute imports should come before relative imports.',
                 });
               }


### PR DESCRIPTION
The rule now handles `TSImportEqualsDeclaration`.

This closes #1957.