### PR TITLE
[Fix]: no-unresolved: Support importing only types when the module isn't installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-internal-modules`]: Add `forbid` option ([#1846], thanks [@guillaumewuip])
 - add [`no-relative-packages`] ([#1860], [#966], thanks [@tapayne88] [@panrafal])
 - add [`no-import-module-exports`] rule: report import declarations with CommonJS exports ([#804], thanks [@kentcdodds] and [@ttmarek])
+- [`no-unresolved`]: Don't trigger an error when only types are imported in TypeScript, when the module's typings are installed and the module is not ([#2009], thanks [@EdenGottlieb])
 
 ### Fixed
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
@@ -759,6 +760,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2009]: https://github.com/benmosher/eslint-plugin-import/pull/2009
 [#1983]: https://github.com/benmosher/eslint-plugin-import/pull/1983
 [#1974]: https://github.com/benmosher/eslint-plugin-import/pull/1974
 [#1958]: https://github.com/benmosher/eslint-plugin-import/pull/1958
@@ -1341,3 +1343,4 @@ for info on changes for earlier releases.
 [@ttmarek]: https://github.com/ttmarek
 [@christianvuerings]: https://github.com/christianvuerings
 [@devongovett]: https://github.com/devongovett
+[@EdenGottlieb]: https://github.com/EdenGottlieb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-internal-modules`]: Add `forbid` option ([#1846], thanks [@guillaumewuip])
 - add [`no-relative-packages`] ([#1860], [#966], thanks [@tapayne88] [@panrafal])
 - add [`no-import-module-exports`] rule: report import declarations with CommonJS exports ([#804], thanks [@kentcdodds] and [@ttmarek])
-- [`no-unresolved`]: Don't trigger an error when only types are imported in TypeScript, when the module's typings are installed and the module is not ([#2009], thanks [@EdenGottlieb])
 
 ### Fixed
 - [`export`]/TypeScript: properly detect export specifiers as children of a TS module block ([#1889], thanks [@andreubotella])
@@ -26,6 +25,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`extensions`]/[`no-cycle`]/[`no-extraneous-dependencies`]: Correct module real path resolution ([#1696], thanks [@paztis])
 - [`no-named-default`]: ignore Flow import type and typeof ([#1983], thanks [@christianvuerings])
 - [`no-extraneous-dependencies`]: Exclude flow `typeof` imports ([#1534], thanks [@devongovett])
+- [`no-unresolved`]: Don't trigger an error when only types are imported in TypeScript, when the module's typings are installed and the module is not ([#2009], thanks [@EdenGottlieb])
 
 ### Changed
 - [Generic Import Callback] Make callback for all imports once in rules ([#1237], thanks [@ljqx])

--- a/docs/rules/no-unresolved.md
+++ b/docs/rules/no-unresolved.md
@@ -6,6 +6,9 @@ as defined by standard Node `require.resolve` behavior.
 See [settings](../../README.md#settings) for customization options for the resolution (i.e.
 additional filetypes, `NODE_PATH`, etc.)
 
+
+When used in conjuction with TypeScript: If only a module's types are imported, having just the typings installed without the module itself (typings under `node_modules/@types`) is sufficient to not trigger an error.
+
 This rule can also optionally report on unresolved modules in CommonJS `require('./foo')` calls and AMD `require(['./foo'], function (foo){...})` and `define(['./foo'], function (foo){...})`.
 
 To enable this, send `{ commonjs: true/false, amd: true/false }` as a rule option.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
     "@test-scope/some-module": "file:./tests/files/symlinked-module",
+    "@types/memorystream": "^0.3.0",
     "@typescript-eslint/parser": "^2.23.0 || ^3.3.0",
     "array.prototype.flatmap": "^1.2.3",
     "babel-cli": "^6.26.0",

--- a/resolvers/node/index.js
+++ b/resolvers/node/index.js
@@ -30,7 +30,7 @@ function opts(file, config) {
   return Object.assign({
     // more closely matches Node (#333)
     // plus 'mjs' for native modules! (#939)
-    extensions: ['.mjs', '.js', '.json', '.node'],
+    extensions: ['.mjs', '.js', '.json', '.node', '.d.ts'],
   },
   config,
   {

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -22,11 +22,15 @@ module.exports = {
 
   create: function (context) {
 
-    function checkSourceValue(source) {
+    function checkSourceValue(source, importer) {
       const shouldCheckCase = !CASE_SENSITIVE_FS &&
         (!context.options[0] || context.options[0].caseSensitive !== false);
 
-      const resolvedPath = resolve(source.value, context);
+      let resolvedPath = resolve(source.value, context);
+
+      if (resolvedPath === undefined && importer.importKind === 'type') {
+        resolvedPath = resolve(`@types/${source.value}`, context);
+      }
 
       if (resolvedPath === undefined) {
         context.report(source,

--- a/tests/files/webpack.config.js
+++ b/tests/files/webpack.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   resolve: {
-    extensions: ['', '.js', '.jsx'],
+    extensions: ['', '.js', '.jsx', '.d.ts'],
     root: __dirname,
     alias: {
       'alias/chai$': 'chai' // alias for no-extraneous-dependencies tests

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -29,6 +29,8 @@ function runResolverTests(resolver) {
       rest({ code: "import bar from './bar.js';" }),
       rest({ code: "import {someThing} from './test-module';" }),
       rest({ code: "import fs from 'fs';" }),
+      rest({ code: "import type MemoryStream from 'memorystream';",
+        parser: require.resolve('@typescript-eslint/parser') }),
       rest({ code: "import('fs');",
         parser: require.resolve('babel-eslint') }),
 
@@ -106,6 +108,17 @@ function runResolverTests(resolver) {
       rest({
         code: "import bar from './empty-folder';",
         errors: [{ message: "Unable to resolve path to module './empty-folder'.",
+          type: 'Literal',
+        }] }),
+      rest({
+        code: "import MemoryStream from 'memorystream';",
+        errors: [{ message: "Unable to resolve path to module 'memorystream'.",
+          type: 'Literal',
+        }] }),
+      rest({
+        code: "import type Bar from 'this-doesnt-exist';",
+        parser: require.resolve('@typescript-eslint/parser'),
+        errors: [{ message: "Unable to resolve path to module 'this-doesnt-exist'.",
           type: 'Literal',
         }] }),
 


### PR DESCRIPTION
- [ ] write tests
- [ ] implement feature/fix bug
- [ ] update docs
- [ ] make a note in change log

Don't trigger an error when only typings are imported and the actual module is not installed (only its typings are installed under (`node_modules/@types`).
This is useful when defining packages holding domain objects that only need to reference types, without using the actual module.

I chose memorystream for the test for several reasons:
1. I needed a module that won't be added to the project any time soon (adding it would break the tests!)
2. I needed to use a module with publicly available typings
3. It's what I used for the initial debugging :)

Please feel free to comment on code logic, test strategy and documentation phrasing, all feedback is welcome!