### PR TITLE
[Docs] `order`: Document options required to match ordering example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [Generic Import Callback] Make callback for all imports once in rules ([#1237], thanks [@ljqx])
 - [Docs] [`no-named-as-default`]: add semicolon ([#1897], thanks [@bicstone])
 - [Docs] `no-extraneous-dependencies`: correct peerDependencies option default to `true` ([#1993], thanks [@dwardu])
+- [Docs] `order`: Document options required to match ordering example ([#1992], thanks [@silviogutierrez])
 
 ## [2.22.1] - 2020-09-27
 ### Fixed
@@ -1355,3 +1356,4 @@ for info on changes for earlier releases.
 [@s-h-a-d-o-w]: https://github.com/s-h-a-d-o-w
 [@grit96]: https://github.com/grit96
 [@lilling]: https://github.com/lilling
+[@silviogutierrez]: https://github.com/silviogutierrez

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -2,7 +2,8 @@
 
 Enforce a convention in the order of `require()` / `import` statements.
 +(fixable) The `--fix` option on the [command line] automatically fixes problems reported by this rule.
-The order is as shown in the following example:
+
+With the [`groups`](#groups-array) option set to `["builtin", "external", "internal", "parent", "sibling", "index", "object"]` the order is as shown in the following example:
 
 ```js
 // 1. node "builtin" modules


### PR DESCRIPTION
Fixes #1977 