### PR TITLE
[New] `no-deprecated`: detect @deprecated on default-exported identifier declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Added
+- [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247])
+
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236])
 
@@ -1187,6 +1190,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3237]: https://github.com/import-js/eslint-plugin-import/pull/3237
 [#3236]: https://github.com/import-js/eslint-plugin-import/pull/3236
 [#3233]: https://github.com/import-js/eslint-plugin-import/pull/3233
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191

--- a/src/exportMap/visitor.js
+++ b/src/exportMap/visitor.js
@@ -52,6 +52,27 @@ export default class ImportExportVisitorBuilder {
         const exportMeta = captureDoc(this.source, this.docStyleParsers, astNode);
         if (astNode.declaration.type === 'Identifier') {
           this.namespace.add(exportMeta, astNode.declaration);
+          // If the export has no JSDoc, look for it on the referenced declaration
+          if (!exportMeta.doc) {
+            const exportName = astNode.declaration.name;
+            const decl = this.ast.body.find((node) => {
+              if (node.type === 'VariableDeclaration') {
+                return node.declarations.some((d) => d.id.name === exportName);
+              }
+              return (node.type === 'FunctionDeclaration' || node.type === 'ClassDeclaration')
+                && node.id && node.id.name === exportName;
+            });
+            if (decl) {
+              if (decl.type === 'VariableDeclaration') {
+                const varDecl = decl.declarations.find((d) => d.id.name === exportName);
+                const varMeta = captureDoc(this.source, this.docStyleParsers, varDecl, decl);
+                if (varMeta.doc) { exportMeta.doc = varMeta.doc; }
+              } else {
+                const fnMeta = captureDoc(this.source, this.docStyleParsers, decl);
+                if (fnMeta.doc) { exportMeta.doc = fnMeta.doc; }
+              }
+            }
+          }
         }
         this.exportMap.namespace.set('default', exportMeta);
       },

--- a/tests/files/deprecated-default-indirect.js
+++ b/tests/files/deprecated-default-indirect.js
@@ -1,0 +1,6 @@
+/**
+ * @deprecated Use the new one
+ */
+const Button = () => null;
+
+export default Button;

--- a/tests/src/rules/no-deprecated.js
+++ b/tests/src/rules/no-deprecated.js
@@ -55,6 +55,12 @@ ruleTester.run('no-deprecated', rule, {
       errors: ['Deprecated: this is awful, use NotAsBadClass.'],
     }),
 
+    // default export via identifier reference to a locally-deprecated binding
+    test({
+      code: "import Button from './deprecated-default-indirect'",
+      errors: ['Deprecated: Use the new one'],
+    }),
+
     test({
       code: "import { MY_TERRIBLE_ACTION } from './deprecated'",
       errors: ['Deprecated: please stop sending/handling this action type.'],


### PR DESCRIPTION
## What

When a binding is declared with `@deprecated` JSDoc and then exported separately via `export default <name>`, the `no-deprecated` rule previously did not detect the deprecation.

## Why

The `ExportDefaultDeclaration` handler called `captureDoc` only on the export statement node itself. When the export is `export default Button;` (Identifier form), the JSDoc comment is on the *declaration* (`const Button = ...`), not the export statement.

## How

In `ExportDefaultDeclaration()`, when the declaration is an `Identifier` and has no JSDoc on the export statement, we now look up the corresponding variable/function/class declaration in the module body and capture its JSDoc tags.

## Test

Added a new test case and fixture file (`deprecated-default-indirect.js`) covering the indirect default export scenario.

Fixes #3245