### PR TITLE
[Fix] `no-duplicates`: avoid false positives for TypeScript namespace and default type imports that cannot be merged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236])
+- [`no-duplicates`]: avoid false positives for TypeScript namespace and default type imports that cannot be merged ([#3195])
 
 ### Changed
 - [Docs] `no-unused-modules`: Fix docs of `ignoreUnusedTypeExports` option ([#3233], thanks [@ej612])
@@ -1193,6 +1194,7 @@ for info on changes for earlier releases.
 [#3237]: https://github.com/import-js/eslint-plugin-import/pull/3237
 [#3236]: https://github.com/import-js/eslint-plugin-import/pull/3236
 [#3233]: https://github.com/import-js/eslint-plugin-import/pull/3233
+[#3195]: https://github.com/import-js/eslint-plugin-import/issues/3195
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191
 [#3173]: https://github.com/import-js/eslint-plugin-import/pull/3173
 [#3172]: https://github.com/import-js/eslint-plugin-import/pull/3172

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -328,7 +328,7 @@ module.exports = {
       return `${defaultResolver(parts[1])}?${parts[2]}`;
     } : defaultResolver;
 
-    /** @type {Map<unknown, { imported: Map<string, import('estree').ImportDeclaration[]>, nsImported: Map<string, import('estree').ImportDeclaration[]>, defaultTypesImported: Map<string, import('estree').ImportDeclaration[]>, namedTypesImported: Map<string, import('estree').ImportDeclaration[]>}>} */
+    /** @type {Map<unknown, { imported: Map<string, import('estree').ImportDeclaration[]>, nsImported: Map<string, import('estree').ImportDeclaration[]>, defaultTypesImported: Map<string, import('estree').ImportDeclaration[]>, namedTypesImported: Map<string, import('estree').ImportDeclaration[]>, namespaceTypesImported: Map<string, import('estree').ImportDeclaration[]>}>} */
     const moduleMaps = new Map();
 
     /** @param {import('estree').ImportDeclaration} n */
@@ -340,11 +340,18 @@ module.exports = {
           nsImported: new Map(),
           defaultTypesImported: new Map(),
           namedTypesImported: new Map(),
+          namespaceTypesImported: new Map(),
         });
       }
       const map = moduleMaps.get(n.parent);
-      if (!preferInline && n.importKind === 'type') {
-        return n.specifiers.length > 0 && n.specifiers[0].type === 'ImportDefaultSpecifier' ? map.defaultTypesImported : map.namedTypesImported;
+      if (n.importKind === 'type') {
+        if (hasNamespace(n)) {
+          return map.namespaceTypesImported;
+        }
+        if (getDefaultImportName(n) != null) {
+          return map.defaultTypesImported;
+        }
+        return preferInline ? map.imported : map.namedTypesImported;
       }
       if (!preferInline && n.specifiers.some((spec) => spec.importKind === 'type')) {
         return map.namedTypesImported;
@@ -374,6 +381,7 @@ module.exports = {
           checkImports(map.nsImported, context);
           checkImports(map.defaultTypesImported, context);
           checkImports(map.namedTypesImported, context);
+          checkImports(map.namespaceTypesImported, context);
         }
       },
     };

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -548,13 +548,52 @@ context('TypeScript', function () {
           code: "import { type x } from './foo'; import { y } from './foo'",
           ...parserConfig,
         }),
+        ...parser === parsers.TS_NEW ? [
+          // #3195: namespace type imports cannot be merged with named type imports.
+          test({
+            code: "import type * as React from 'react'; import { type ReactElement } from 'react'",
+            ...parserConfig,
+          }),
+          test({
+            code: "import type * as ReactTypes from 'react'; import * as ReactRuntime from 'react'",
+            ...parserConfig,
+          }),
+        ] : [],
         test({
           code: "import { type x } from './foo'; import type y from 'foo'",
           ...parserConfig,
         }),
+        // #3195: default type imports cannot be merged with inline named type imports.
+        test({
+          code: "import type React from 'react'; import { type ReactElement } from 'react'",
+          options: [{ 'prefer-inline': true }],
+          ...parserConfig,
+        }),
+        test({
+          code: "import type ReactTypes from 'react'; import ReactRuntime from 'react'",
+          options: [{ 'prefer-inline': true }],
+          ...parserConfig,
+        }),
       ]);
 
-      const invalid = [
+      const invalid = [].concat(parser === parsers.TS_NEW ? [
+        test(withoutAutofixOutput({
+          code: "import type * as React from './foo'; import type * as ReactDOM from './foo'",
+          ...parserConfig,
+          errors: [
+            {
+              line: 1,
+              column: 29,
+              message: "'./foo' imported multiple times.",
+            },
+            {
+              line: 1,
+              column: 69,
+              message: "'./foo' imported multiple times.",
+            },
+          ],
+        })),
+      ] : [], [
         test(withoutAutofixOutput({
           code: "import type x from './foo'; import type y from './foo'",
           ...parserConfig,
@@ -605,7 +644,7 @@ context('TypeScript', function () {
             },
           ],
         }),
-      ].concat(!tsVersionSatisfies('>= 4.5') || !typescriptEslintParserSatisfies('>= 5.7.0') ? [] : [
+      ]).concat(!tsVersionSatisfies('>= 4.5') || !typescriptEslintParserSatisfies('>= 5.7.0') ? [] : [
         test({
           code: "import {type x} from './foo'; import type {y} from './foo'",
           ...parserConfig,


### PR DESCRIPTION
## Summary

Fixes `import/no-duplicates` false positives for TypeScript type-only imports.

## What changed

- Added regression coverage for namespace type imports with named type imports.
- Added regression coverage for default type imports with inline named type imports.
- Split type-only namespace/default import grouping from named type import grouping.

## Why

Issue #3195 reports cases where imports that cannot be merged in TypeScript are reported as duplicates. In particular, `import type * as ...` cannot be merged with named type imports, and `import type Default from ...` cannot be merged into inline named type imports without changing the import kind.

## Testing

- `npm run mocha -- tests/src/rules/no-duplicates.js`
- `npm test`
- `git diff --check`

Fixes #3195