### PR TITLE
[Fix] `no-unused-modules`: make type imports mark a module as used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ lib/
 yarn.lock
 package-lock.json
 npm-shrinkwrap.json
+
+# macOS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-webpack-loader-syntax`]/TypeScript: avoid crash on missing name ([#1947], thanks @leonardodino)
 - [`no-extraneous-dependencies`]: Add package.json cache ([#1948], thanks @fa93hws)
 - [`prefer-default-export`]: handle empty array destructuring ([#1965], thanks @ljharb)
+- [`no-unused-modules`]: make type imports mark a module as used (fixes #1924) ([#1974], thanks [@cherryblossom000])
 
 ## [2.22.1] - 2020-09-27
 ### Fixed
@@ -739,6 +740,8 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1974]: https://github.com/benmosher/eslint-plugin-import/pull/1974
+[#1924]: https://github.com/benmosher/eslint-plugin-import/issues/1924
 [#1965]: https://github.com/benmosher/eslint-plugin-import/issues/1965
 [#1948]: https://github.com/benmosher/eslint-plugin-import/pull/1948
 [#1947]: https://github.com/benmosher/eslint-plugin-import/pull/1947
@@ -1289,3 +1292,4 @@ for info on changes for earlier releases.
 [@tomprats]: https://github.com/tomprats
 [@straub]: https://github.com/straub
 [@andreubotella]: https://github.com/andreubotella
+[@cherryblossom000]: https://github.com/cherryblossom000

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -114,7 +114,7 @@ const importList = new Map();
  * keys are the paths to the modules containing the exports, while the
  * lower-level Map keys are the specific identifiers or special AST node names
  * being exported. The leaf-level metadata object at the moment only contains a
- * `whereUsed` propoerty, which contains a Set of paths to modules that import
+ * `whereUsed` property, which contains a Set of paths to modules that import
  * the name.
  *
  * For example, if we have a file named bar.js containing the following exports:
@@ -216,12 +216,10 @@ const prepareImportsAndExports = (srcFiles, context) => {
         if (isNodeModule(key)) {
           return;
         }
-        let localImport = imports.get(key);
-        if (typeof localImport !== 'undefined') {
-          localImport = new Set([...localImport, ...value.importedSpecifiers]);
-        } else {
-          localImport = value.importedSpecifiers;
-        }
+        const localImport = imports.get(key) || new Set();
+        value.declarations.forEach(({ importedSpecifiers }) =>
+          importedSpecifiers.forEach(specifier => localImport.add(specifier))
+        );
         imports.set(key, localImport);
       });
       importList.set(file, imports);

--- a/tests/files/no-unused-modules/typescript/file-ts-f-import-type.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-f-import-type.ts
@@ -1,0 +1,1 @@
+import type {g} from './file-ts-g-used-as-type'

--- a/tests/files/no-unused-modules/typescript/file-ts-f.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-f.ts
@@ -1,0 +1,1 @@
+import {g} from './file-ts-g';

--- a/tests/files/no-unused-modules/typescript/file-ts-g-used-as-type.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-g-used-as-type.ts
@@ -1,0 +1,1 @@
+export interface g {}

--- a/tests/files/no-unused-modules/typescript/file-ts-g.ts
+++ b/tests/files/no-unused-modules/typescript/file-ts-g.ts
@@ -1,0 +1,1 @@
+export interface g {}

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -827,6 +827,31 @@ context('TypeScript', function () {
           parser: parser,
           filename: testFilePath('./no-unused-modules/typescript/file-ts-e-used-as-type.ts'),
         }),
+        // Should also be valid when the exporting files are linted before the importing ones
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export interface g {}`,
+          parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-g.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `import {g} from './file-ts-g';`,
+          parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-f.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `export interface g {};`,
+          parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-g-used-as-type.ts'),
+        }),
+        test({
+          options: unusedExportsTypescriptOptions,
+          code: `import type {g} from './file-ts-g';`,
+          parser,
+          filename: testFilePath('./no-unused-modules/typescript/file-ts-f-import-type.ts'),
+        }),
       ],
       invalid: [
         test({
@@ -940,4 +965,3 @@ describe('ignore flow types', () => {
     invalid: [],
   });
 });
-


### PR DESCRIPTION
Fixes #1924

`ExportMap` now keeps track of each imported declaration (`imports.get(path).declarations`) and whether the declarations are only importing types (`isOnlyImportingTypes`). This is used by `no-cycle` to

- ignore only type imports
- report circular dependencies at the correct line

For example (from [this existing test](https://github.com/cherryblossom000/eslint-plugin-import/blob/1924/tests/src/rules/no-cycle.js#L159-L163)):

`depth-zero.js`
```js
import { bar } from './flow-types-depth-one'
```

`flow-types-depth-one.js`
```js
// @flow

// this import declaration doesn't trigger the rule because it's a type import
import type { FooType } from './flow-types-depth-two'
// this declaration does because of the 'bar' import, so the error message refers to this line
import { type BarType, bar } from './flow-types-depth-two'

export { bar }
```

`flow-types-depth-two.js`
```js
import { foo } from './depth-one'
```

`depth-one.js`
```js
import foo from './depth-zero'
```

The only significant change in `no-unused-modules` is [here](https://github.com/benmosher/eslint-plugin-import/pull/1974/files#diff-7d2908b010ec724c0f3a0d7615cb91f4673d765d52c6ba6607501e23470f2966R219-R222) where each declaration's `importedSpecifiers` is added to a file's import list. However, because the `imports` in a file's `ExportMap` now include type imports, type imports now mark an export as being used.