### PR TITLE
[Fix] `no-restricted-paths`: enhance performance for exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-named-default`]: ignore Flow import type and typeof ([#1983], thanks [@christianvuerings])
 - [`no-extraneous-dependencies`]: Exclude flow `typeof` imports ([#1534], thanks [@devongovett])
 - [`newline-after-import`]: respect decorator annotations ([#1985], thanks [@lilling])
+- [`no-restricted-paths`]: enhance performance for zones with `except` paths ([#2022], thanks [@malykhinvi])
 
 ### Changed
 - [Generic Import Callback] Make callback for all imports once in rules ([#1237], thanks [@ljqx])
@@ -763,6 +764,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2022]: https://github.com/benmosher/eslint-plugin-import/pull/2022
 [#2021]: https://github.com/benmosher/eslint-plugin-import/pull/2021
 [#1997]: https://github.com/benmosher/eslint-plugin-import/pull/1997
 [#1993]: https://github.com/benmosher/eslint-plugin-import/pull/1993

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -68,6 +68,19 @@ module.exports = {
       });
     }
 
+    const zoneExceptions = matchingZones.map((zone) => {
+      const exceptionPaths = zone.except || [];
+      const absoluteFrom = path.resolve(basePath, zone.from);
+      const absoluteExceptionPaths = exceptionPaths.map((exceptionPath) => path.resolve(absoluteFrom, exceptionPath));
+      const hasValidExceptionPaths = absoluteExceptionPaths
+        .every((absoluteExceptionPath) => isValidExceptionPath(absoluteFrom, absoluteExceptionPath));
+
+      return {
+        absoluteExceptionPaths,
+        hasValidExceptionPaths,
+      };
+    });
+
     function checkForRestrictedImportPath(importPath, node) {
       const absoluteImportPath = resolve(importPath, context);
 
@@ -75,19 +88,14 @@ module.exports = {
         return;
       }
 
-      matchingZones.forEach((zone) => {
-        const exceptionPaths = zone.except || [];
+      matchingZones.forEach((zone, index) => {
         const absoluteFrom = path.resolve(basePath, zone.from);
 
         if (!containsPath(absoluteImportPath, absoluteFrom)) {
           return;
         }
 
-        const absoluteExceptionPaths = exceptionPaths.map((exceptionPath) =>
-          path.resolve(absoluteFrom, exceptionPath)
-        );
-        const hasValidExceptionPaths = absoluteExceptionPaths
-          .every((absoluteExceptionPath) => isValidExceptionPath(absoluteFrom, absoluteExceptionPath));
+        const { hasValidExceptionPaths, absoluteExceptionPaths } = zoneExceptions[index];
 
         if (!hasValidExceptionPaths) {
           reportInvalidExceptionPath(node);


### PR DESCRIPTION
**Main changes**
Move exceptions paths resolution and validation to rule create phase. 

**Background**
There was a performance downgrade if `zone` had `except` option defined. On every import every relative exception path had to be resolved to absolute path and validated. See a corresponding issue https://github.com/benmosher/eslint-plugin-import/issues/1758

**Results**
On our SPA we have a lot of zones with exceptions. It turned out that this simple change gives us almost 10 times better performance. Measured with `TIMING=1 eslint` on our project.

Before:
```
Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
import/no-restricted-paths              | 94633.358 |    72.2%
@typescript-eslint/no-floating-promises | 18576.419 |    14.2%
react/no-multi-comp                     |  4629.594 |     3.5%
@typescript-eslint/no-redeclare         |  2634.454 |     2.0%
lodash/callback-binding                 |  1272.849 |     1.0%
@typescript-eslint/naming-convention    |  1209.871 |     0.9%
lodash/collection-return                |   885.415 |     0.7%
lodash/no-unbound-this                  |   669.923 |     0.5%
lodash/collection-method-value          |   668.716 |     0.5%
lodash/no-extra-args                    |   569.119 |     0.4%

```
After:
```
Rule                                    | Time (ms) | Relative
:---------------------------------------|----------:|--------:
@typescript-eslint/no-floating-promises | 18438.043 |    40.6%
import/no-restricted-paths              |  8910.373 |    19.6%
react/no-multi-comp                     |  4617.370 |    10.2%
@typescript-eslint/no-redeclare         |  2697.734 |     5.9%
lodash/callback-binding                 |  1282.186 |     2.8%
@typescript-eslint/naming-convention    |  1177.818 |     2.6%
lodash/collection-return                |   885.509 |     1.9%
lodash/collection-method-value          |   727.829 |     1.6%
lodash/no-unbound-this                  |   681.466 |     1.5%
lodash/no-extra-args                    |   606.288 |     1.3%

```