### PR TITLE
[Fix] fixed SyntaxError: Unexpected token ) in parse.js

### DIFF
--- a/utils/.eslintrc
+++ b/utils/.eslintrc
@@ -2,4 +2,14 @@
   "parserOptions": {
     "ecmaVersion": 6,
   },
+  "rules": {
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
+      "functions": "never"
+    }],
+    "no-console": 1,
+  }
 }

--- a/utils/.eslintrc.yml
+++ b/utils/.eslintrc.yml
@@ -1,3 +1,0 @@
----
-rules:
-  no-console: 1

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+ - fixed SyntaxError in node <= 6: Unexpected token ) in parse.js ([#2261], thanks [@VitusFW])
+
 ## v2.7.0 - 2021-10-11
 
 ### Added
@@ -97,6 +100,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#2261]: https://github.com/import-js/eslint-plugin-import/pull/2261
 [#2212]: https://github.com/import-js/eslint-plugin-import/pull/2212
 [#2160]: https://github.com/import-js/eslint-plugin-import/pull/2160
 [#2047]: https://github.com/import-js/eslint-plugin-import/pull/2047
@@ -137,3 +141,4 @@ Yanked due to critical issue with cache key resulting from #839.
 [@sompylasar]: https://github.com/sompylasar
 [@timkraut]: https://github.com/timkraut
 [@vikr01]: https://github.com/vikr01
+[@VitusFW]: https://github.com/VitusFW

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -93,7 +93,7 @@ exports.default = function parse(path, content, context) {
       console.warn(
         '`parseForESLint` from parser `' +
           parserPath +
-          '` is invalid and will just be ignored',
+          '` is invalid and will just be ignored'
       );
     } else {
       return {


### PR DESCRIPTION
There is a typo in parse.js that breaks my build:

[INFO] Module build failed: C:\Development\workspace_rap\frontend_core_BAD\frontend\node_modules\eslint-module-utils\parse.js:97
[INFO]       );
[INFO]       ^
[INFO] SyntaxError: Unexpected token )

There is a trailing comma at the parameters for a console.warn call that results in the syntax error.

Fixes #2262.