### PR TITLE
import/extensions: Reverse logic of `ignorePackages` with `never`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-unused-modules`]: add eslint v8 support ([#2194], thanks [@coderaiser])
 - [`no-restricted-paths`]: add/restore glob pattern support ([#2219], thanks [@stropho])
 - [`no-unused-modules`]: support dynamic imports ([#1660], [#2212], thanks [@maxkomarychev], [@aladdin-add], [@Hypnosphi])
+- [`import/extensions`]: revert `ignorePackages` with `never` ([#2231], thanks [@Drafter500])
 
 ## [2.24.2] - 2021-08-24
 
@@ -906,6 +907,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2231]: https://github.com/import-js/eslint-plugin-import/pull/2231
 [#2219]: https://github.com/import-js/eslint-plugin-import/pull/2219
 [#2212]: https://github.com/import-js/eslint-plugin-import/pull/2212
 [#2196]: https://github.com/import-js/eslint-plugin-import/pull/2196
@@ -1402,6 +1404,7 @@ for info on changes for earlier releases.
 [@dbrewer5]: https://github.com/dbrewer5
 [@devongovett]: https://github.com/devongovett
 [@dmnd]: https://github.com/dmnd
+[@Drafter500]: https://github.com/Drafter500
 [@duncanbeevers]: https://github.com/duncanbeevers
 [@dwardu]: https://github.com/dwardu
 [@echenley]: https://github.com/echenley

--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -194,7 +194,7 @@ import Component from './Component';
 
 import baz from 'package/module-one';
 
-import express from 'package/module-two.js';
+import bizz from 'package/module-two.js';
 ```
 
 ## When Not To Use It

--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -1,12 +1,20 @@
 # import/extensions - Ensure consistent use of file extension within the import path
 
-Some file resolve algorithms allow you to omit the file extension within the import source path. For example the `node` resolver can resolve `./foo/bar` to the absolute path `/User/someone/foo/bar.js` because the `.js` extension is resolved automatically by default. Depending on the resolver you can configure more extensions to get resolved automatically.
+Some file resolve algorithms allow you to omit the file extension within the import source path.
+For example the `node` resolver can resolve `./foo/bar` to the absolute path
+`/User/someone/foo/bar.js` because the `.js` extension is resolved automatically by default.
+Depending on the resolver you can configure more extensions to get resolved automatically.
 
-In order to provide a consistent use of file extensions across your code base, this rule can enforce or disallow the use of certain file extensions.
+In order to provide a consistent use of file extensions across your code base, this rule can
+enforce or disallow the use of certain file extensions.
 
 ## Rule Details
 
-This rule either takes one string option, one object option, or a string and an object option. If it is the string `"never"` (the default value), then the rule forbids the use for any extension. If it is the string `"always"`, then the rule enforces the use of extensions for all import statements. If it is the string `"ignorePackages"`, then the rule enforces the use of extensions for all import statements except package imports.
+This rule either takes one string option, one object option, or a string and an object option.
+If it is the string `"never"` (the default value), then the rule forbids the use for any
+extension. If it is the string `"always"`, then the rule enforces the use of extensions for all
+import statements. If it is the string`"ignorePackages"`, then the rule enforces the use of
+extensions for all import statements except package imports.
 
 ```
 "import/extensions": [<severity>, "never" | "always" | "ignorePackages"]
@@ -20,9 +28,11 @@ By providing an object you can configure each extension separately.
 }]
 ```
 
- For example `{ "js": "always", "json": "never" }` would always enforce the use of the `.js` extension but never allow the use of the `.json` extension.
+ For example `{ "js": "always", "json": "never" }` would always enforce the use of the `.js`
+ extension but never allow the use of the `.json` extension.
 
-By providing both a string and an object, the string will set the default setting for all extensions, and the object can be used to set granular overrides for specific extensions.
+By providing both a string and an object, the string will set the default setting for all
+extensions, and the object can be used to set granular overrides for specific extensions.
 
 ```
 "import/extensions": [
@@ -34,7 +44,8 @@ By providing both a string and an object, the string will set the default settin
 ]
 ```
 
-For example, `["error", "never", { "svg": "always" }]` would require that all extensions are omitted, except for "svg".
+For example, `["error", "never", { "svg": "always" }]` would require that all
+extensions are omitted, except for "svg".
 
 `ignorePackages` can be set as a separate boolean option like this:
 ```
@@ -49,13 +60,20 @@ For example, `["error", "never", { "svg": "always" }]` would require that all ex
   }
 ]
 ```
-In that case, if you still want to specify extensions, you can do so inside the **pattern** property.
+In that case, if you still want to specify extensions, you can do so inside the **pattern**
+property.
 Default value of `ignorePackages` is `false`.
+
+Note that in combination with `never` option
+`ignorePackages` works in reverse manner: it allows extensions in package imports.
+For example `['error', 'never', {ignorePackages: true} ]` will forbid extensions
+everywhere except package imports.
 
 
 ### Exception
 
-When disallowing the use of certain extensions this rule makes an exception and allows the use of extension when the file would not be resolvable without extension.
+When disallowing the use of certain extensions this rule makes an exception and allows the use of
+extension when the file would not be resolvable without extension.
 
 For example, given the following folder structure:
 
@@ -71,11 +89,13 @@ and this import statement:
 import bar from './foo/bar.json';
 ```
 
-then the extension can’t be omitted because it would then resolve to `./foo/bar.js`.
+then the extension can’t be omitted because it would then resolve to
+`./foo/bar.js`.
 
 ### Examples
 
-The following patterns are considered problems when configuration set to "never":
+The following patterns are considered problems when configuration set to
+"never":
 
 ```js
 import foo from './foo.js';
@@ -87,7 +107,8 @@ import Component from './Component.jsx';
 import express from 'express/index.js';
 ```
 
-The following patterns are not considered problems when configuration set to "never":
+The following patterns are **not** considered problems when configuration set
+to "never":
 
 ```js
 import foo from './foo';
@@ -113,7 +134,7 @@ import Component from './Component';
 import foo from '@/foo';
 ```
 
-The following patterns are not considered problems when configuration set to "always":
+The following patterns are **not** considered problems when configuration set to "always":
 
 ```js
 import foo from './foo.js';
@@ -138,7 +159,7 @@ import Component from './Component';
 
 ```
 
-The following patterns are not considered problems when configuration set to "ignorePackages":
+The following patterns are **not** considered problems when configuration set to "ignorePackages":
 
 ```js
 import foo from './foo.js';
@@ -152,7 +173,8 @@ import express from 'express';
 import foo from '@/foo'
 ```
 
-The following patterns are not considered problems when configuration set to `['error', 'always', {ignorePackages: true} ]`:
+The following patterns are **not** considered problems when configuration set to
+`['error', 'always', {ignorePackages: true} ]`:
 
 ```js
 import Component from './Component.jsx';
@@ -162,6 +184,17 @@ import baz from 'foo/baz.js';
 import express from 'express';
 
 import foo from '@/foo';
+```
+
+The following patterns are **not** considered problems when configuration set to
+`['error', 'never', {ignorePackages: true} ]`:
+
+```js
+import Component from './Component';
+
+import baz from 'package/module-one';
+
+import express from 'package/module-two.js';
 ```
 
 ## When Not To Use It

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -115,8 +115,8 @@ module.exports = {
       return getModifier(extension) === 'always' && (!props.ignorePackages || !isPackage);
     }
 
-    function isUseOfExtensionForbidden(extension) {
-      return getModifier(extension) === 'never';
+    function isUseOfExtensionForbidden(extension, isPackage) {
+      return getModifier(extension) === 'never' && (!props.ignorePackages || !isPackage);
     }
 
     function isResolvableWithoutExtension(file) {
@@ -138,7 +138,7 @@ module.exports = {
     function checkFileExtension(source) {
       // bail if the declaration doesn't have a source, e.g. "export { foo };", or if it's only partially typed like in an editor
       if (!source || !source.value) return;
-      
+
       const importPathWithQueryString = source.value;
 
       // don't enforce anything on builtins
@@ -166,7 +166,7 @@ module.exports = {
 
       if (!extension || !importPath.endsWith(`.${extension}`)) {
         const extensionRequired = isUseOfExtensionRequired(extension, isPackage);
-        const extensionForbidden = isUseOfExtensionForbidden(extension);
+        const extensionForbidden = isUseOfExtensionForbidden(extension, isPackage);
         if (extensionRequired && !extensionForbidden) {
           context.report({
             node: source,
@@ -175,7 +175,7 @@ module.exports = {
           });
         }
       } else if (extension) {
-        if (isUseOfExtensionForbidden(extension) && isResolvableWithoutExtension(importPath)) {
+        if (isUseOfExtensionForbidden(extension, isPackage) && isResolvableWithoutExtension(importPath)) {
           context.report({
             node: source,
             message: `Unexpected use of file extension "${extension}" for "${importPathWithQueryString}"`,

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -76,6 +76,7 @@ ruleTester.run('extensions', rule, {
         import bar from './bar.json'
         import Component from './Component.jsx'
         import express from 'express'
+        import { ifDefined } from 'lit/directives/if-defined.js'
       `,
       options: [ 'always', { ignorePackages: true } ],
     }),
@@ -86,18 +87,18 @@ ruleTester.run('extensions', rule, {
         import bar from './bar'
         import Component from './Component'
         import express from 'express'
+        import { ifDefined } from 'lit/directives/if-defined.js'
       `,
       options: [ 'never', { ignorePackages: true } ],
     }),
 
     test({
-      code: `
-        import foo from './foo'
-        import bar from './bar'
-        import Component from './Component'
-        import express from 'lit/directives/if-defined.js'
-      `,
-      options: [ 'never', { ignorePackages: true } ],
+      code: [
+        'import bar from "./bar"',
+        'import pack from "./package.json"',
+        'import { ifDefined } from "lit/directives/if-defined.js"',
+      ].join('\n'),
+      options: [ 'ignorePackages', { js: 'never' } ],
     }),
 
     test({
@@ -388,6 +389,27 @@ ruleTester.run('extensions', rule, {
           message: 'Missing file extension for "@/configs/chart"',
           line: 7,
           column: 27,
+        },
+      ],
+    }),
+
+    test({
+      code: [
+        'import bar from "./bar.js"',
+        'import pack from "./package"',
+        'import { ifDefined } from "lit/directives/if-defined.js"',
+      ].join('\n'),
+      options: [ 'ignorePackages', { js: 'never' } ],
+      errors: [
+        {
+          message: 'Unexpected use of file extension "js" for "./bar.js"',
+          line: 1,
+          column: 17,
+        },
+        {
+          message: 'Missing file extension "json" for "./package"',
+          line: 2,
+          column: 18,
         },
       ],
     }),

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -91,6 +91,16 @@ ruleTester.run('extensions', rule, {
     }),
 
     test({
+      code: `
+        import foo from './foo'
+        import bar from './bar'
+        import Component from './Component'
+        import express from 'lit/directives/if-defined.js'
+      `,
+      options: [ 'never', { ignorePackages: true } ],
+    }),
+
+    test({
       code: 'import exceljs from "exceljs"',
       options: [ 'always', { js: 'never', jsx: 'never' } ],
       filename: testFilePath('./internal-modules/plugins/plugin.js'),


### PR DESCRIPTION
`ignorePackages` flag always works in one direction, it only allows skipping extensions in packages in `always` mode (default), but it is impossible to make it reverse: allow having extensions for packages in `never` mode. Currently in combination with `never`, it does nothing. By the name of the flag, I expected it to stop complaining about package imports in any situation. 

For example, with this config:
`['error', 'never', {ignorePackages: true} ]`

It should forbid extensions except for packages:
```js
import Component from './Component'; // OK
import Component from './Component.jsx'; // Not OK
import baz from 'package/module-one'; // OK
import bizz from 'package/module-two.js'; // Should be also OK!!! 
```
