### PR TITLE
Update tests to illustrate `pathGroupsExcludedImportTypes: ['type']`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Changed
 - [Docs] `extensions`: removed incorrect cases ([#2138], thanks [@wenfangdu])
+- [Tests] `order`: add tests for `pathGroupsExcludedImportTypes: ['type']` ([#2158], thanks [@atav32])
 
 ## [2.23.4] - 2021-05-29
 
@@ -808,6 +809,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2158]: https://github.com/benmosher/eslint-plugin-import/pull/2158
 [#2138]: https://github.com/benmosher/eslint-plugin-import/pull/2138
 [#2121]: https://github.com/benmosher/eslint-plugin-import/pull/2121
 [#2099]: https://github.com/benmosher/eslint-plugin-import/pull/2099
@@ -1250,6 +1252,7 @@ for info on changes for earlier releases.
 [@arvigeus]: https://github.com/arvigeus
 [@asapach]: https://github.com/asapach
 [@astorije]: https://github.com/astorije
+[@atav32]: https://github.com/atav32
 [@atikenny]: https://github.com/atikenny
 [@atos1990]: https://github.com/atos1990
 [@barbogast]: https://github.com/barbogast

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -745,6 +745,36 @@ ruleTester.run('order', rule, {
         'newlines-between': 'always',
       }],
     }),
+    test({
+      code: `
+        import { ReactElement, ReactNode } from 'react';
+
+        import { util } from 'Internal/lib';
+
+        import { parent } from '../parent';
+
+        import { sibling } from './sibling';
+      `,
+      options: [{
+        alphabetize: {
+          caseInsensitive: true,
+          order: 'asc',
+        },
+        pathGroups: [
+          { pattern: 'Internal/**/*', group: 'internal' },
+        ],
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
+        'newlines-between': 'always',
+        pathGroupsExcludedImportTypes: [],
+      }],
+    }),
     ...flatMap(getTSParsers, parser => [
       // Order of the `import ... = require(...)` syntax
       test({
@@ -2329,6 +2359,71 @@ context('TypeScript', function () {
                 {
                   groups: ['external', 'index', 'type'],
                   alphabetize: { order: 'asc' },
+                },
+              ],
+            },
+            parserConfig,
+          ),
+          // Option alphabetize: {order: 'asc'} with type group & path group
+          test(
+            {
+              // only: true,
+              code: `
+                import c from 'Bar';
+                import a from 'foo';
+
+                import b from 'dirA/bar';
+
+                import index from './';
+
+                import type { C } from 'dirA/Bar';
+                import type { A } from 'foo';
+              `,
+              parser,
+              options: [
+                {
+                  alphabetize: { order: 'asc' },
+                  groups: ['external', 'internal', 'index', 'type'],
+                  pathGroups: [
+                    {
+                      pattern: 'dirA/**',
+                      group: 'internal',
+                    },
+                  ],
+                  'newlines-between': 'always',
+                  pathGroupsExcludedImportTypes: ['type'],
+                },
+              ],
+            },
+            parserConfig,
+          ),
+          // Option alphabetize: {order: 'asc'} with path group
+          test(
+            {
+              // only: true,
+              code: `
+                import c from 'Bar';
+                import type { A } from 'foo';
+                import a from 'foo';
+
+                import type { C } from 'dirA/Bar';
+                import b from 'dirA/bar';
+
+                import index from './';
+              `,
+              parser,
+              options: [
+                {
+                  alphabetize: { order: 'asc' },
+                  groups: ['external', 'internal', 'index'],
+                  pathGroups: [
+                    {
+                      pattern: 'dirA/**',
+                      group: 'internal',
+                    },
+                  ],
+                  'newlines-between': 'always',
+                  pathGroupsExcludedImportTypes: [],
                 },
               ],
             },


### PR DESCRIPTION
Issue: https://github.com/benmosher/eslint-plugin-import/issues/2159