### PR TITLE
[Fix] `extensions`: ignore unresolvable type-only imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## [Unreleased]
 
 ### Fixed
-- [`extensions`]: ignore type-only imports ([#2270], [@jablko])
+- [`extensions`]: ignore unresolveable type-only imports ([#2270], [#2271], [@jablko])
 
 ## [2.25.2] - 2021-10-12
 
@@ -932,6 +932,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2271]: https://github.com/import-js/eslint-plugin-import/pull/2271
 [#2270]: https://github.com/import-js/eslint-plugin-import/pull/2270
 [#2240]: https://github.com/import-js/eslint-plugin-import/pull/2240
 [#2233]: https://github.com/import-js/eslint-plugin-import/pull/2233

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -136,11 +136,6 @@ module.exports = {
     }
 
     function checkFileExtension(source, node) {
-      // ignore type-only imports
-      if (node.importKind === 'type') {
-        return;
-      }
-
       // bail if the declaration doesn't have a source, e.g. "export { foo };", or if it's only partially typed like in an editor
       if (!source || !source.value) return;
       
@@ -170,6 +165,8 @@ module.exports = {
       ) || isScoped(importPath);
 
       if (!extension || !importPath.endsWith(`.${extension}`)) {
+        // ignore type-only imports
+        if (node.importKind === 'type') return;
         const extensionRequired = isUseOfExtensionRequired(extension, isPackage);
         const extensionForbidden = isUseOfExtensionForbidden(extension);
         if (extensionRequired && !extensionForbidden) {

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -606,7 +606,7 @@ describe('TypeScript', () => {
       ruleTester.run(`${parser}: extensions ignore type-only`, rule, {
         valid: [
           test({
-            code: 'import type { T } from "./typescript-declare";',
+            code: 'import type T from "./typescript-declare";',
             options: [
               'always',
               { ts: 'never', tsx: 'never', js: 'never', jsx: 'never' },
@@ -616,7 +616,7 @@ describe('TypeScript', () => {
         ],
         invalid: [
           test({
-            code: 'import { T } from "./typescript-declare";',
+            code: 'import T from "./typescript-declare";',
             errors: ['Missing file extension for "./typescript-declare"'],
             options: [
               'always',


### PR DESCRIPTION
Revise #2270: Only ignore *unresolvable* type-only imports. For resolvable type-only imports (if using eslint-import-resolver-typescript, or customizing [import/extensions](https://github.com/import-js/eslint-plugin-import#importextensions)), restore the pre-#2270 behavior.