### PR TITLE
[Tests] `no-unresolved`: add tests for `import()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [Docs] [`no-named-as-default`]: add semicolon ([#1897], thanks [@bicstone])
 - [Docs] `no-extraneous-dependencies`: correct peerDependencies option default to `true` ([#1993], thanks [@dwardu])
 - [Docs] `order`: Document options required to match ordering example ([#1992], thanks [@silviogutierrez])
+- [Tests] `no-unresolved`: add tests for `import()` ([#2012], thanks [@davidbonnet])
 
 ## [2.22.1] - 2020-09-27
 ### Fixed
@@ -769,6 +770,7 @@ for info on changes for earlier releases.
 [#2026]: https://github.com/benmosher/eslint-plugin-import/pull/2026
 [#2022]: https://github.com/benmosher/eslint-plugin-import/pull/2022
 [#2021]: https://github.com/benmosher/eslint-plugin-import/pull/2021
+[#2012]: https://github.com/benmosher/eslint-plugin-import/pull/2012
 [#1997]: https://github.com/benmosher/eslint-plugin-import/pull/1997
 [#1993]: https://github.com/benmosher/eslint-plugin-import/pull/1993
 [#1985]: https://github.com/benmosher/eslint-plugin-import/pull/1985
@@ -1360,3 +1362,4 @@ for info on changes for earlier releases.
 [@lilling]: https://github.com/lilling
 [@silviogutierrez]: https://github.com/silviogutierrez
 [@aladdin-add]: https://github.com/aladdin-add
+[@davidbonnet]: https://github.com/davidbonnet

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -22,7 +22,7 @@ function runResolverTests(resolver) {
   }
 
   ruleTester.run(`no-unresolved (${resolver})`, rule, {
-    valid: [
+    valid: [].concat(
       test({ code: 'import "./malformed.js"' }),
 
       rest({ code: 'import foo from "./bar";' }),
@@ -31,6 +31,12 @@ function runResolverTests(resolver) {
       rest({ code: "import fs from 'fs';" }),
       rest({ code: "import('fs');",
         parser: require.resolve('babel-eslint') }),
+
+      // check with eslint parser
+      testVersion('>= 7', () => rest({
+        code: "import('fs');",
+        parserOptions: { ecmaVersion: 2021 },
+      })) || [],
 
       rest({ code: 'import * as foo from "a"' }),
 
@@ -83,9 +89,9 @@ function runResolverTests(resolver) {
         options: [{ commonjs: true }] }),
       rest({ code: 'require(foo)',
         options: [{ commonjs: true }] }),
-    ],
+    ),
 
-    invalid: [
+    invalid: [].concat(
       rest({
         code: 'import reallyfake from "./reallyfake/module"',
         settings: { 'import/ignore': ['^\\./fake/'] },
@@ -117,9 +123,9 @@ function runResolverTests(resolver) {
         }] }),
       rest({
         code: "import('in-alternate-root').then(function({DEEP}){});",
-        errors: [{ message: 'Unable to resolve path to ' +
-                          "module 'in-alternate-root'.",
-        type: 'Literal',
+        errors: [{
+          message: 'Unable to resolve path to module \'in-alternate-root\'.',
+          type: 'Literal',
         }],
         parser: require.resolve('babel-eslint') }),
 
@@ -129,6 +135,16 @@ function runResolverTests(resolver) {
         code: 'export * from "./does-not-exist"',
         errors: ["Unable to resolve path to module './does-not-exist'."],
       }),
+
+      // check with eslint parser
+      testVersion('>= 7', () => rest({
+        code: "import('in-alternate-root').then(function({DEEP}){});",
+        errors: [{
+          message: 'Unable to resolve path to module \'in-alternate-root\'.',
+          type: 'Literal',
+        }],
+        parserOptions: { ecmaVersion: 2021 },
+      })) || [],
 
       // export symmetry proposal
       rest({ code: 'export * as bar from "./does-not-exist"',
@@ -186,7 +202,7 @@ function runResolverTests(resolver) {
           type: 'Literal',
         }],
       }),
-    ],
+    ),
   });
 
   ruleTester.run(`issue #333 (${resolver})`, rule, {


### PR DESCRIPTION
Dynamic imports landed in EcmaScript 2020, and Eslint now parses it out of the box.
However, the AST `node` containing the dynamic import is an `ImportExpression`, which is ignored by the `no-unresolved` rule.
