### PR TITLE
[Tests] Use supported Windows runner for Native and WSL CI

### DIFF
--- a/.github/workflows/native-wsl.yml
+++ b/.github/workflows/native-wsl.yml
@@ -18,16 +18,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019]
+        os: [windows-2022]
         node-version: [18, 16, 14, 12, 10, 8, 6, 4]
         configuration: [wsl, native]
 
     steps:
     - uses: actions/checkout@v4
-    - uses: Vampire/setup-wsl@v3
+    - uses: Vampire/setup-wsl@v7
       if: matrix.configuration == 'wsl'
       with:
         distribution: Ubuntu-22.04
+        wsl-version: 2
     - run: curl --version
     - name: 'WSL: do all npm install steps'
       if: matrix.configuration == 'wsl'
@@ -35,6 +36,7 @@ jobs:
         ESLINT_VERSION: 7
         TRAVIS_NODE_VERSION: ${{ matrix.node-version }}
       run: |
+        export ESLINT_IMPORT_WSL_TEST_TIMEOUT=60000
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
         export NVM_DIR="$HOME/.nvm"
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
@@ -78,7 +80,7 @@ jobs:
         fi
         npm run copy-metafiles
         npm run pretest
-        npm run tests-only
+        npm run mocha -- tests/src --timeout "$ESLINT_IMPORT_WSL_TEST_TIMEOUT"
 
     - name: install dependencies for node <= 10
       if: matrix.node-version <= '10' && matrix.configuration == 'native'

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -289,7 +289,7 @@ describe('dynamic imports', function () {
     return;
   }
 
-  this.timeout(10e3);
+  this.timeout(Number(process.env.ESLINT_IMPORT_WSL_TEST_TIMEOUT) || 10e3);
 
   // test for unused exports with `import()`
   ruleTester.run('no-unused-modules', rule, {


### PR DESCRIPTION
## Summary

- Update the Native and WSL workflow from `windows-2019` to `windows-2022`.
- Update `Vampire/setup-wsl` to `v7` and explicitly request WSL 2 for the Windows 2022 hosted image.
- Keep the existing node-version and native/WSL matrix unchanged.
- Give WSL test runs a longer Mocha timeout, and let the existing dynamic-import `no-unused-modules` timeout use that WSL-only value.

## Why

`windows-2019` is no longer a supported GitHub-hosted runner image after the Windows 2019 deprecation window, which can leave this workflow waiting for runner capacity instead of exercising the Windows coverage. This keeps the workflow on a supported Windows hosted image.

The first Windows 2022 run did start on hosted runners, but the old `Vampire/setup-wsl@v3` setup configured WSL 1. The WSL job then reported `WSL 1 is not supported` from nvm before failing during the Node 6 npm upgrade. `setup-wsl@v7` supports the `wsl-version` input, so this keeps the migration scoped to the Native and WSL runner setup.

After switching to WSL 2, the WSL jobs reached the test suite and exposed repeated Mocha timeout failures on otherwise running tests. The workflow now passes a longer timeout only for WSL runs; local and non-WSL test defaults stay unchanged.

Refs https://github.com/actions/runner-images/issues/12045
Refs #3253

## Testing

- `git diff --check`
- Native and WSL workflow on this PR: 17/17 jobs passed on `windows-2022`.
- Verified the initial `windows-2022` Native and WSL jobs were assigned GitHub-hosted runners instead of remaining stuck waiting for unsupported `windows-2019` capacity.
- Inspected the failing `build (windows-2022, 6, wsl)` log and confirmed the failure came from WSL 1 setup under `Vampire/setup-wsl@v3`.
- Inspected the next WSL 2 run and confirmed WSL jobs reached tests, with failures caused by Mocha timeouts under WSL.

Note: I used Codex to inspect the queued CI state and prepare this narrow workflow change, then reviewed the final diff locally.