### PR TITLE
Add a `prefer-top-level-if-only-type-imports` option for the `consistent-type-specifier-style` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Added
 - [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247], thanks [@mixelburg] [@etyrrell22])
+- [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])
 
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
@@ -1202,6 +1203,7 @@ for info on changes for earlier releases.
 [#3236]: https://github.com/import-js/eslint-plugin-import/pull/3236
 [#3235]: https://github.com/import-js/eslint-plugin-import/issues/3235
 [#3233]: https://github.com/import-js/eslint-plugin-import/pull/3233
+[#3210]: https://github.com/import-js/eslint-plugin-import/pull/3210
 [#3208]: https://github.com/import-js/eslint-plugin-import/issues/3208
 [#3195]: https://github.com/import-js/eslint-plugin-import/issues/3195
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191
@@ -1831,6 +1833,7 @@ for info on changes for earlier releases.
 [@akwodkiewicz]: https://github.com/akwodkiewicz
 [@aladdin-add]: https://github.com/aladdin-add
 [@albertpastrana]: https://github.com/albertpastrana
+[@aldeed]: https://github.com/aldeed
 [@alex-page]: https://github.com/alex-page
 [@alexgorbatchev]: https://github.com/alexgorbatchev
 [@amsardesai]: https://github.com/amsardesai

--- a/docs/rules/consistent-type-specifier-style.md
+++ b/docs/rules/consistent-type-specifier-style.md
@@ -38,7 +38,8 @@ This rule includes a fixer that will automatically convert your specifiers to th
 The rule accepts a single string option which may be one of:
 
  - `'prefer-inline'` - enforces that named type-only specifiers are only ever written with an inline marker; and never as part of a top-level, type-only import.
- - `'prefer-top-level'` - enforces that named type-only specifiers only ever written as part of a top-level, type-only import; and never with an inline marker.
+ - `'prefer-top-level'` - enforces that named type-only specifiers are only ever written as part of a top-level, type-only import; and never with an inline marker.
+ - `'prefer-top-level-if-only-type-imports'` - enforces that named type-only specifiers must use a top-level, type-only import when all named imports are types; if some are values, then inline markers are allowed. This is useful when you generally prefer inline but you are using TypeScript `verbatimModuleSyntax` and want all-type imports omitted by bundlers.
 
 By default the rule will use the `prefer-inline` option.
 
@@ -59,6 +60,27 @@ import {typeof Foo} from 'Foo';
 
 ```ts
 import type {Foo} from 'Foo';
+import type Foo, {Bar} from 'Foo';
+// flow only
+import typeof {Foo} from 'Foo';
+```
+
+### `prefer-top-level-if-only-type-imports`
+
+❌ Invalid with `["error", "prefer-top-level-if-only-type-imports"]`
+
+```ts
+import {type Foo} from 'Foo';
+import {type Foo,type Bar} from 'Foo';
+// flow only
+import {typeof Foo} from 'Foo';
+```
+
+✅ Valid with `["error", "prefer-top-level-if-only-type-imports"]`
+
+```ts
+import type {Foo} from 'Foo';
+import { type Foo, someValue } from 'Foo';
 import type Foo, {Bar} from 'Foo';
 // flow only
 import typeof {Foo} from 'Foo';

--- a/tests/src/rules/consistent-type-specifier-style.js
+++ b/tests/src/rules/consistent-type-specifier-style.js
@@ -54,6 +54,70 @@ const COMMON_TESTS = {
     }),
 
     //
+    // prefer-top-level-if-only-type-imports
+    //
+    test({
+      code: "import Foo from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import type Foo from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import { Foo } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import { Foo as Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import * as Foo from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import {} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import type {} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import type { Foo } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import type { Foo as Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import type { Foo, Bar, Baz, Bam } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import { Foo, type Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import { type Foo, Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import Foo, { type Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+    test({
+      code: "import Foo, { type Bar, Baz } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    }),
+
+    //
     // prefer-inline
     //
     test({
@@ -197,6 +261,37 @@ import {
     },
 
     //
+    // prefer-top-level-if-only-type-imports
+    //
+    {
+      code: "import { type Foo } from 'Foo';",
+      output: "import type {Foo} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level type-only import instead of inline type specifiers when there are only type imports.',
+        type: 'ImportDeclaration',
+      }],
+    },
+    {
+      code: "import { type Foo as Bar } from 'Foo';",
+      output: "import type {Foo as Bar} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level type-only import instead of inline type specifiers when there are only type imports.',
+        type: 'ImportDeclaration',
+      }],
+    },
+    {
+      code: "import { type Foo, type Bar } from 'Foo';",
+      output: "import type {Foo, Bar} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level type-only import instead of inline type specifiers when there are only type imports.',
+        type: 'ImportDeclaration',
+      }],
+    },
+
+    //
     // prefer-inline
     //
     {
@@ -242,6 +337,26 @@ const FLOW_ONLY = {
     {
       code: "import typeof { Foo, Bar, Baz, Bam } from 'Foo';",
       options: ['prefer-top-level'],
+    },
+
+    //
+    // prefer-top-level-if-only-type-imports
+    //
+    {
+      code: "import typeof Foo from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    },
+    {
+      code: "import typeof { Foo, Bar, Baz, Bam } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    },
+    {
+      code: "import { Foo, typeof Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    },
+    {
+      code: "import Foo, { typeof Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
     },
 
     //
@@ -353,6 +468,46 @@ const FLOW_ONLY = {
       errors: [{
         message: 'Prefer using a top-level typeof-only import instead of inline typeof specifiers.',
         type: 'ImportSpecifier',
+      }],
+    },
+
+    //
+    // prefer-top-level-if-only-type-imports
+    //
+    {
+      code: "import { typeof Foo } from 'Foo';",
+      output: "import typeof {Foo} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level typeof-only import instead of inline typeof specifiers when there are only type imports.',
+        type: 'ImportDeclaration',
+      }],
+    },
+    {
+      code: "import { typeof Foo as Bar } from 'Foo';",
+      output: "import typeof {Foo as Bar} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level typeof-only import instead of inline typeof specifiers when there are only type imports.',
+        type: 'ImportDeclaration',
+      }],
+    },
+    {
+      code: "import { typeof Foo, typeof Bar } from 'Foo';",
+      output: "import typeof {Foo, Bar} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level typeof-only import instead of inline typeof specifiers when there are only type imports.',
+        type: 'ImportDeclaration',
+      }],
+    },
+    {
+      code: "import { type Foo, typeof Bar } from 'Foo';",
+      output: "import type {Foo} from 'Foo';\nimport typeof {Bar} from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level type/typeof-only import instead of inline type/typeof specifiers when there are only type imports.',
+        type: 'ImportDeclaration',
       }],
     },
 


### PR DESCRIPTION
Adds a `prefer-top-level-if-only-type-imports` option for the `consistent-type-specifier-style` rule. See docs. This is useful when you generally prefer inline but you are using TypeScript `verbatimModuleSyntax` and want all-type imports to be omitted by bundlers.