### PR TITLE
Fix: import/no-unresolved can not resolve sub-directory of built-in module

### DIFF
--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -7,6 +7,7 @@ import resolve, { CASE_SENSITIVE_FS, fileExistsWithCaseSync } from 'eslint-modul
 import ModuleCache from 'eslint-module-utils/ModuleCache';
 import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor';
 import docsUrl from '../docsUrl';
+import { isBuiltIn } from '../core/importType';
 
 module.exports = {
   meta: {
@@ -25,6 +26,10 @@ module.exports = {
     function checkSourceValue(source) {
       const shouldCheckCase = !CASE_SENSITIVE_FS &&
         (!context.options[0] || context.options[0].caseSensitive !== false);
+
+      if (isBuiltIn(source.value, context.settings)) {
+        return;
+      }
 
       const resolvedPath = resolve(source.value, context);
 

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -378,6 +378,25 @@ ruleTester.run('no-unresolved electron', rule, {
   ],
 });
 
+ruleTester.run('no-unresolved sub-directory', rule, {
+  valid: [
+    test({
+      code: 'import "@generated/bar/module"',
+      settings: { 'import/core-modules': ['@generated/bar'] },
+    }),
+    test({
+      code: 'import "@generated/bar/and/sub/path"',
+      settings: { 'import/core-modules': ['@generated/bar'] },
+    }),
+  ],
+  invalid:[
+    test({
+      code: 'import "@generated/bar/module"',
+      errors: [`Unable to resolve path to module '@generated/bar/module'.`],
+    }),
+  ],
+});
+
 ruleTester.run('no-unresolved syntax verification', rule, {
   valid: SYNTAX_CASES,
   invalid:[],


### PR DESCRIPTION
The rule [import/core-modules](https://github.com/benmosher/eslint-plugin-import#importcore-modules) allows us to add customized core modules, such as 'electron':

```js
import 'electron';
```

But it is unable to resolve sub-directory:

```js
import 'electron/foo'; // eslint error, unable to resolve "electron/foo"
```

However, there is another rule [no-extraneous-dependencies](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md) that supports sub-directory, for example:

```js
import 'lodash/get'; // no eslint error
```

So I think it should be better if we make those rules unified for subdirectory, so I opened this PR.

The modification is very simple: if a module is kind of built-in (even if it is customized core module), then we just skip the rest checks of rule `import/no-unresolved`.

Unit tests are also added :D
