### PR TITLE
Fix a couple of `no-cycle` bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - [`no-restricted-paths`]: fix false positive matches ([#2090], thanks [@malykhinvi])
+- [`no-cycle`]: ignore imports where imported file only imports types of importing file ([#2083], thanks [@cherryblossom000])
 
 ### Changed
 - [Docs] Add `no-relative-packages` to list of to the list of rules ([#2075], thanks [@arvigeus])
@@ -790,6 +791,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#2090]: https://github.com/benmosher/eslint-plugin-import/pull/2090
+[#2083]: https://github.com/benmosher/eslint-plugin-import/pull/2083
 [#2075]: https://github.com/benmosher/eslint-plugin-import/pull/2075
 [#2071]: https://github.com/benmosher/eslint-plugin-import/pull/2071
 [#2034]: https://github.com/benmosher/eslint-plugin-import/pull/2034

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - [`no-restricted-paths`]: fix false positive matches ([#2090], thanks [@malykhinvi])
 - [`no-cycle`]: ignore imports where imported file only imports types of importing file ([#2083], thanks [@cherryblossom000])
+- [`no-cycle`]: fix false negative when file imports a type after importing a value in Flow ([#2083], thanks [@cherryblossom000])
 
 ### Changed
 - [Docs] Add `no-relative-packages` to list of to the list of rules ([#2075], thanks [@arvigeus])

--- a/tests/files/cycles/flow-types-only-importing-multiple-types.js
+++ b/tests/files/cycles/flow-types-only-importing-multiple-types.js
@@ -1,0 +1,3 @@
+// @flow
+
+import { type FooType, type BarType } from './depth-zero';

--- a/tests/files/cycles/flow-types-only-importing-type.js
+++ b/tests/files/cycles/flow-types-only-importing-type.js
@@ -1,0 +1,3 @@
+// @flow
+
+import type { FooType } from './depth-zero';

--- a/tests/files/cycles/flow-types-some-type-imports.js
+++ b/tests/files/cycles/flow-types-some-type-imports.js
@@ -1,0 +1,3 @@
+// @flow
+
+import { foo, type BarType } from './depth-zero'

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -73,6 +73,14 @@ ruleTester.run('no-cycle', rule, {
       code: 'import { bar } from "./flow-types"',
       parser: require.resolve('babel-eslint'),
     }),
+    test({
+      code: 'import { bar } from "./flow-types-only-importing-type"',
+      parser: require.resolve('babel-eslint'),
+    }),
+    test({
+      code: 'import { bar } from "./flow-types-only-importing-multiple-types"',
+      parser: require.resolve('babel-eslint'),
+    }),
   ],
   invalid: [
     test({

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -88,6 +88,11 @@ ruleTester.run('no-cycle', rule, {
       errors: [error(`Dependency cycle detected.`)],
     }),
     test({
+      code: 'import { bar } from "./flow-types-some-type-imports"',
+      parser: require.resolve('babel-eslint'),
+      errors: [error(`Dependency cycle detected.`)],
+    }),
+    test({
       code: 'import { foo } from "cycles/external/depth-one"',
       errors: [error(`Dependency cycle detected.`)],
       settings: {


### PR DESCRIPTION
This fixes these two bugs:

```ts
// a.ts
// false positive: reports a cycle even though b.ts is only importing types
import { foo } from './b'

// b.ts
import type { Bar } from './a'
```

```js
// a.js
// @flow
// false negative: doesn't report a cycle even though b.js is importing the value bar
import { foo } from './b'

// b.js
// @flow
import { bar, type Baz } from './a'
```

There isn't an open issue for these, but these issues were relatively quick and easy for me to fix so I don't really mind if this PR gets rejected. Also, these bugs were introduced by me in #1974 (oops), so I wanted to fix them.

If you would like me to split these two bug fixes into two PRs, I'm more than happy to do that as well.