### PR TITLE
[`import/order`] Add ability to sort groups in order of nested groups

### DIFF
--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -88,7 +88,9 @@ This rule supports the following options:
 
 How groups are defined, and the order to respect. `groups` must be an array of `string` or [`string`]. The only allowed `string`s are:
 `"builtin"`, `"external"`, `"internal"`, `"unknown"`, `"parent"`, `"sibling"`, `"index"`, `"object"`, `"type"`.
-The enforced order is the same as the order of each element in a group. Omitted types are implicitly grouped together as the last element. Example:
+By default, the order of elements in a group is ignored and can be mingled
+together (see `intraGroupOrder`). Omitted types are implicitly grouped together as the last element.
+Example:
 ```ts
 [
   'builtin', // Built-in types are first
@@ -321,6 +323,73 @@ import * as classnames from 'classnames';
 import aTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { compose, apply } from 'xcompose';
+```
+
+### `intraGroupOrdering: true|false`:
+
+* default: `false`
+* Will be changed to `true` in the next major release.
+
+Enforces or forbids the ordering of imports within a group. This option applies
+slightly differently depending on whether the import is a `type` import or a
+regular import.
+
+#### Regular imports
+When nested groups have been defined in `groups` (ie. `['builtin', ['parent', 'sibling']]`),
+regular imports are sorted in the order of the elements in the nested group. So
+in the case of `['builtin', ['parent', 'sibling']]`, parents would be sorted
+above sibling imports but no newline would separate them.
+
+When `intraGroupOrdering` is set to `true`, the following will be invalid:
+
+```ts
+/* eslint import/order: ["error", {"intraGroupOrdering": true, groups: ['builtin', ['parent', 'sibling']]}] */
+import { fs } from 'fs';
+import { Select } from './Select';
+import { Button } from '../Button';
+```
+
+While this will be valid:
+
+```ts
+/* eslint import/order: ["error", {"intraGroupOrdering": true, groups: ['builtin', ['parent', 'sibling']]}] */
+import { fs } from 'fs';
+import { Button } from '../Button';
+import { Select } from './Select';
+```
+
+When alphabetization is enabled, imports with will be sorted in alphabetical
+order within each sub group before the sub group is sorted relative to the order
+of the nested group.
+
+#### Type imports
+When `intraGroupOrdering` is set to `true`, type imports are sorted in the order
+of the original groups array but flattened. So in the case of
+`['builtin', ['parent', 'sibling']]`, the order would be [`builtin`, `parent`, `sibling`].
+
+When `intraGroupOrdering` is set to `true`, the following will be invalid:
+
+```ts
+/* eslint import/order: ["error", {"intraGroupOrdering": true, groups: ['type', 'builtin', ['parent', 'sibling']]}] */
+import type { SelectProps } from './Select';
+import type { ButtonProps } from '../Button';
+import type { Dirent } from 'fs';
+
+import fs from 'fs';
+import { Button } from '../Button';
+import { Select } from './Select';
+```
+
+While this will be valid:
+```ts
+/* eslint import/order: ["error", {"intraGroupOrdering": true, groups: ['type', 'builtin', ['parent', 'sibling']]}] */
+import type { Dirent } from 'fs';
+import type { ButtonProps } from '../Button';
+import type { SelectProps } from './Select';
+
+import fs from 'fs';
+import { Button } from '../Button';
+import { Select } from './Select';
 ```
 
 ### `warnOnUnassignedImports: true|false`:

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -517,11 +517,12 @@ const types = ['builtin', 'external', 'internal', 'unknown', 'parent', 'sibling'
 // Will throw an error if it contains a type that does not exist, or has a duplicate
 function convertGroupsToRanks(groups) {
   const ranks = groups.reduce(function (res, group, index) {
+    let groupItems = group;
     if (typeof group === 'string') {
-      group = [group];
+      groupItems = [group];
     }
 
-    group.forEach(function (groupItem) {
+    groupItems.forEach(function (groupItem) {
       if (types.indexOf(groupItem) === -1) {
         throw new Error('Incorrect configuration of the rule: Unknown type `' +
           JSON.stringify(groupItem) + '`');
@@ -780,7 +781,7 @@ module.exports = {
     try {
       const { pathGroups, maxPosition } = convertPathGroupsForRanks(options.pathGroups || []);
       const { ranks, omittedTypes } = convertGroupsToRanks(groups);
-
+      
       computedContext = {
         ranks,
         omittedTypes,

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -2,6 +2,7 @@
 
 import minimatch from 'minimatch';
 import includes from 'array-includes';
+import flat from 'array.prototype.flat';
 
 import resolveImportType from '../core/importType';
 import isStaticRequire from '../core/staticRequire';
@@ -328,7 +329,7 @@ function getSorter(alphabetizeOptions) {
 function mutateRanksForIntraGroupOrdering(computedContext, imported, groups, intraGroupOrdering, alphabetizeOptions) {
   const { omittedTypes } = computedContext;
 
-  const nonTypeGroups = new Set(groups.flat());
+  const nonTypeGroups = new Set(flat(groups));
   if (intraGroupOrdering) {
     nonTypeGroups.delete('type');
 

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -3014,25 +3014,6 @@ context('TypeScript', function () {
               },
             ],
           }),
-          
-          // Option intraGroupOrdering: true (should sort type imports in remaining group order)
-          test({
-            name: 'pearce',
-            code: `
-              import type { Dirent } from 'fs';
-
-              import type { Fooz } from '../baz';
-              import type { Foo } from './bar';
-            `,
-            ...parserConfig,
-            options: [
-              {
-                groups: ['type', 'external' ['parent', 'sibling']],
-                intraGroupOrdering: true,
-                'newlines-between': 'always',
-              },
-            ],
-          }),
         ],
         invalid: [
           // Option alphabetize: {order: 'asc'}


### PR DESCRIPTION
Resolves #2685, #2683, #2682

This PR changes 2 things:
1. Add the ability to sort groups in the order of nested groups
2. Add the ability to sort types in the order of the rest of the `groups` array. 

Both of these features are currently disabled by default and must be enabled with the `intraGroupOrdering` option. I've added a `TODO: semver major` flag to this option indicating to make this behavior the default in the next major version. We can either remove the flag after that or enable its behavior by default with the option to disable it. 

**Add the ability to sort groups in the order of nested groups** (`intraGroupOrdering = true`)
Will mutate ranks of a single group based on the order of the of the group's nested groups.

If the rule is configured to alphabetize, it will alphabetize each subgroup individually and then sort the subgroups in nested `groups` order. That is to say, if the rule is configured as `[['parent', 'sibling']]`, it will sort all of the parent imports alphabetically, then sort all of the sibling imports alphabetically. Then move all the alphabetized `parent` imports before the alphabetized `sibling` imports.

Ex.
Given the following code and rule options
```
// code
import fs from 'fs';
import { foo } from './foo';
import { bar } from './bar';
import { fooz } from '../fooz';

// options
{
  intraGroupOrdering: true,
  groups: ['builtin', ['parent', 'sibling']],
  newlines: 'always',
  alphabetize: {
    order: 'asc',
  }
}
```
Results in: `../fooz` being before `./foo` because `parent` is listed before `sibling` in the `groups` array
```
import fs from 'fs';

import { fooz } from '../fooz';
import { bar } from './bar';
import { foo } from './foo';
```

**Add the ability to sort types in the order of the rest of the `groups` array** (`intraGroupOrdering = true`)
Will mutate ranks of all type imports such that they are sorted in the flattened order of the original `groups` array without the types. If the rule is configured to alphabetize, it will do the same thing as how alphabetization works above. 

Ex. 
Given the following code and rule options
```
// code
import type { Dirent } from 'fs';
import type { Foo } from './foo';
import type { Bar } from './bar';
import type { Fooz } from '../fooz';

import fs from 'fs';
import { fooz } from '../fooz';
import { bar } from './bar';
import { foo } from './foo';

// options
{
  intraGroupOrdering: true,
  groups: ['type, 'builtin', ['parent', 'sibling']],
  newlines: 'always',
  alphabetize: {
    order: 'asc',
  }
}
```
Results in: `../fooz` being before `./foo` because `parent` is listed before `sibling` in the `groups` array
```
import type { Dirent } from 'fs';
import type { Fooz } from '../fooz';
import type { Foo } from './foo';
import type { Bar } from './bar';

import fs from 'fs';

import { fooz } from '../fooz';
import { bar } from './bar';
import { foo } from './foo';
```

### Testing
I had a lot of trouble with tests. @ljharb I'm not sure if you've seen this before but I was randomly getting cases where the `groups` array was setting elements to `undefined`. I assumed the code was mutating the `groups` array somewhere but I couldn't find it. Please be on the lookout for that. Also, I would randomly need newlines in the output of some tests but not for others. 

I decided I would rather get the PR up so that I can show progress than continue struggling with the system. I think there should be more testing for the case where both `intraGroupOrdering` and `alphabetize` is enabled. As well as tests for unknown types when this option is enabled. The tests I did add are very basic. I am open to test suggestions.