### PR TITLE
[Fix] `no-extraneous-dependencies`: fix package name algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-cycle`]: fix false negative when file imports a type after importing a value in Flow ([#2083], thanks [@cherryblossom000])
 - [`order`]: restore default behavior unless `type` is in groups ([#2087], thanks [@grit96])
 - [`no-import-module-exports`]: Don't crash if packages have no entrypoint ([#2099], thanks [@eps1lon])
+- [`no-extraneous-dependencies`]: fix package name algorithm ([#2097], thanks [@paztis])
 
 ### Changed
 - [Docs] Add `no-relative-packages` to list of to the list of rules ([#2075], thanks [@arvigeus])
@@ -796,6 +797,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#2099]: https://github.com/benmosher/eslint-plugin-import/pull/2099
+[#2097]: https://github.com/benmosher/eslint-plugin-import/pull/2097
 [#2090]: https://github.com/benmosher/eslint-plugin-import/pull/2090
 [#2087]: https://github.com/benmosher/eslint-plugin-import/pull/2087
 [#2083]: https://github.com/benmosher/eslint-plugin-import/pull/2083

--- a/tests/files/node_modules/rxjs/index.js
+++ b/tests/files/node_modules/rxjs/index.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/tests/files/node_modules/rxjs/operators/index.js
+++ b/tests/files/node_modules/rxjs/operators/index.js
@@ -1,0 +1,1 @@
+export default function () {}

--- a/tests/files/node_modules/rxjs/operators/package.json
+++ b/tests/files/node_modules/rxjs/operators/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "rxjs/operators",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/files/node_modules/rxjs/package.json
+++ b/tests/files/node_modules/rxjs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "rxjs",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/tests/files/package.json
+++ b/tests/files/package.json
@@ -11,7 +11,8 @@
     "@org/package": "^1.0.0",
     "jquery": "^3.1.0",
     "lodash.cond": "^4.3.0",
-    "pkg-up": "^1.0.0"
+    "pkg-up": "^1.0.0",
+    "rxjs": "^1.0.0"
   },
   "optionalDependencies": {
     "lodash.isarray": "^4.0.0"

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -88,7 +88,7 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: `
-        // @flow                                                                                                                                                                                                   
+        // @flow
         import typeof TypeScriptModule from 'typescript';
       `,
       options: [{ packageDir: packageDirWithFlowTyped }],
@@ -149,6 +149,10 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'import "@generated/bar/and/sub/path"',
       settings: { 'import/core-modules': ['@generated/bar'] },
+    }),
+    // check if "rxjs" dependency declaration fix the "rxjs/operators subpackage
+    test({
+      code: 'import "rxjs/operators"',
     }),
   ],
   invalid: [


### PR DESCRIPTION
- resolve nested package.json problems (a/b/c import will check a, a/b and a/b/c)
- resolve renamed dependencies: checks the import name and the resolve package name

Fixes #2066. Fixes #2065. Fixes #2058. Fixes #2078.