### PR TITLE
[resolvers/webpack] [New] add support for webpack 5 'externals function'

### DIFF
--- a/resolvers/webpack/.eslintrc
+++ b/resolvers/webpack/.eslintrc
@@ -3,4 +3,7 @@
     "import/no-extraneous-dependencies": 1,
     "no-console": 1,
   },
+  "env": {
+    "es6": true,
+  },
 }

--- a/resolvers/webpack/CHANGELOG.md
+++ b/resolvers/webpack/CHANGELOG.md
@@ -5,8 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Added
+- add support for webpack5 'externals function' ([#2023], thanks [@jet2jet])
+
 ### Changed
- - Add warning about async Webpack configs ([#1962], thanks [@ogonkov])
+- Add warning about async Webpack configs ([#1962], thanks [@ogonkov])
 - Replace node-libs-browser with is-core-module ([#1967], thanks [@andersk])
 
 ## 0.13.0 - 2020-09-27
@@ -141,6 +144,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - `interpret` configs (such as `.babel.js`).
   Thanks to [@gausie] for the initial PR ([#164], ages ago! 😅) and [@jquense] for tests ([#278]).
 
+[#2023]: https://github.com/benmosher/eslint-plugin-import/pull/2023
 [#1967]: https://github.com/benmosher/eslint-plugin-import/pull/1967
 [#1962]: https://github.com/benmosher/eslint-plugin-import/pull/1962
 [#1705]: https://github.com/benmosher/eslint-plugin-import/pull/1705
@@ -201,3 +205,4 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 [@opichals]: https://github.com/opichals
 [@andersk]: https://github.com/andersk
 [@ogonkov]: https://github.com/ogonkov
+[@jet2jet]: https://github.com/jet2jet

--- a/resolvers/webpack/test/externals.js
+++ b/resolvers/webpack/test/externals.js
@@ -9,6 +9,13 @@ const webpack = require('../index');
 const file = path.join(__dirname, 'files', 'dummy.js');
 
 describe('externals', function () {
+  const settingsWebpack5 = {
+    config: require(path.join(__dirname, './files/webpack.config.webpack5.js')),
+  };
+  const settingsWebpack5Async = {
+    config: require(path.join(__dirname, './files/webpack.config.webpack5.async-externals.js')),
+  };
+
   it('works on just a string', function () {
     const resolved = webpack.resolve('bootstrap', file);
     expect(resolved).to.have.property('found', true);
@@ -31,5 +38,27 @@ describe('externals', function () {
     const resolved = webpack.resolve('fs', file);
     expect(resolved).to.have.property('found', true);
     expect(resolved).to.have.property('path', null);
+  });
+
+  it('works on a function (synchronous) for webpack 5', function () {
+    const resolved = webpack.resolve('underscore', file, settingsWebpack5);
+    expect(resolved).to.have.property('found', true);
+    expect(resolved).to.have.property('path', null);
+  });
+
+  it('works on a function (synchronous) which uses getResolve for webpack 5', function () {
+    const resolved = webpack.resolve('graphql', file, settingsWebpack5);
+    expect(resolved).to.have.property('found', true);
+    expect(resolved).to.have.property('path', null);
+  });
+
+  it('prevents using an asynchronous function for webpack 5', function () {
+    const resolved = webpack.resolve('underscore', file, settingsWebpack5Async);
+    expect(resolved).to.have.property('found', false);
+  });
+
+  it('prevents using a function which uses Promise returned by getResolve for webpack 5', function () {
+    const resolved = webpack.resolve('graphql', file, settingsWebpack5Async);
+    expect(resolved).to.have.property('found', false);
   });
 });

--- a/resolvers/webpack/test/files/webpack.config.webpack5.async-externals.js
+++ b/resolvers/webpack/test/files/webpack.config.webpack5.async-externals.js
@@ -1,0 +1,21 @@
+module.exports = {
+  externals: [
+    { 'jquery': 'jQuery' },
+    'bootstrap',
+    async function ({ request },) {
+      if (request === 'underscore') {
+        return 'underscore'
+      }
+    },
+    function ({ request, getResolve }, callback) {
+      if (request === 'graphql') {
+        const resolve = getResolve()
+        // dummy call (some-module should be resolved on __dirname)
+        resolve(__dirname, 'some-module').then(
+          function () { callback(null, 'graphql') },
+          function (e) { callback(e) }
+        )
+      }
+    },
+  ],
+}

--- a/resolvers/webpack/test/files/webpack.config.webpack5.js
+++ b/resolvers/webpack/test/files/webpack.config.webpack5.js
@@ -1,0 +1,27 @@
+module.exports = {
+  externals: [
+    { 'jquery': 'jQuery' },
+    'bootstrap',
+    function ({ request }, callback) {
+      if (request === 'underscore') {
+        return callback(null, 'underscore')
+      }
+      callback()
+    },
+    function ({ request, getResolve }, callback) {
+      if (request === 'graphql') {
+        const resolve = getResolve()
+        // dummy call (some-module should be resolved on __dirname)
+        resolve(__dirname, 'some-module', function (err, value) {
+          if (err) {
+            callback(err)
+          } else {
+            callback(null, 'graphql')
+          }
+        })
+      } else {
+        callback()
+      }
+    },
+  ],
+}


### PR DESCRIPTION
This PR allows functions for resolving externals for both webpack 5 and prior to webpack 5 (issue: #1966 )

- To handle configs for both webpack 5 and priors, this PR [checks `externals.length` as webpack does](https://github.com/webpack/webpack/blob/v5.30.0/lib/ExternalModuleFactoryPlugin.js#L166).
- In webpack 5.15, `getResolve` function is added to the object in the first argument, so this PR provides a very simple `getResolve` implementation (using the return value of `getResolveSync`).
- In this PR async 'external functions' are still not supported (as async webpack config not supported; related: #1962)
  - [synchronized-promise](https://www.npmjs.com/package/synchronized-promise) might be usable to resolve this, but I haven't tried yet. (If it is OK, I'll try to add using synchronized-promise into this PR or another.)