### PR TITLE
[New] `order`: Add `warnOnUnassignedImports` option to enable warnings for out of order unassigned imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - add [`no-import-module-exports`] rule: report import declarations with CommonJS exports ([#804], thanks [@kentcdodds] and [@ttmarek])
 - [`no-unused-modules`]: Support destructuring assignment for `export`. ([#1997], thanks [@s-h-a-d-o-w])
 - [`order`]: support type imports ([#2021], thanks [@grit96])
+- [`order`]: Add `warnOnUnassignedImports` option to enable warnings for out of order unassigned imports ([#1990], thanks [@hayes])
 
 ### Fixed
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
@@ -773,6 +774,7 @@ for info on changes for earlier releases.
 [#2012]: https://github.com/benmosher/eslint-plugin-import/pull/2012
 [#1997]: https://github.com/benmosher/eslint-plugin-import/pull/1997
 [#1993]: https://github.com/benmosher/eslint-plugin-import/pull/1993
+[#1990]: https://github.com/benmosher/eslint-plugin-import/pull/1990
 [#1985]: https://github.com/benmosher/eslint-plugin-import/pull/1985
 [#1983]: https://github.com/benmosher/eslint-plugin-import/pull/1983
 [#1974]: https://github.com/benmosher/eslint-plugin-import/pull/1974
@@ -1363,3 +1365,4 @@ for info on changes for earlier releases.
 [@silviogutierrez]: https://github.com/silviogutierrez
 [@aladdin-add]: https://github.com/aladdin-add
 [@davidbonnet]: https://github.com/davidbonnet
+[@hayes]: https://github.com/hayes

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -256,6 +256,33 @@ import React, { PureComponent } from 'react';
 import { compose, apply } from 'xcompose';
 ```
 
+### `warnOnUnassignedImports: true|false`:
+
+* default: `false`
+
+Warns when unassigned imports are out of order.  These warning will not be fixed
+with `--fix` because unassigned imports are used for side-effects and changing the
+import of order of modules with side effects can not be done automatically in a
+way that is safe.
+
+This will fail the rule check:
+
+```js
+/* eslint import/order: ["error", {"warnOnUnassignedImports": true}] */
+import fs from 'fs';
+import './styles.css';
+import path from 'path';
+```
+
+While this will pass:
+
+```js
+/* eslint import/order: ["error", {"warnOnUnassignedImports": true}] */
+import fs from 'fs';
+import path from 'path';
+import './styles.css';
+```
+
 ## Related
 
 - [`import/external-module-folders`] setting

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -339,7 +339,7 @@ function isModuleLevelRequire(node) {
   let n = node;
   // Handle cases like `const baz = require('foo').bar.baz`
   // and `const foo = require('foo')()`
-  while ( 
+  while (
     (n.parent.type === 'MemberExpression' && n.parent.object === n) ||
     (n.parent.type === 'CallExpression' && n.parent.callee === n)
   ) {
@@ -348,7 +348,7 @@ function isModuleLevelRequire(node) {
   return (
     n.parent.type === 'VariableDeclarator' &&
     n.parent.parent.type === 'VariableDeclaration' &&
-    n.parent.parent.parent.type === 'Program' 
+    n.parent.parent.parent.type === 'Program'
   );
 }
 
@@ -568,6 +568,10 @@ module.exports = {
             },
             additionalProperties: false,
           },
+          warnOnUnassignedImports: {
+            type: 'boolean',
+            default: false,
+          },
         },
         additionalProperties: false,
       },
@@ -600,7 +604,8 @@ module.exports = {
 
     return {
       ImportDeclaration: function handleImports(node) {
-        if (node.specifiers.length) { // Ignoring unassigned imports
+        // Ignoring unassigned imports unless warnOnUnassignedImports is set
+        if (node.specifiers.length || options.warnOnUnassignedImports) {
           const name = node.source.value;
           registerNode(
             context,


### PR DESCRIPTION
fixes #1639 

This seems like a pretty simple solution, but does have one weird side effect: The behavior of the newline option changes slightly, in that it can now remove newlines between groups correctly when there are unassigned imports.  This is only the case when the new option is enabled.  Updating this to make that behavior consistent (always allow new-line changes around unassigned imports) would be safe, and easy to implement, but is a breaking change, so leaving it as is seems better.

cc @Alphy11  @ljharb 