### PR TITLE
[Fix] `extensions`: ignore type-only imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+### Fixed
+- [`extensions`]: ignore type-only imports ([#2270], [@jablko])
+
 ## [2.25.2] - 2021-10-12
 
 ### Fixed
@@ -929,6 +932,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2270]: https://github.com/import-js/eslint-plugin-import/pull/2270
 [#2240]: https://github.com/import-js/eslint-plugin-import/pull/2240
 [#2233]: https://github.com/import-js/eslint-plugin-import/pull/2233
 [#2226]: https://github.com/import-js/eslint-plugin-import/pull/2226

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -135,7 +135,12 @@ module.exports = {
       return false;
     }
 
-    function checkFileExtension(source) {
+    function checkFileExtension(source, node) {
+      // ignore type-only imports
+      if (node.importKind === 'type') {
+        return;
+      }
+
       // bail if the declaration doesn't have a source, e.g. "export { foo };", or if it's only partially typed like in an editor
       if (!source || !source.value) return;
       

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -1,6 +1,6 @@
 import { RuleTester } from 'eslint';
 import rule from 'rules/extensions';
-import { test, testFilePath } from '../utils';
+import { getTSParsers, test, testFilePath } from '../utils';
 
 const ruleTester = new RuleTester();
 
@@ -596,4 +596,35 @@ ruleTester.run('extensions', rule, {
       ],
     }),
   ],
+});
+
+describe('TypeScript', () => {
+  getTSParsers()
+    // Type-only imports were added in TypeScript ESTree 2.23.0
+    .filter((parser) => parser !== require.resolve('typescript-eslint-parser'))
+    .forEach((parser) => {
+      ruleTester.run(`${parser}: extensions ignore type-only`, rule, {
+        valid: [
+          test({
+            code: 'import type { T } from "./typescript-declare";',
+            options: [
+              'always',
+              { ts: 'never', tsx: 'never', js: 'never', jsx: 'never' },
+            ],
+            parser,
+          }),
+        ],
+        invalid: [
+          test({
+            code: 'import { T } from "./typescript-declare";',
+            errors: ['Missing file extension for "./typescript-declare"'],
+            options: [
+              'always',
+              { ts: 'never', tsx: 'never', js: 'never', jsx: 'never' },
+            ],
+            parser,
+          }),
+        ],
+      });
+    });
 });


### PR DESCRIPTION
1. Resolving type-only imports is only supported by eslint-import-resolver-typescript
2. `import/extensions` rule currently errors on unresolved imports ([I gather](https://github.com/import-js/eslint-plugin-import/issues/2267#issuecomment-945534912))

&therefore; disable `import/extensions` for type-only imports, along the lines of #2220.

Relates to #2267