### PR TITLE
Add exemptFrom option to no-restricted-paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## [Unreleased]
+- [`no-restricted-paths`]: Add `exemptFrom` option to allow files within `from` to import eachother, even if `from` is inside `target`.
 
 ### Fixed
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])

--- a/docs/rules/no-restricted-paths.md
+++ b/docs/rules/no-restricted-paths.md
@@ -9,7 +9,7 @@ In order to prevent such scenarios this rule allows you to define restricted zon
 
 This rule has one option. The option is an object containing the definition of all restricted `zones` and the optional `basePath` which is used to resolve relative paths within.
 The default value for `basePath` is the current working directory.
-Each zone consists of the `target` path and a `from` path. The `target` is the path where the restricted imports should be applied. The `from` path defines the folder that is not allowed to be used in an import. An optional `except` may be defined for a zone, allowing exception paths that would otherwise violate the related `from`. Note that `except` is relative to `from` and cannot backtrack to a parent directory.
+Each zone consists of the `target` path and a `from` path. The `target` is the path where the restricted imports should be applied. The `from` path defines the folder that is not allowed to be used in an import. If `exemptFrom` is `true` files within the `from` path will be allowed to import from the `from` path. This can be useful if `from` is nested inside `target`. An optional `except` may be defined for a zone, allowing exception paths that would otherwise violate the related `from`. Note that `except` is relative to `from` and cannot backtrack to a parent directory.
 You may also specify an optional `message` for a zone, which will be displayed in case of the rule violation.
 
 ### Examples
@@ -77,4 +77,41 @@ The following pattern is not considered a problem:
 
 ```js
 import b from './b'
+```
+
+---------------
+
+Given the following folder structure:
+
+```
+my-project
+├── client
+│   └── foo.js
+└── server
+    └── a.js
+    └── b.js
+```
+
+and the current file being linted is `my-project/server/a.js`.
+
+and the current configuration is set to:
+
+```
+{ "zones": [ {
+    "target": "./tests/files/restricted-paths/",
+    "from": "./tests/files/restricted-paths/server",
+    "exemptFrom": true,
+} ] }
+```
+
+The following pattern is not considered a problem:
+
+```js
+import b from './b.js'
+```
+
+But for `my-project/client/foo.js` the following pattern is considered a problem:
+
+```js
+import b from '../server/b.js'
 ```

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -32,6 +32,7 @@ module.exports = {
                   },
                   uniqueItems: true,
                 },
+                exemptFrom: { type: 'boolean' },
                 message: { type: 'string' },
               },
               additionalProperties: false,
@@ -51,6 +52,11 @@ module.exports = {
     const currentFilename = context.getFilename()
     const matchingZones = restrictedPaths.filter((zone) => {
       const targetPath = path.resolve(basePath, zone.target)
+      const fromPath = path.resolve(basePath, zone.from)
+
+      if (zone.exemptFrom && containsPath(currentFilename, fromPath)) {
+        return false
+      }
 
       return containsPath(currentFilename, targetPath)
     })

--- a/tests/src/rules/no-restricted-paths.js
+++ b/tests/src/rules/no-restricted-paths.js
@@ -50,6 +50,17 @@ ruleTester.run('no-restricted-paths', rule, {
         } ],
       } ],
     }),
+    test({
+      code: 'import b from "./b.js"',
+      filename: testFilePath('./restricted-paths/server/c.js'),
+      options: [ {
+        zones: [ {
+          target: './tests/files/restricted-paths',
+          from: './tests/files/restricted-paths/server',
+          exemptFrom: true,
+        } ],
+      } ],
+    }),
 
 
     // irrelevant function calls
@@ -175,6 +186,36 @@ ruleTester.run('no-restricted-paths', rule, {
       errors: [ {
         message: 'Restricted path exceptions must be descendants of the configured ' +
           '`from` path for that zone.',
+        line: 1,
+        column: 15,
+      } ],
+    }),
+    test({
+      code: 'import b from "../server/b.js"',
+      filename: testFilePath('./restricted-paths/client/a.js'),
+      options: [ {
+        zones: [ {
+          target: './tests/files/restricted-paths',
+          from: './tests/files/restricted-paths/server',
+        } ],
+      } ],
+      errors: [ {
+        message: 'Unexpected path "../server/b.js" imported in restricted zone.',
+        line: 1,
+        column: 15,
+      } ],
+    }),
+    test({
+      code: 'import b from "./b.js"',
+      filename: testFilePath('./restricted-paths/server/c.js'),
+      options: [ {
+        zones: [ {
+          target: './tests/files/restricted-paths',
+          from: './tests/files/restricted-paths/server',
+        } ],
+      } ],
+      errors: [ {
+        message: 'Unexpected path "./b.js" imported in restricted zone.',
         line: 1,
         column: 15,
       } ],


### PR DESCRIPTION
Personally I want to use this for the following use case:

I have a directory like:
```
src/
  pages/
  features/
  ...many more directories
```

I want to disallow any files (outside of pages) to import from /src/pages. This is not currently possible because `from` (`src/pages`) is nested inside of `target` (`src`).

I would do that with the following rule:
```
{ 
  zones: [ {
    target: './src',
    from: '.src/pages',
    exemptFrom: true,
  } ],
}
```

A different approach would be to go with something like `exceptTarget` or `targetExcept` to mirror the existing `except` option. It might cover more use cases, but does not fit cleanly in the api.