### PR TITLE
[Fix] `no-named-default`: ignore Flow import type and typeof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`first`]: fix handling of `import = require` ([#1963], thanks [@MatthiasKunnen])
 - [`no-cycle`]/[`extensions`]: fix isExternalModule usage ([#1696], thanks [@paztis])
 - [`extensions`]/[`no-cycle`]/[`no-extraneous-dependencies`]: Correct module real path resolution ([#1696], thanks [@paztis])
+- [`no-named-default`]: ignore Flow import type and typeof ([#1983], thanks [@christianvuerings])
 
 ### Changed
 - [Generic Import Callback] Make callback for all imports once in rules ([#1237], thanks [@ljqx])
@@ -757,6 +758,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1983]: https://github.com/benmosher/eslint-plugin-import/pull/1983
 [#1974]: https://github.com/benmosher/eslint-plugin-import/pull/1974
 [#1958]: https://github.com/benmosher/eslint-plugin-import/pull/1958
 [#1948]: https://github.com/benmosher/eslint-plugin-import/pull/1948
@@ -1335,3 +1337,4 @@ for info on changes for earlier releases.
 [@tapayne88]: https://github.com/tapayne88
 [@panrafal]: https://github.com/panrafal
 [@ttmarek]: https://github.com/ttmarek
+[@christianvuerings]: https://github.com/christianvuerings

--- a/docs/rules/no-named-default.md
+++ b/docs/rules/no-named-default.md
@@ -4,6 +4,10 @@ Reports use of a default export as a locally named import.
 
 Rationale: the syntax exists to import default exports expressively, let's use it.
 
+Note that type imports, as used by [Flow], are always ignored.
+
+[Flow]: https://flow.org/
+
 ## Rule Details
 
 Given:

--- a/src/rules/no-named-default.js
+++ b/src/rules/no-named-default.js
@@ -13,6 +13,10 @@ module.exports = {
     return {
       'ImportDeclaration': function (node) {
         node.specifiers.forEach(function (im) {
+          if (im.importKind === 'type' || im.importKind === 'typeof') {
+            return;
+          }
+
           if (im.type === 'ImportSpecifier' && im.imported.name === 'default') {
             context.report({
               node: im.local,

--- a/tests/src/rules/no-named-default.js
+++ b/tests/src/rules/no-named-default.js
@@ -9,6 +9,16 @@ ruleTester.run('no-named-default', rule, {
     test({ code: 'import bar from "./bar";' }),
     test({ code: 'import bar, { foo } from "./bar";' }),
 
+    // Should ignore imported flow types
+    test({
+      code: 'import { type default as Foo } from "./bar";',
+      parser: require.resolve('babel-eslint'),
+    }),
+    test({
+      code: 'import { typeof default as Foo } from "./bar";',
+      parser: require.resolve('babel-eslint'),
+    }),
+
     ...SYNTAX_CASES,
   ],
 


### PR DESCRIPTION
## Description

Syncs the behavior of [`no-named-default`](https://github.com/benmosher/eslint-plugin-import/blob/v2.22.1/docs/rules/no-named-default.md) with [`named`](https://github.com/benmosher/eslint-plugin-import/blob/v2.22.1/docs/rules/named.md), which also ignores Flow imports & exports:

> Note that type imports and exports, as used by [Flow], are always ignored.

Without this fix, [`no-named-default`](https://github.com/benmosher/eslint-plugin-import/blob/v2.22.1/docs/rules/no-named-default.md) conflicts with the [`flowtype/type-import-style`](https://github.com/gajus/eslint-plugin-flowtype/blob/e93f1c0102c03b465bce260b6e085b04e1a0f934/.README/rules/type-import-style.md) rule with a default setting of "identifier".

## Issue

"Identifier syntax":

```js
// @flow
import { type default as Foo } from "./bar";
```
Gives following error:

```
2:15  error    Use default import syntax to import './bar'.       import/no-named-default
```

Whilst the "declaration syntax":

```js
// @flow
import type Foo from './bar';
```
Generates no error.

## Related PRs / Issues

- https://github.com/benmosher/eslint-plugin-import/pull/1117: Fix named flow type imports in specifiers (https://github.com/benmosher/eslint-plugin-import/issues/1115)
- https://github.com/benmosher/eslint-plugin-import/pull/1345: [fix] `named`: ignore Flow import typeof and export type
