### PR TITLE
[Fix] `order`: Autofix not working if alphabetical order is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`order`]: move nested imports closer to main import entry ([#2396], thanks [@pri1311])
 - [`no-restricted-paths`]: fix an error message ([#2466], thanks [@AdriAt360])
 - [`no-restricted-paths`]: use `Minimatch.match` instead of `minimatch` to comply with Windows Native paths ([#2466], thanks [@AdriAt360])
+- [`order`]: require with member expression could not be fixed if alphabetize.order was used ([#2490], thanks [@msvab])
 
 ### Changed
 - [Tests] `named`: Run all TypeScript test ([#2427], thanks [@ProdigySim])
@@ -994,6 +995,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2490]: https://github.com/import-js/eslint-plugin-import/pull/2490
 [#2466]: https://github.com/import-js/eslint-plugin-import/pull/2466
 [#2440]: https://github.com/import-js/eslint-plugin-import/pull/2440
 [#2427]: https://github.com/import-js/eslint-plugin-import/pull/2427
@@ -1638,6 +1640,7 @@ for info on changes for earlier releases.
 [@MikeyBeLike]: https://github.com/MikeyBeLike
 [@mplewis]: https://github.com/mplewis
 [@mrmckeb]: https://github.com/mrmckeb
+[@msvab]: https://github.com/msvab
 [@mx-bernhard]: https://github.com/mx-bernhard
 [@nickofthyme]: https://github.com/nickofthyme
 [@nicolashenry]: https://github.com/nicolashenry
@@ -1645,8 +1648,8 @@ for info on changes for earlier releases.
 [@ntdb]: https://github.com/ntdb
 [@nwalters512]: https://github.com/nwalters512
 [@ombene]: https://github.com/ombene
-[@OutdatedVersion]: https://github.com/OutdatedVersion
 [@ota-meshi]: https://github.com/ota-meshi
+[@OutdatedVersion]: https://github.com/OutdatedVersion
 [@panrafal]: https://github.com/panrafal
 [@paztis]: https://github.com/paztis
 [@pcorpet]: https://github.com/pcorpet

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -896,13 +896,13 @@ ruleTester.run('order', rule, {
         import express from 'express';
 
         import service from '@/api/service';
-        
+
         import fooParent from '../foo';
-        
+
         import fooSibling from './foo';
-        
+
         import index from './';
-        
+
         import internalDoesNotExistSoIsUnknown from '@/does-not-exist';
       `,
       options: [
@@ -2289,7 +2289,7 @@ ruleTester.run('order', rule, {
         import b from "foo-bar";
       `,
       errors: [{
-        message: '`foo-bar` import should occur after import of `foo/barfoo`', 
+        message: '`foo-bar` import should occur after import of `foo/barfoo`',
       }],
     }),
     // Option alphabetize {order: 'asc': caseInsensitive: true}
@@ -2334,6 +2334,23 @@ ruleTester.run('order', rule, {
       }],
       errors: [{
         message: '`foo` import should occur before import of `Bar`',
+      }],
+    }),
+    // Option alphabetize {order: 'asc'} and require with member expression
+    test({
+      code: `
+        const b = require('./b').get();
+        const a = require('./a');
+      `,
+      output: `
+        const a = require('./a');
+        const b = require('./b').get();
+      `,
+      options: [{
+        alphabetize: { order: 'asc' },
+      }],
+      errors: [{
+        message: '`./a` import should occur before import of `./b`',
       }],
     }),
     // Alphabetize with parent paths


### PR DESCRIPTION
This PR fixes Autofix which did not support require calls with an expression when `alphabetise.order` option was used.

```js
const b = require('./b').get();
const a = require('./a');
```