### PR TITLE
[New] `order`: add `distinctGroup` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-cycle`]: add `allowUnsafeDynamicCyclicDependency` option ([#2387], thanks [@GerkinDev])
 - [`no-restricted-paths`]: support arrays for `from` and `target` options ([#2466], thanks [@AdriAt360])
 - [`no-anonymous-default-export`]: add `allowNew` option ([#2505], thanks [@DamienCassou])
+- [`order`]: Add `distinctGroup` option ([#2395], thanks [@hyperupcall])
 
 ### Fixed
 - [`order`]: move nested imports closer to main import entry ([#2396], thanks [@pri1311])
@@ -1014,6 +1015,7 @@ for info on changes for earlier releases.
 [#2411]: https://github.com/import-js/eslint-plugin-import/pull/2411
 [#2399]: https://github.com/import-js/eslint-plugin-import/pull/2399
 [#2396]: https://github.com/import-js/eslint-plugin-import/pull/2396
+[#2395]: https://github.com/import-js/eslint-plugin-import/pull/2395
 [#2393]: https://github.com/import-js/eslint-plugin-import/pull/2393
 [#2388]: https://github.com/import-js/eslint-plugin-import/pull/2388
 [#2387]: https://github.com/import-js/eslint-plugin-import/pull/2387

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -128,6 +128,31 @@ Properties of the objects
 }
 ```
 
+### `distinctGroup: [boolean]`:
+
+This changes how `pathGroups[].position` affects grouping. The property is most useful when `newlines-between` is set to `always` and at least 1 `pathGroups` entry has a `position` property set.
+
+By default, in the context of a particular `pathGroup` entry, when setting `position`, a new "group" will silently be created. That is, even if the `group` is specified, a newline will still separate imports that match that `pattern` with the rest of the group (assuming `newlines-between` is `always`). This is undesirable if your intentions are to use `position` to position _within_ the group (and not create a new one). Override this behavior by setting `distinctGroup` to `false`; this will keep imports within the same group as intended.
+
+Note that currently, `distinctGroup` defaults to `true`. However, in a later update, the default will change to `false`
+
+Example:
+```json
+{
+  "import/order": ["error", {
+    "newlines-between": "always",
+    "pathGroups": [
+      {
+        "pattern": "@app/**",
+        "group": "external",
+        "position": "after"
+      }
+    ],
+    "distinctGroup": false
+  }]
+}
+```
+
 ### `pathGroupsExcludedImportTypes: [array]`:
 
 This defines import types that are not handled by configured pathGroups.

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -925,6 +925,161 @@ ruleTester.run('order', rule, {
         },
       },
     }),
+    // Option pathGroup[].distinctGroup: 'true' does not prevent 'position' properties from affecting the visible grouping
+    test({
+      code: `
+        import A from 'a';
+
+        import C from 'c';
+
+        import B from 'b';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+          'distinctGroup': true,
+          'pathGroupsExcludedImportTypes': [],
+          'pathGroups': [
+            {
+              'pattern': 'a',
+              'group': 'external',
+              'position': 'before',
+            },
+            {
+              'pattern': 'b',
+              'group': 'external',
+              'position': 'after',
+            },
+          ],
+        },
+      ],
+    }),
+    // Option pathGroup[].distinctGroup: 'false' should prevent 'position' properties from affecting the visible grouping
+    test({
+      code: `
+        import A from 'a';
+        import C from 'c';
+        import B from 'b';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+          'distinctGroup': false,
+          'pathGroupsExcludedImportTypes': [],
+          'pathGroups': [
+            {
+              'pattern': 'a',
+              'group': 'external',
+              'position': 'before',
+            },
+            {
+              'pattern': 'b',
+              'group': 'external',
+              'position': 'after',
+            },
+          ],
+        },
+      ],
+    }),
+    // Option pathGroup[].distinctGroup: 'false' should prevent 'position' properties from affecting the visible grouping 2
+    test({
+      code: `
+        import A from 'a';
+
+        import b from './b';
+        import B from './B';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+          'distinctGroup': false,
+          'pathGroupsExcludedImportTypes': [],
+          'pathGroups': [
+            {
+              'pattern': 'a',
+              'group': 'external',
+            },
+            {
+              'pattern': 'b',
+              'group': 'internal',
+              'position': 'before',
+            },
+          ],
+        },
+      ],
+    }),
+    // Option pathGroup[].distinctGroup: 'false' should prevent 'position' properties from affecting the visible grouping 3
+    test({
+      code: `
+        import A from "baz";
+        import B from "Bar";
+        import C from "Foo";
+
+        import D from "..";
+        import E from "../";
+        import F from "../baz";
+        import G from "../Bar";
+        import H from "../Foo";
+
+        import I from ".";
+        import J from "./baz";
+        import K from "./Bar";
+        import L from "./Foo";
+      `,
+      options: [
+        {
+          'alphabetize': {
+            'caseInsensitive': false,
+            'order': 'asc',
+          },
+          'newlines-between': 'always',
+          'groups': [
+            ['builtin', 'external', 'internal', 'unknown', 'object', 'type'],
+            'parent',
+            ['sibling', 'index'],
+          ],
+          'distinctGroup': false,
+          'pathGroupsExcludedImportTypes': [],
+          'pathGroups': [
+            {
+              'pattern': './',
+              'group': 'sibling',
+              'position': 'before',
+            },
+            {
+              'pattern': '.',
+              'group': 'sibling',
+              'position': 'before',
+            },
+            {
+              'pattern': '..',
+              'group': 'parent',
+              'position': 'before',
+            },
+            {
+              'pattern': '../',
+              'group': 'parent',
+              'position': 'before',
+            },
+            {
+              'pattern': '[a-z]*',
+              'group': 'external',
+              'position': 'before',
+            },
+            {
+              'pattern': '../[a-z]*',
+              'group': 'parent',
+              'position': 'before',
+            },
+            {
+              'pattern': './[a-z]*',
+              'group': 'sibling',
+              'position': 'before',
+            },
+          ],
+        },
+      ],
+    }),
   ],
   invalid: [
     // builtin before external module (require)
@@ -2437,6 +2592,62 @@ ruleTester.run('order', rule, {
       }],
       errors: [{
         message: '`..` import should occur before import of `../a`',
+      }],
+    }),
+    // Option pathGroup[].distinctGroup: 'false' should error when newlines are incorrect 2
+    test({
+      code: `
+        import A from 'a';
+        import C from './c';
+      `,
+      output: `
+        import A from 'a';
+
+        import C from './c';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+          'distinctGroup': false,
+          'pathGroupsExcludedImportTypes': [],
+        },
+      ],
+      errors: [{
+        message: 'There should be at least one empty line between import groups',
+      }],
+    }),
+    // Option pathGroup[].distinctGroup: 'false' should error when newlines are incorrect 2
+    test({
+      code: `
+        import A from 'a';
+
+        import C from 'c';
+      `,
+      output: `
+        import A from 'a';
+        import C from 'c';
+      `,
+      options: [
+        {
+          'newlines-between': 'always',
+          'distinctGroup': false,
+          'pathGroupsExcludedImportTypes': [],
+          'pathGroups': [
+            {
+              'pattern': 'a',
+              'group': 'external',
+              'position': 'before',
+            },
+            {
+              'pattern': 'c',
+              'group': 'external',
+              'position': 'after',
+            },
+          ],
+        },
+      ],
+      errors: [{
+        message: 'There should be no empty line within import group',
       }],
     }),
     // Alphabetize with require


### PR DESCRIPTION
This PR aims to close #2292. It implements what is proposed

I'll add that this functionality is really useful for emulating the behavior of TSLint's native `ordered-imports` option. This is needed for a PR I've made for [tslint-to-eslint-config](https://github.com/typescript-eslint/tslint-to-eslint-config/pull/1402).

In the linked issue:

> It seems reasonable to allow a custom pathGroup to be able to opt out of having a newline inserted around it, but I'm not sure what that schema would look like

I did a first pass implementation that seemed good - lemmie know if I need to change anything

Before this gets merged, I would like to add several more tests to ensure everything is working OK - I opened this PR hopefully for some initial feedback