### PR TITLE
[Fix] `no-restricted-paths`: false-positive matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+### Fixed
+- [`no-restricted-paths`]: fix false positive matches ([#2090], thanks [@malykhinvi])
+
 ### Changed
 - [Docs] Add `no-relative-packages` to list of to the list of rules ([#2075], thanks [@arvigeus])
 
@@ -786,6 +789,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2090]: https://github.com/benmosher/eslint-plugin-import/pull/2090
 [#2075]: https://github.com/benmosher/eslint-plugin-import/pull/2075
 [#2071]: https://github.com/benmosher/eslint-plugin-import/pull/2071
 [#2034]: https://github.com/benmosher/eslint-plugin-import/pull/2034
@@ -1238,7 +1242,6 @@ for info on changes for earlier releases.
 [@wtgtybhertgeghgtwtg]: https://github.com/wtgtybhertgeghgtwtg
 [@duncanbeevers]: https://github.com/duncanbeevers
 [@giodamelio]: https://github.com/giodamelio
-[@ntdb]: https://github.com/ntdb
 [@ramasilveyra]: https://github.com/ramasilveyra
 [@sompylasar]: https://github.com/sompylasar
 [@kevin940726]: https://github.com/kevin940726

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
   "dependencies": {
     "array-includes": "^3.1.3",
     "array.prototype.flat": "^1.2.4",
-    "contains-path": "^1.0.0",
     "debug": "^2.6.9",
     "doctrine": "^2.1.0",
     "eslint-import-resolver-node": "^0.3.4",

--- a/src/rules/no-restricted-paths.js
+++ b/src/rules/no-restricted-paths.js
@@ -1,10 +1,14 @@
-import containsPath from 'contains-path';
 import path from 'path';
 
 import resolve from 'eslint-module-utils/resolve';
 import moduleVisitor from 'eslint-module-utils/moduleVisitor';
 import docsUrl from '../docsUrl';
 import importType from '../core/importType';
+
+const containsPath = (filepath, target) => {
+  const relative = path.relative(target, filepath);
+  return relative === '' || !relative.startsWith('..');
+};
 
 module.exports = {
   meta: {

--- a/tests/src/rules/no-restricted-paths.js
+++ b/tests/src/rules/no-restricted-paths.js
@@ -50,6 +50,17 @@ ruleTester.run('no-restricted-paths', rule, {
         } ],
       } ],
     }),
+    test({
+      code: 'import a from "../one/a.js"',
+      filename: testFilePath('./restricted-paths/server/two-new/a.js'),
+      options: [ {
+        zones: [ {
+          target: './tests/files/restricted-paths/server/two',
+          from: './tests/files/restricted-paths/server',
+          except: [],
+        } ],
+      } ],
+    }),
 
 
     // irrelevant function calls


### PR DESCRIPTION
Fixes #2089

In this PR I removed `contains-paths` dependency and used node's `path.relative` to identify if a file is inside the `target`. I used an approach similar to the one used in `src/core/importType`
