### PR TITLE
[Fix] Process halts when body is undefined. 

### DIFF
--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -78,7 +78,7 @@ module.exports = {
             }
           }
         }
-        body.forEach(processBodyStatement);
+        if (body) body.forEach(processBodyStatement);
       },
 
       // same as above, but does not add names to local map


### PR DESCRIPTION
The change will do a null check on the `body` variable before calling `body.forEach()`