### PR TITLE
Add wildcard pattern support for core modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,21 @@ core module:
 }
 ```
 
+Wildcard patterns are supported to match multiple modules, using `*` as a wildcard:
+
+```jsonc
+// .eslintrc
+{
+  "settings": {
+    "import/core-modules": [
+      "electron",
+      "@my-monorepo/*", // matches @my-monorepo/package-a, @my-monorepo/package-b, etc.
+      "@my-*/*", // matches @my-org/package, @my-company/package, etc.
+    ],
+  },
+}
+```
+
 In Electron's specific case, there is a shared config named `electron`
 that specifies this for you.
 

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -23,6 +23,13 @@ function isInternalRegexMatch(name, settings) {
   return internalScope && new RegExp(internalScope).test(name);
 }
 
+function matchesCoreModulePattern(name, pattern) {
+  const regexPattern = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*');
+  return new RegExp(`^${regexPattern}$`).test(name);
+}
+
 export function isAbsolute(name) {
   return typeof name === 'string' && nodeIsAbsolute(name);
 }
@@ -32,7 +39,9 @@ export function isBuiltIn(name, settings, path) {
   if (path || !name) { return false; }
   const base = baseModule(name);
   const extras = settings && settings['import/core-modules'] || [];
-  return isCoreModule(base) || extras.indexOf(base) > -1;
+  return isCoreModule(base) 
+    || extras.indexOf(base) > -1
+    || extras.some(pattern => pattern.includes('*') && matchesCoreModulePattern(base, pattern));
 }
 
 const moduleRegExp = /^\w/;

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -38,8 +38,8 @@ function isDangerousPattern(pattern) {
   // Block patterns with multiple wildcards that could be too broad
   const wildcardCount = (pattern.match(/\*/g) || []).length;
   if (wildcardCount > 1) {
-    // Allow @namespace/* patterns but block things like */*/* or *abc*
-    if (!pattern.match(/^@[^*]+\/\*$/)) { return true; }
+    // Allow valid scoped patterns like @namespace/* or @my-*/*, but block overly broad ones
+    if (!pattern.match(/^@[^/]+\/\*$/)) { return true; }
   }
 
   return false;

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -39,9 +39,9 @@ export function isBuiltIn(name, settings, path) {
   if (path || !name) { return false; }
   const base = baseModule(name);
   const extras = settings && settings['import/core-modules'] || [];
-  return isCoreModule(base) 
+  return isCoreModule(base)
     || extras.indexOf(base) > -1
-    || extras.some(pattern => pattern.includes('*') && matchesCoreModulePattern(base, pattern));
+    || extras.some((pattern) => pattern.includes('*') && matchesCoreModulePattern(base, pattern));
 }
 
 const moduleRegExp = /^\w/;

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -24,6 +24,11 @@ function isInternalRegexMatch(name, settings) {
 }
 
 function matchesCoreModulePattern(name, pattern) {
+  // Prevent dangerous bare wildcard patterns
+  if (pattern === '*') {
+    return false;
+  }
+
   const regexPattern = pattern
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
     .replace(/\*/g, '.*');

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -24,7 +24,6 @@ function isInternalRegexMatch(name, settings) {
   return internalScope && new RegExp(internalScope).test(name);
 }
 
-
 export function isAbsolute(name) {
   return typeof name === 'string' && nodeIsAbsolute(name);
 }

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -157,7 +157,7 @@ describe('importType(name)', function () {
     expect(importType('@my-org/package', multiWildcardContext)).to.equal('builtin');
     expect(importType('@my-company/package', multiWildcardContext)).to.equal('builtin');
     expect(importType('@my-test/package', multiWildcardContext)).to.equal('builtin');
-    
+
     // Should not match different patterns
     expect(importType('@other-org/package', multiWildcardContext)).to.equal('external');
     expect(importType('my-org/package', multiWildcardContext)).to.equal('external');
@@ -169,16 +169,16 @@ describe('importType(name)', function () {
     expect(importType('@my-monorepo/package-b/nested/module', wildcardContext)).to.equal('builtin');
   });
 
-  it("should support mixing exact matches and wildcards in core modules", function () {
+  it('should support mixing exact matches and wildcards in core modules', function () {
     const mixedContext = testContext({ 'import/core-modules': ['electron', '@my-monorepo/*', '@specific/package'] });
-    
+
     // Exact matches should work
     expect(importType('electron', mixedContext)).to.equal('builtin');
     expect(importType('@specific/package', mixedContext)).to.equal('builtin');
-    
+
     // Wildcard matches should work
     expect(importType('@my-monorepo/any-package', mixedContext)).to.equal('builtin');
-    
+
     // Non-matches should be external
     expect(importType('@other/package', mixedContext)).to.equal('external');
   });

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -183,6 +183,21 @@ describe('importType(name)', function () {
     expect(importType('@other/package', mixedContext)).to.equal('external');
   });
 
+  it('should handle dangerous bare wildcard patterns safely', function () {
+    const bareWildcardContext = testContext({ 'import/core-modules': ['*'] });
+
+    // A bare wildcard should NOT match everything - this would be dangerous
+    expect(importType('react', bareWildcardContext)).to.equal('external');
+    expect(importType('lodash', bareWildcardContext)).to.equal('external');
+    expect(importType('@babel/core', bareWildcardContext)).to.equal('external');
+    expect(importType('any-random-package', bareWildcardContext)).to.equal('external');
+
+    // However, valid wildcard patterns should still work
+    const validWildcardContext = testContext({ 'import/core-modules': ['@my-org/*'] });
+    expect(importType('@my-org/package', validWildcardContext)).to.equal('builtin');
+    expect(importType('react', validWildcardContext)).to.equal('external');
+  });
+
   it("should return 'external' for module from 'node_modules' with default config", function () {
     expect(importType('resolve', context)).to.equal('external');
   });

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -370,7 +370,7 @@ describe('isAbsolute', () => {
     expect(() => isAbsolute(false)).not.to.throw();
     expect(() => isAbsolute(0)).not.to.throw();
     expect(() => isAbsolute(NaN)).not.to.throw();
-    });
+  });
 
   it('should not use dynamic regex patterns that could cause ReDoS vulnerabilities', function () {
     // Test that dangerous patterns are blocked by isDangerousPattern
@@ -385,8 +385,8 @@ describe('isAbsolute', () => {
       'a*',          // Too short
       'ab*',         // Too short
     ];
-    
-    dangerousPatterns.forEach(pattern => {
+
+    dangerousPatterns.forEach((pattern) => {
       const context = testContext({ 'import/core-modules': [pattern] });
       // These should all be blocked and not match anything
       expect(isBuiltIn('test-module', context.settings, null)).to.equal(false);
@@ -397,7 +397,6 @@ describe('isAbsolute', () => {
   it('should use safe glob matching instead of regex construction', function () {
     // Verify no dynamic regex patterns like [\\s\\S]*? are created
     const context = testContext({ 'import/core-modules': ['@my-monorepo/*'] });
-    
     // Valid patterns should work safely without regex construction
     expect(isBuiltIn('@my-monorepo/package-a', context.settings, null)).to.equal(true);
     expect(isBuiltIn('@my-monorepo/package-b', context.settings, null)).to.equal(true);

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -196,6 +196,7 @@ describe('importType(name)', function () {
       '*a',         // Too short and broad
       '*foo*',      // Multiple wildcards (too broad)
       'foo*bar*',   // Multiple wildcards (too broad)
+      '*/*/*',      // Triple wildcards
     ];
 
     dangerousPatterns.forEach((pattern) => {

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -155,6 +155,23 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "@generated/bar/and/sub/path"',
       settings: { 'import/core-modules': ['@generated/bar'] },
     }),
+    // Test wildcard patterns in core-modules
+    test({
+      code: 'import "@my-monorepo/package-a"',
+      settings: { 'import/core-modules': ['@my-monorepo/*'] },
+    }),
+    test({
+      code: 'import "@my-monorepo/package-b/nested/module"',
+      settings: { 'import/core-modules': ['@my-monorepo/*'] },
+    }),
+    test({
+      code: 'import "@my-org/any-package"',
+      settings: { 'import/core-modules': ['@my-*/*'] },
+    }),
+    test({
+      code: 'import "@namespace/any-package"',
+      settings: { 'import/core-modules': ['@namespace/*', 'specific-module'] },
+    }),
     // check if "rxjs" dependency declaration fix the "rxjs/operators subpackage
     test({
       code: 'import "rxjs/operators"',


### PR DESCRIPTION
## Summary

Addresses: https://github.com/import-js/eslint-plugin-import/issues/1281

- Add support for wildcard patterns in `import/core-modules` setting
- Allow `*` to match multiple modules like `@my-monorepo/*` or `@my-*/*`
- Update documentation with examples of wildcard usage

## Changes
- Modified `src/core/importType.js` to support wildcard pattern matching
- Added comprehensive test cases for wildcard patterns
- Updated README.md with wildcard pattern examples

## Test plan
- [x] All existing tests pass
- [x] Added tests for basic wildcard patterns (`@my-monorepo/*`)
- [x] Added tests for multiple wildcard patterns (`@my-*/*`)
- [x] Added tests for mixed exact matches and wildcards
- [x] Added tests for resources inside wildcard core modules
- [x] Updated no-extraneous-dependencies rule tests
