### PR TITLE
no-unused-modules: support dynamic imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Added
 - [`no-unused-modules`]: consider exported TypeScript interfaces, types and enums ([#1819], thanks [@nicolashenry])
 - [`no-cycle`]: allow `maxDepth` option to be `"∞"` (thanks [@ljharb])
+- [`no-unused-modules`]: support dynamic imports ([#1660], thanks [@maxkomarychev])
 
 ### Fixed
 - [`order`]/TypeScript: properly support `import = object` expressions ([#1823], thanks [@manuth])
@@ -55,6 +56,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [2.21.0] - 2020-06-07
 ### Added
+
 - [`import/default`]: support default export in TSExportAssignment ([#1528], thanks [@joaovieira])
 - [`no-cycle`]: add `ignoreExternal` option ([#1681], thanks [@sveyret])
 - [`order`]: Add support for TypeScript's "import equals"-expressions ([#1785], thanks [@manuth])

--- a/docs/rules/no-unused-modules.md
+++ b/docs/rules/no-unused-modules.md
@@ -3,8 +3,8 @@
 Reports:
   - modules without any exports
   - individual exports not being statically `import`ed or `require`ed from other modules in the same project
+  - dynamic imports are supported if argument is a literal string
 
-Note: dynamic imports are currently not supported.
 
 ## Rule Details
 

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -7,6 +7,7 @@ import debug from 'debug'
 import { SourceCode } from 'eslint'
 
 import parse from 'eslint-module-utils/parse'
+import visit from 'eslint-module-utils/visit'
 import resolve from 'eslint-module-utils/resolve'
 import isIgnored, { hasValidExtension } from 'eslint-module-utils/ignore'
 
@@ -350,14 +351,51 @@ ExportMap.parse = function (path, content, context) {
   var m = new ExportMap(path)
 
   try {
-    var ast = parse(path, content, context)
+    var { ast, visitorKeys } = parse(path, content, context)
   } catch (err) {
-    log('parse error:', path, err)
     m.errors.push(err)
     return m // can't continue
   }
 
-  if (!unambiguous.isModule(ast)) return null
+  m.visitorKeys = visitorKeys
+
+  let hasDynamicImports = false
+
+  function processDynamicImport(source) {
+    hasDynamicImports = true
+    if (source.type !== 'Literal') {
+      return null
+    }
+    const p = remotePath(source.value)
+    if (p == null) {
+      return null
+    }
+    const importedSpecifiers = new Set()
+    importedSpecifiers.add('ImportNamespaceSpecifier')
+    const getter = thunkFor(p, context)
+    m.imports.set(p, {
+      getter,
+      source: {
+        // capturing actual node reference holds full AST in memory!
+        value: source.value,
+        loc: source.loc,
+      },
+      importedSpecifiers,
+    })
+  }
+
+  visit(ast, visitorKeys, {
+    ImportExpression(node) {
+      processDynamicImport(node.source)
+    },
+    CallExpression(node) {
+      if (node.callee.type === 'Import') {
+        processDynamicImport(node.arguments[0])
+      }
+    },
+  })
+
+  if (!unambiguous.isModule(ast) && !hasDynamicImports) return null
 
   const docstyle = (context.settings && context.settings['import/docstyle']) || ['jsdoc']
   const docStyleParsers = {}

--- a/tests/files/no-unused-modules/dynamic-import-js-2.js
+++ b/tests/files/no-unused-modules/dynamic-import-js-2.js
@@ -1,0 +1,13 @@
+const importPath = './exports-for-dynamic-js';
+class A {
+    method() {
+        const c = import(importPath)
+    }
+}
+
+
+class B {
+    method() {
+        const c = import('i-do-not-exist')
+    }
+}

--- a/tests/files/no-unused-modules/dynamic-import-js.js
+++ b/tests/files/no-unused-modules/dynamic-import-js.js
@@ -1,0 +1,5 @@
+class A {
+    method() {
+        const c = import('./exports-for-dynamic-js')
+    }
+}

--- a/tests/files/no-unused-modules/exports-for-dynamic-js-2.js
+++ b/tests/files/no-unused-modules/exports-for-dynamic-js-2.js
@@ -1,0 +1,5 @@
+export const a = 10;
+export const b = 20;
+export const c = 30;
+const d = 40;
+export default d;

--- a/tests/files/no-unused-modules/exports-for-dynamic-js.js
+++ b/tests/files/no-unused-modules/exports-for-dynamic-js.js
@@ -1,0 +1,5 @@
+export const a = 10
+export const b = 20
+export const c = 30
+const d = 40
+export default d

--- a/tests/files/no-unused-modules/typescript/dynamic-import-ts.ts
+++ b/tests/files/no-unused-modules/typescript/dynamic-import-ts.ts
@@ -1,0 +1,6 @@
+class A {
+    method() {
+        const c = import('./exports-for-dynamic-ts')
+    }
+}
+

--- a/tests/files/no-unused-modules/typescript/exports-for-dynamic-ts.ts
+++ b/tests/files/no-unused-modules/typescript/exports-for-dynamic-ts.ts
@@ -1,0 +1,5 @@
+export const ts_a = 10
+export const ts_b = 20
+export const ts_c = 30
+const ts_d = 40
+export default ts_d

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -1,6 +1,8 @@
 import { test, testFilePath, getTSParsers } from '../utils'
 import jsxConfig from '../../../config/react'
 import typescriptConfig from '../../../config/typescript'
+import eslintPkg from 'eslint/package.json'
+import semver from 'semver'
 
 import { RuleTester } from 'eslint'
 import fs from 'fs'
@@ -103,32 +105,39 @@ ruleTester.run('no-unused-modules', rule, {
 // tests for  exports
 ruleTester.run('no-unused-modules', rule, {
   valid: [
-
     test({ options: unusedExportsOptions,
            code: 'import { o2 } from "./file-o";export default () => 12',
-           filename: testFilePath('./no-unused-modules/file-a.js')}),
+           filename: testFilePath('./no-unused-modules/file-a.js'),
+           parser: require.resolve('babel-eslint')}),
     test({ options: unusedExportsOptions,
            code: 'export const b = 2',
-           filename: testFilePath('./no-unused-modules/file-b.js')}),
+           filename: testFilePath('./no-unused-modules/file-b.js'),
+           parser: require.resolve('babel-eslint')}),
     test({ options: unusedExportsOptions,
            code: 'const c1 = 3; function c2() { return 3 }; export { c1, c2 }',
-           filename: testFilePath('./no-unused-modules/file-c.js')}),
+           filename: testFilePath('./no-unused-modules/file-c.js'),
+           parser: require.resolve('babel-eslint')}),
     test({ options: unusedExportsOptions,
            code: 'export function d() { return 4 }',
-           filename: testFilePath('./no-unused-modules/file-d.js')}),
+           filename: testFilePath('./no-unused-modules/file-d.js'),
+           parser: require.resolve('babel-eslint')}),
     test({ options: unusedExportsOptions,
            code: 'export class q { q0() {} }',
-           filename: testFilePath('./no-unused-modules/file-q.js')}),
+           filename: testFilePath('./no-unused-modules/file-q.js'),
+           parser: require.resolve('babel-eslint')}),
     test({ options: unusedExportsOptions,
            code: 'const e0 = 5; export { e0 as e }',
-           filename: testFilePath('./no-unused-modules/file-e.js')}),
+           filename: testFilePath('./no-unused-modules/file-e.js'),
+           parser: require.resolve('babel-eslint')}),
     test({ options: unusedExportsOptions,
            code: 'const l0 = 5; const l = 10; export { l0 as l1, l }; export default () => {}',
-           filename: testFilePath('./no-unused-modules/file-l.js')}),
+           filename: testFilePath('./no-unused-modules/file-l.js'),
+           parser: require.resolve('babel-eslint')}),
     test({ options: unusedExportsOptions,
            code: 'const o0 = 0; const o1 = 1; export { o0, o1 as o2 }; export default () => {}',
-           filename: testFilePath('./no-unused-modules/file-o.js')}),
-    ],
+           filename: testFilePath('./no-unused-modules/file-o.js'),
+           parser: require.resolve('babel-eslint')}),
+  ],
   invalid: [
     test({ options: unusedExportsOptions,
            code: `import eslint from 'eslint'
@@ -194,6 +203,64 @@ ruleTester.run('no-unused-modules', rule, {
            filename: testFilePath('./no-unused-modules/file-k.js'),
            errors: [error(`exported declaration 'k' not used within other modules`)]}),
   ],
+})
+
+
+describe('dynamic imports', () => { 
+  if (semver.satisfies(eslintPkg.version, '< 6')) {
+    this.skip()
+    return
+  }
+
+  // test for unused exports with `import()`
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({ options: unusedExportsOptions,
+            code: `
+            export const a = 10
+            export const b = 20
+            export const c = 30
+            const d = 40
+            export default d
+            `,
+            parser: require.resolve('babel-eslint'),
+            filename: testFilePath('./no-unused-modules/exports-for-dynamic-js.js')}),
+    ],
+    invalid: [
+      test({ options: unusedExportsOptions,
+        code: `
+        export const a = 10
+        export const b = 20
+        export const c = 30
+        const d = 40
+        export default d
+        `,
+        parser: require.resolve('babel-eslint'),
+        filename: testFilePath('./no-unused-modules/exports-for-dynamic-js-2.js'),
+        errors: [
+            error(`exported declaration 'a' not used within other modules`),
+            error(`exported declaration 'b' not used within other modules`),
+            error(`exported declaration 'c' not used within other modules`),
+            error(`exported declaration 'default' not used within other modules`),
+        ]}),
+    ],
+  })
+  typescriptRuleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({ options: unusedExportsTypescriptOptions,
+            code: `
+            export const ts_a = 10
+            export const ts_b = 20
+            export const ts_c = 30
+            const ts_d = 40
+            export default ts_d
+            `,
+            parser: require.resolve('@typescript-eslint/parser'),
+            filename: testFilePath('./no-unused-modules/typescript/exports-for-dynamic-ts.ts')}),
+    ],
+    invalid: [
+    ],
+  })
 })
 
 // // test for export from

--- a/utils/unambiguous.js
+++ b/utils/unambiguous.js
@@ -1,8 +1,7 @@
 'use strict'
 exports.__esModule = true
 
-
-const pattern = /(^|;)\s*(export|import)((\s+\w)|(\s*[{*=]))/m
+const pattern = /(^|;)\s*(export|import)((\s+\w)|(\s*[{*=]))|import\(/m
 /**
  * detect possible imports/exports without a full parse.
  *
@@ -26,5 +25,5 @@ const unambiguousNodeType = /^(?:(?:Exp|Imp)ort.*Declaration|TSExportAssignment)
  * @return {Boolean}
  */
 exports.isModule = function isUnambiguousModule(ast) {
-  return ast.body.some(node => unambiguousNodeType.test(node.type))
+  return ast.body && ast.body.some(node => unambiguousNodeType.test(node.type))
 }

--- a/utils/visit.js
+++ b/utils/visit.js
@@ -1,0 +1,24 @@
+'use strict'
+exports.__esModule = true
+
+exports.default = function visit(node, keys, visitorSpec) {
+  if (!node || !keys) {
+    return
+  }
+  const type = node.type
+  if (typeof visitorSpec[type] === 'function') {
+    visitorSpec[type](node)
+  }
+  const childFields = keys[type]
+  if (!childFields) {
+    return
+  }
+  childFields.forEach((fieldName) => {
+    [].concat(node[fieldName]).forEach((item) => {
+      visit(item, keys, visitorSpec)
+    })
+  })
+  if (typeof visitorSpec[`${type}:Exit`] === 'function') {
+    visitorSpec[`${type}:Exit`](node)
+  }
+}


### PR DESCRIPTION
All occurences of `import('...')` are treated as namespace imports
(`import * as X from '...'`)

Skip tests for lower versions of eslint

Use strict

Address some review comments

Straighten if-else

Replace loops with foreach

Support newer babel parser

Update updateImportUsage

Support @babel/eslint-parser