### PR TITLE
[Fix] add missing optional peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ rules:
 
 You may use the following shortcut or assemble your own config using the granular settings described below.
 
-Make sure you have installed [`@typescript-eslint/parser`] which is used in the following configuration. Unfortunately NPM does not allow to list optional peer dependencies.
+Make sure you have installed [`@typescript-eslint/parser`] which is used in the following configuration.
 
 ```yaml
 extends:

--- a/package.json
+++ b/package.json
@@ -94,6 +94,11 @@
     "typescript": "^2.8.1 || ~3.9.5",
     "typescript-eslint-parser": "^15 || ^22.0.0"
   },
+  "peerDependenciesMeta": {
+    "@typescript-eslint/parser": {
+      "optional": true
+    }
+  },
   "peerDependencies": {
     "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
   },

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
 ## Unreleased
+- add missing optional peer dependencies ([#2283], thanks [@jdanil])
 
 ## v2.7.1 - 2021-10-13
 

--- a/utils/package.json
+++ b/utils/package.json
@@ -25,6 +25,14 @@
     "url": "https://github.com/import-js/eslint-plugin-import/issues"
   },
   "homepage": "https://github.com/import-js/eslint-plugin-import#readme",
+  "peerDependenciesMeta": {
+    "@typescript-eslint/parser": {
+      "optional": true
+    },
+    "eslint-import-resolver-node": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "debug": "^3.2.7",
     "find-up": "^2.1.0",


### PR DESCRIPTION
The plugin uses `@typescript-eslint/parser` as the default parser for typescript files in the exported typescript config. `eslint-import-resolver-node` is also used as the default resolver.

This PR adds the packages as optional peer dependencies so that they can be safely accessed.