### PR TITLE
feat: add ignore option to extraneous deps

### DIFF
--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -126,7 +126,7 @@ function getModuleRealName(resolved) {
   return getFilePackageName(resolved);
 }
 
-function reportIfMissing(context, deps, depsOptions, node, name) {
+function reportIfMissing(context, deps, depsOptions, node, name, ignore) {
   // Do not report when importing types
   if (node.importKind === 'type' || (node.parent && node.parent.importKind === 'type') || node.importKind === 'typeof') {
     return;
@@ -144,6 +144,10 @@ function reportIfMissing(context, deps, depsOptions, node, name) {
   // fallback on original name in case no package.json found
   const packageName = getModuleRealName(resolved) || getModuleOriginalName(name);
 
+  if (packageName.match(ignore)) {
+    return;
+  }
+  
   const isInDeps = deps.dependencies[packageName] !== undefined;
   const isInDevDeps = deps.devDependencies[packageName] !== undefined;
   const isInOptDeps = deps.optionalDependencies[packageName] !== undefined;
@@ -200,6 +204,7 @@ module.exports = {
           'peerDependencies': { 'type': ['boolean', 'array'] },
           'bundledDependencies': { 'type': ['boolean', 'array'] },
           'packageDir': { 'type': ['string', 'array'] },
+          'ignore': { 'type': 'regexp' },
         },
         'additionalProperties': false,
       },
@@ -219,7 +224,7 @@ module.exports = {
     };
 
     return moduleVisitor((source, node) => {
-      reportIfMissing(context, deps, depsOptions, node, source.value);
+      reportIfMissing(context, deps, depsOptions, node, source.value, options.ignore);
     }, { commonjs: true });
   },
 };


### PR DESCRIPTION
We are doing a migration with 1st party dependencies in a monorepo that requires this ability, otherwise we get false positives. This option allows the user to pass a regex so that if a package matches the regex it won't report as an offender.