### PR TITLE
feat(extensions): enhance import extension enforcement with autofix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 | [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.      |    |       |    | 🔧 |    |    |
 | [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.   |    |       |    |    | 💡 |    |
 | [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                          |    |       |    |    |    |    |
-| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.            |    |       |    |    |    |    |
+| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.            |    |       |    | 🔧 |    |    |
 | [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                         |    |       |    | 🔧 |    |    |
 | [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration |    |       |    |    |    |    |
 | [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import/first`.                                                |    |       |    | 🔧 |    | ❌  |

--- a/docs/rules/extensions.md
+++ b/docs/rules/extensions.md
@@ -1,5 +1,7 @@
 # import/extensions
 
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 <!-- end auto-generated rule header -->
 
 Some file resolve algorithms allow you to omit the file extension within the import source path. For example the `node` resolver (which does not yet support ESM/`import`) can resolve `./foo/bar` to the absolute path `/User/someone/foo/bar.js` because the `.js` extension is resolved automatically by default in CJS. Depending on the resolver you can configure more extensions to get resolved automatically.

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -46,6 +46,7 @@ function buildProperties(context) {
     defaultConfig: 'never',
     pattern: {},
     ignorePackages: false,
+    fix: false,
   };
 
   context.options.forEach((obj) => {
@@ -70,6 +71,11 @@ function buildProperties(context) {
     // If ignorePackages is provided, transfer it to result
     if (obj.ignorePackages !== undefined) {
       result.ignorePackages = obj.ignorePackages;
+    }
+
+    // If fix is provided, transfer it to result
+    if (obj.fix !== undefined) {
+      result.fix = obj.fix;
     }
 
     if (obj.checkTypeImports !== undefined) {
@@ -97,7 +103,7 @@ module.exports = {
       description: 'Ensure consistent use of file extension within the import path.',
       url: docsUrl('extensions'),
     },
-
+    fixable: 'code',
     schema: {
       anyOf: [
         {
@@ -225,6 +231,14 @@ module.exports = {
             node: source,
             message:
               `Missing file extension ${extension ? `"${extension}" ` : ''}for "${importPathWithQueryString}"`,
+            ...props.fix && extension ? {
+              fix(fixer) {
+                return fixer.replaceText(
+                  source,
+                  JSON.stringify(`${importPathWithQueryString}.${extension}`),
+                );
+              },
+            } : {},
           });
         }
       } else if (extension) {
@@ -232,6 +246,17 @@ module.exports = {
           context.report({
             node: source,
             message: `Unexpected use of file extension "${extension}" for "${importPathWithQueryString}"`,
+            ...props.fix
+              ? {
+                fix(fixer) {
+                  return fixer.replaceText(
+                    source,
+                    JSON.stringify(
+                      importPath.slice(0, -(extension.length + 1)),
+                    ),
+                  );
+                },
+              } : {},
           });
         }
       }

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -155,6 +155,16 @@ ruleTester.run('extensions', rule, {
       ].join('\n'),
       options: ['always'],
     }),
+
+    test({
+      code: "import foo from './foo';",
+      options: [{ fix: true }],
+    }),
+
+    test({
+      code: "import foo from './foo.js';",
+      options: [{ fix: true, pattern: { js: 'always' } }],
+    }),
   ],
 
   invalid: [
@@ -651,6 +661,13 @@ ruleTester.run('extensions', rule, {
           line: 1,
         },
       ],
+    }),
+
+    test({
+      code: 'import foo from "./foo.js";',
+      options: ['always', { pattern: { js: 'never' }, fix: true }],
+      errors: [{ message: 'Unexpected use of file extension "js" for "./foo.js"' }],
+      output: 'import foo from "./foo";',
     }),
   ],
 });


### PR DESCRIPTION
### Summary

This PR enhances the import extensions rule by introducing auto-fix support. With this change, ESLint can now automatically:
- Append a missing file extension when one is required.
- Remove an extension when its presence is forbidden and the module is resolvable without it.

### Changes

- **New Configuration Option:**  
  Added a new `fix` option (defaulting to `false`) in the rule's configuration. When enabled, the rule will attempt to fix detected issues automatically.

- **Meta Update:**  
  Marked the rule as fixable by adding `fixable: 'code'` in the meta information.

- **Auto-fix Implementation:**  
  Extended the reporting logic in `checkFileExtension` with fixer functions:
  - For missing file extensions, if auto-fix is enabled, the fixer appends the detected extension.
  - For extraneous file extensions, the fixer removes the extension from the import statement.

- **Code Adjustments:**  
  Updated the `buildProperties` function to handle the new `fix` property from the user configuration.

### Motivation

This update improves developer experience by allowing ESLint to automatically correct common mistakes regarding file extensions in import paths, reducing manual intervention during code review or development.

### Backward Compatibility

All existing functionality remains unchanged when the `fix` option is disabled. Users can enable auto-fixing by setting `fix: true` in their ESLint configuration for this rule.

