### PR TITLE
[resolvers/webpack] Replace node-libs-browser with is-core-module

### DIFF
--- a/resolvers/webpack/index.js
+++ b/resolvers/webpack/index.js
@@ -5,7 +5,7 @@ var findRoot = require('find-root')
   , find = require('array-find')
   , interpret = require('interpret')
   , fs = require('fs')
-  , coreLibs = require('node-libs-browser')
+  , isCore = require('is-core-module')
   , resolve = require('resolve')
   , semver = require('semver')
   , has = require('has')
@@ -142,8 +142,8 @@ exports.resolve = function (source, file, settings) {
   try {
     return { found: true, path: resolveSync(path.dirname(file), source) }
   } catch (err) {
-    if (source in coreLibs) {
-      return { found: true, path: coreLibs[source] }
+    if (isCore(source)) {
+      return { found: true, path: null }
     }
 
     log('Error during module resolution:', err)

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -38,8 +38,8 @@
     "find-root": "^1.1.0",
     "has": "^1.0.3",
     "interpret": "^1.2.0",
+    "is-core-module": "^2.0.0",
     "lodash": "^4.17.15",
-    "node-libs-browser": "^1.0.0 || ^2.0.0",
     "resolve": "^1.13.1",
     "semver": "^5.7.1"
   },


### PR DESCRIPTION
This significantly shrinks our dependency tree.  Fixes #631.