### PR TITLE
Proposal: (no-unused-modules) Restrict report to the identifier on named exports.

### DIFF
--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -77,10 +77,10 @@ function forEachDeclarationIdentifier(declaration, cb) {
       declaration.type === TS_TYPE_ALIAS_DECLARATION ||
       declaration.type === TS_ENUM_DECLARATION
     ) {
-      cb(declaration.id.name);
+      cb(declaration.id.name, declaration.id.loc);
     } else if (declaration.type === VARIABLE_DECLARATION) {
       declaration.declarations.forEach(({ id }) => {
-        cb(id.name);
+        cb(id.name, id.loc);
       });
     }
   }
@@ -479,7 +479,7 @@ module.exports = {
       exportCount.set(IMPORT_NAMESPACE_SPECIFIER, namespaceImports);
     };
 
-    const checkUsage = (node, exportedValue) => {
+    const checkUsage = (node, exportedValue, loc) => {
       if (!unusedExports) {
         return;
       }
@@ -532,16 +532,18 @@ module.exports = {
 
       if (typeof exportStatement !== 'undefined'){
         if (exportStatement.whereUsed.size < 1) {
-          context.report(
+          context.report({
             node,
-            `exported declaration '${value}' not used within other modules`
-          );
+            loc,
+            message: `exported declaration '${value}' not used within other modules`,
+          });
         }
       } else {
-        context.report(
+        context.report({
           node,
-          `exported declaration '${value}' not used within other modules`
-        );
+          loc,
+          message: `exported declaration '${value}' not used within other modules`,
+        });
       }
     };
 
@@ -890,10 +892,10 @@ module.exports = {
       },
       'ExportNamedDeclaration': node => {
         node.specifiers.forEach(specifier => {
-          checkUsage(node, specifier.exported.name);
+          checkUsage(node, specifier.exported.name, specifier.loc);
         });
-        forEachDeclarationIdentifier(node.declaration, (name) => {
-          checkUsage(node, name);
+        forEachDeclarationIdentifier(node.declaration, (name, loc) => {
+          checkUsage(node, name, loc);
         });
       },
     };


### PR DESCRIPTION
First of all thanks for the tool. I would like to propose a change in the reporting behavior for the rule no-unused-modules:

Currently the rule "flags" all the ExportNamedDeclaration body for unused exports, but when using tools like vscode-eslint the editor gets pretty convoluted with all lines being painted when you are working on a new exported function. This behavior also creates a misleading situation when exporting multiple variables within a unique export keyword, if one of the variables is unused, all the variables in the block gets flagged.

The new behavior is consistent with rules like "@typescript-eslint/no-unused-vars" where only the identifier is flagged if the variable is unused. I attached 2 images showing the current and the new behavior on my IDE.

![no_unused_modules_current_behavior](https://user-images.githubusercontent.com/9766675/116802673-0736cb00-aaeb-11eb-878e-8e993450a6e3.png)

![no_unused_modules_new_behavior](https://user-images.githubusercontent.com/9766675/116802675-0c941580-aaeb-11eb-81fa-14fe0b07e81f.png)
