### PR TITLE
Remove stray errors from valid tests.

### DIFF
--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -165,12 +165,10 @@ ruleTester.run('named', rule, {
 
     test({
       code: 'const { baz } = require("./bar")',
-      errors: [error('baz', './bar')],
     }),
 
     test({
       code: 'const { baz } = require("./bar")',
-      errors: [error('baz', './bar')],
       options: [{ commonjs: false }],
     }),
 

--- a/tests/src/rules/no-dynamic-require.js
+++ b/tests/src/rules/no-dynamic-require.js
@@ -100,7 +100,6 @@ ruleTester.run('no-dynamic-require', rule, {
         }),
         _test({
           code: 'import("../" + name)',
-          errors: [dynamicImportError],
           parser,
           parserOptions: {
             ecmaVersion: 2020,
@@ -108,7 +107,6 @@ ruleTester.run('no-dynamic-require', rule, {
         }),
         _test({
           code: 'import(`../${name}`)',
-          errors: [dynamicImportError],
           parser,
           parserOptions: {
             ecmaVersion: 2020,


### PR DESCRIPTION
These valid cases carried `errors` arrays that never fired: `named`'s `checkRequire` early-returns unless `commonjs: true` (54d86c8a64dc21c14088fcdd8fc3935206e8347a), and `no-dynamic-require` only flags `import()` with `esmodule: true` (7163824ddefc01e8dcb3f02cbf482ea946deb6b6), which these cases don't set. Pre-v10 `RuleTester` silently ignored `errors`/`output` on valid cases; ESLint v10's `RuleTester` rejects them, which is what surfaced these in #3230. Correctly-configured versions already exist.

Extracted from #3230 to keep that PR clean. (see context [here](https://github.com/import-js/eslint-plugin-import/pull/3230#discussion_r3030886367) and [here](https://github.com/import-js/eslint-plugin-import/pull/3230#discussion_r3255642584) and [here](https://github.com/import-js/eslint-plugin-import/pull/3230#discussion_r3255650710)).
