### PR TITLE
[Deps] update eslint-module-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "debug": "^2.6.9",
     "doctrine": "^2.1.0",
     "eslint-import-resolver-node": "^0.3.6",
-    "eslint-module-utils": "^2.6.2",
+    "eslint-module-utils": "^2.7.0",
     "has": "^1.0.3",
     "is-core-module": "^2.7.0",
     "is-glob": "^4.0.3",


### PR DESCRIPTION
Resolves #2255

 ## What was the problem?
 the file eslint-module-utils/visit didn't exist previously
 https://github.com/import-js/eslint-plugin-import/tree/v2.24.2/utils/visit.js
 it only exists in the latest minor version bump
 https://github.com/import-js/eslint-plugin-import/blob/v2.25.0/utils/visit.js