### PR TITLE
Match against "pattern*" as RegExp

### DIFF
--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -87,7 +87,12 @@ function relative(modulePath, sourceFile, settings) {
 function fullResolve(modulePath, sourceFile, settings) {
   // check if this is a bonus core module
   const coreSet = new Set(settings['import/core-modules']);
-  if (coreSet.has(modulePath)) return { found: true, path: null };
+  if (coreSet.some(c => {
+    const regex = new RegExp(`^${c.slice(-1) === '*' ? c.replaceFirst('.$', '.*') : c}$`);
+    return regex.test(modulePath);
+  })) {
+    return { found: true, path: null };
+  }
 
   const sourceDir = path.dirname(sourceFile);
   const cacheKey = sourceDir + hashObject(settings).digest('hex') + modulePath;


### PR DESCRIPTION
RE: https://github.com/benmosher/eslint-plugin-import/issues/1281#issuecomment-461200205

We want to allow people to use a wildcard string in their core-modules settings.

This will convert "pattern*" into `RegExp('^pattern.*$')` while also still enforcing a direct match on core-module strings that do not have the wildcard.

Per the issue thread, the allowable scenario was that the string ends in a wildcard, and nothing else.