### PR TITLE
Resolve `export * as ns` re-exports under modern parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236])
 - [`no-duplicates`]: avoid false positives for TypeScript namespace and default type imports that cannot be merged ([#3195])
+- ExportMap: resolve export * as ns re-exports under modern parsers ([#3250])
 
 ### Changed
 - [Docs] `no-unused-modules`: Fix docs of `ignoreUnusedTypeExports` option ([#3233], thanks [@ej612])
@@ -1191,6 +1192,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250
 [#3237]: https://github.com/import-js/eslint-plugin-import/pull/3237
 [#3236]: https://github.com/import-js/eslint-plugin-import/pull/3236
 [#3233]: https://github.com/import-js/eslint-plugin-import/pull/3233

--- a/src/exportMap/specifier.js
+++ b/src/exportMap/specifier.js
@@ -9,16 +9,27 @@ export default function processSpecifier(specifier, astNode, exportMap, namespac
       local = 'default';
       break;
     case 'ExportNamespaceSpecifier':
-      exportMap.namespace.set(specifier.exported.name, Object.defineProperty(exportMeta, 'namespace', {
+      Object.defineProperty(exportMeta, 'namespace', {
         get() { return namespace.resolveImport(nsource); },
-      }));
+      });
+      exportMap.namespace.set(specifier.exported.name, exportMeta);
       return;
     case 'ExportAllDeclaration':
-      exportMap.namespace.set(specifier.exported.name || specifier.exported.value, namespace.add(exportMeta, specifier.source.value));
+      Object.defineProperty(exportMeta, 'namespace', {
+        get() { return namespace.resolveImport(specifier.source.value); },
+      });
+      exportMap.namespace.set(
+        specifier.exported.name || specifier.exported.value,
+        exportMeta,
+      );
       return;
     case 'ExportSpecifier':
       if (!astNode.source) {
-        exportMap.namespace.set(specifier.exported.name || specifier.exported.value, namespace.add(exportMeta, specifier.local));
+        namespace.add(exportMeta, specifier.local);
+        exportMap.namespace.set(
+          specifier.exported.name || specifier.exported.value,
+          exportMeta,
+        );
         return;
       }
     // else falls through

--- a/src/exportMap/visitor.js
+++ b/src/exportMap/visitor.js
@@ -78,9 +78,12 @@ export default class ImportExportVisitorBuilder {
       },
       ExportAllDeclaration() {
         const getter = captureDependency(astNode, astNode.exportKind === 'type', this.remotePathResolver, this.exportMap, this.context, this.thunkFor);
-        if (getter) { this.exportMap.dependencies.add(getter); }
         if (astNode.exported) {
+          // `export * as ns from './mod'` — named namespace, not a star-export
           processSpecifier(astNode, astNode.exported, this.exportMap, this.namespace);
+        } else if (getter) {
+          // `export * from './mod'` — star-export flattens into current module
+          this.exportMap.dependencies.add(getter);
         }
       },
       /** capture namespaces in case of later export */

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -325,6 +325,18 @@ const invalid = [].concat(
     errors: ["'e' not found in deeply imported namespace 'b.c'."],
     parserOptions: { ecmaVersion: 2022 },
   })),
+
+  // #3250: `export * as` re-export resolves under espree
+  testVersion('>= 6', () => ({
+    code: `
+      import * as middle from './middle';
+
+      console.log(middle.myName.b);
+    `,
+    filename: testFilePath('export-star-2/downstream.js'),
+    parserOptions: { ecmaVersion: 2020 },
+    errors: ["'b' not found in deeply imported namespace 'middle.myName'."],
+  })),
 );
 
 ///////////////////////


### PR DESCRIPTION
Fixes two pre-existing `ExportAllDeclaration` bugs that affect modern parsers (espree ES2020+, `@babel/eslint-parser`) but not `babel-eslint`. Extracted from [#3230](https://github.com/import-js/eslint-plugin-import/pull/3230) (eslint v10 support) to make that PR cleaner.

## Root cause

`babel-eslint` represents `export * as ns from './mod'` as `ExportNamedDeclaration` + `ExportNamespaceSpecifier` (a working code path), so the bug was latent. Modern parsers emit `ExportAllDeclaration` with `exported`, which hit two broken spots:

- **`specifier.js`**: passed a string (`specifier.source.value`) to `namespace.add()`, which expects an AST node — so the namespace getter was never set up and `ns` didn't resolve. Fixed by defining the lazy getter directly, matching the existing [`ExportNamespaceSpecifier`](https://github.com/rasmi/eslint-plugin-import/blob/export-star-as-fix/src/exportMap/specifier.js#L11-L15) case.
- **`visitor.js`**: `export * as ns` was unconditionally added to the star-export `dependencies` set, incorrectly flattening the target module's exports into the current one. Fixed by only adding to `dependencies` for plain `export *` (no `as`).

## Tests

The included regression test covers the false negative: the `namespace` rule now correctly flags invalid deep references through `export * as` re-exports that were previously silently missed (fails on `main`, passes with the fix).

The false-positive symptoms #1834, #1883, #1845, #2002, #2289 ("errors after upgrading Babel") are resolved by the same change, but only reproduce with `@babel/eslint-parser`, which is introduced in #3230.

Fixes #2002, #1883, #1834, #1845, #2289.