### PR TITLE
Replace eslint-plugin-json with a fixture processor

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "eslint-module-utils": "file:./utils",
     "eslint-plugin-eslint-plugin": "^2.3.0",
     "eslint-plugin-import": "2.x",
-    "eslint-plugin-json": "^2.1.2",
     "find-babel-config": "=1.2.0",
     "fs-copy-file-sync": "^1.1.1",
     "glob": "^7.2.3",

--- a/tests/files/just-json-files/.eslintrc.json
+++ b/tests/files/just-json-files/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "root": true,
 
-  "plugins": ["import", "json"],
+  "plugins": ["import"],
 
   "rules": {
     "import/no-unused-modules": [
@@ -11,12 +11,5 @@
         "unusedExports": true
       }
     ]
-  },
-
-  "overrides": [
-    {
-      "files": "*.json",
-      "extends": "plugin:json/recommended"
-    }
-  ]
+  }
 }

--- a/tests/files/just-json-files/eslint.config.js
+++ b/tests/files/just-json-files/eslint.config.js
@@ -1,13 +1,9 @@
-var jsonPlugin = require('eslint-plugin-json');
-
-if (!jsonPlugin.processors.json) {
-  jsonPlugin.processors.json = jsonPlugin.processors['.json'];
-}
+var jsonPlugin = require('./fixture-json-plugin');
 
 module.exports = [
   {
     files: ['tests/files/just-json-files/*.json'],
-    plugins:{
+    plugins: {
       json: jsonPlugin,
     },
     processor: 'json/json',
@@ -23,6 +19,6 @@ module.exports = [
         ],
       },
       jsonPlugin.configs.recommended.rules
-    )
+    ),
   },
 ];

--- a/tests/files/just-json-files/fixture-json-plugin.js
+++ b/tests/files/just-json-files/fixture-json-plugin.js
@@ -1,0 +1,49 @@
+// Stand-in for eslint-plugin-json for #1645 regression test
+
+'use strict';
+
+var parseErrorsByFile = {};
+
+var processor = {
+  preprocess: function (text, filename) {
+    try {
+      JSON.parse(text);
+      delete parseErrorsByFile[filename];
+    } catch (e) {
+      parseErrorsByFile[filename] = [{
+        ruleId: 'json/*',
+        severity: 2,
+        message: 'Invalid JSON',
+        line: 1,
+        column: 1,
+        endLine: 1,
+        endColumn: 2,
+        nodeType: null,
+      }];
+    }
+    return ['']; // one empty JS block: no JS rules can report on it
+  },
+  postprocess: function (messages, filename) {
+    var own = parseErrorsByFile[filename] || [];
+    delete parseErrorsByFile[filename];
+    return own; // discard messages[] from the empty block
+  },
+  supportsAutofix: false,
+};
+
+module.exports = {
+  // no-op rule so `json/*` resolves under eslint 9+ flat config (it rejects unresolved plugin rules)
+  rules: {
+    '*': { create: function () { return {}; } },
+  },
+  processors: {
+    '.json': processor,
+    json: processor,
+  },
+  configs: {
+    recommended: {
+      plugins: ['json'],
+      rules: { 'json/*': 'error' },
+    },
+  },
+};

--- a/tests/src/cli.js
+++ b/tests/src/cli.js
@@ -8,6 +8,7 @@ import { CLIEngine, ESLint } from 'eslint';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 import * as importPlugin from '../../src/index';
+import jsonFixture from '../files/just-json-files/fixture-json-plugin';
 
 describe('CLI regression tests', function () {
   describe('issue #210', function () {
@@ -79,7 +80,20 @@ describe('CLI regression tests', function () {
               overrideConfigFile: './tests/files/just-json-files/.eslintrc.json',
               rulePaths: ['./src/rules'],
               ignore: false,
-              plugins: { 'eslint-plugin-import': importPlugin },
+              overrideConfig: {
+                plugins: ['json'],
+                overrides: [
+                  {
+                    files: ['*.json'],
+                    processor: 'json/json',
+                    rules: { 'json/*': 'error' },
+                  },
+                ],
+              },
+              plugins: {
+                'eslint-plugin-import': importPlugin,
+                'eslint-plugin-json': jsonFixture,
+              },
             });
           }
         } else {
@@ -88,8 +102,19 @@ describe('CLI regression tests', function () {
             configFile: './tests/files/just-json-files/.eslintrc.json',
             rulePaths: ['./src/rules'],
             ignore: false,
+            baseConfig: {
+              plugins: ['json'],
+              overrides: [
+                {
+                  files: ['*.json'],
+                  processor: 'json/json',
+                  rules: { 'json/*': 'error' },
+                },
+              ],
+            },
           });
           cli.addPlugin('eslint-plugin-import', importPlugin);
+          cli.addPlugin('eslint-plugin-json', jsonFixture);
         }
       }
     });
@@ -104,15 +129,14 @@ describe('CLI regression tests', function () {
                 filePath: path.resolve(invalidJSON),
                 messages: [
                   {
-                    column: 2,
-                    endColumn: 3,
+                    column: 1,
+                    endColumn: 2,
                     endLine: 1,
                     line: 1,
-                    message: 'Expected a JSON object, array or literal.',
+                    message: 'Invalid JSON',
                     nodeType: results[0].messages[0].nodeType, // we don't care about this one
                     ruleId: 'json/*',
                     severity: 2,
-                    source: results[0].messages[0].source, // NewLine-characters might differ depending on git-settings
                   },
                 ],
                 errorCount: 1,
@@ -139,15 +163,14 @@ describe('CLI regression tests', function () {
               filePath: path.resolve(invalidJSON),
               messages: [
                 {
-                  column: 2,
-                  endColumn: 3,
+                  column: 1,
+                  endColumn: 2,
                   endLine: 1,
                   line: 1,
-                  message: 'Expected a JSON object, array or literal.',
+                  message: 'Invalid JSON',
                   nodeType: results.results[0].messages[0].nodeType, // we don't care about this one
                   ruleId: 'json/*',
                   severity: 2,
-                  source: results.results[0].messages[0].source, // NewLine-characters might differ depending on git-settings
                 },
               ],
               errorCount: 1,


### PR DESCRIPTION
While updating to support eslint v10 in #3230, `eslint-plugin-json` (and specifically `eslint-plugin-jsonc` for v10+) caused a series of interrelated version/dependency issues which required various `dep-time-travel.sh` and version-pinning workarounds (see [here](https://github.com/import-js/eslint-plugin-import/pull/3230#discussion_r3255667807)). 

The #1645 regression test only needs *some* `.json` processor in the pipeline so `no-unused-modules` is exercised against a JSON-only directory (the bug was the import rule crashing there, not the JSON diagnostic). The fixture does that and removes the JSON-plugin dependency entirely.

(potential alternative to #3230's `eslint-plugin-jsonc` switch https://github.com/import-js/eslint-plugin-import/commit/d8d72941d0e5b52a88359ba73a8f7876728ff803)