### PR TITLE
[Tests] regression tests for `export * as` bug class fixed by #3250

### DIFF
--- a/tests/files/issue-1845/alpha/abc.js
+++ b/tests/files/issue-1845/alpha/abc.js
@@ -1,0 +1,3 @@
+export const A = 'A';
+export const B = 'B';
+export const C = 'C';

--- a/tests/files/issue-1845/alpha/def.js
+++ b/tests/files/issue-1845/alpha/def.js
@@ -1,0 +1,3 @@
+export const D = 'D';
+export const E = 'E';
+export const F = 'F';

--- a/tests/files/issue-1845/alpha/index.js
+++ b/tests/files/issue-1845/alpha/index.js
@@ -1,0 +1,2 @@
+export * as abc from './abc';
+export * as def from './def';

--- a/tests/files/issue-1845/consumer.js
+++ b/tests/files/issue-1845/consumer.js
@@ -1,0 +1,4 @@
+import * as alpha from './alpha';
+
+console.log(alpha.abc.A);
+console.log(alpha.def.D);

--- a/tests/files/issue-2002/index.js
+++ b/tests/files/issue-2002/index.js
@@ -1,0 +1,2 @@
+export * from './processors';
+export * from './rules';

--- a/tests/files/issue-2002/processors/index.js
+++ b/tests/files/issue-2002/processors/index.js
@@ -1,0 +1,1 @@
+export * as processors from './remark';

--- a/tests/files/issue-2002/processors/remark.js
+++ b/tests/files/issue-2002/processors/remark.js
@@ -1,0 +1,1 @@
+export const remark = {};

--- a/tests/files/issue-2002/rules/index.js
+++ b/tests/files/issue-2002/rules/index.js
@@ -1,0 +1,3 @@
+import { remark } from './remark';
+export { remark };
+export const rules = { remark };

--- a/tests/files/issue-2002/rules/remark.js
+++ b/tests/files/issue-2002/rules/remark.js
@@ -1,0 +1,1 @@
+export const remark = {};

--- a/tests/files/issue-2289/A/A1.js
+++ b/tests/files/issue-2289/A/A1.js
@@ -1,0 +1,1 @@
+export const X = 'A1';

--- a/tests/files/issue-2289/A/A2.js
+++ b/tests/files/issue-2289/A/A2.js
@@ -1,0 +1,1 @@
+export const X = 'A2';

--- a/tests/files/issue-2289/A/index.js
+++ b/tests/files/issue-2289/A/index.js
@@ -1,0 +1,2 @@
+export * as A1 from './A1';
+export * as A2 from './A2';

--- a/tests/files/issue-2289/B/B.js
+++ b/tests/files/issue-2289/B/B.js
@@ -1,0 +1,1 @@
+export const X = 'B';

--- a/tests/files/issue-2289/B/index.js
+++ b/tests/files/issue-2289/B/index.js
@@ -1,0 +1,1 @@
+export * as B from './B';

--- a/tests/files/issue-2289/index.js
+++ b/tests/files/issue-2289/index.js
@@ -1,0 +1,2 @@
+export * from './A';
+export * from './B';

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -46,6 +46,28 @@ ruleTester.run('export', rule, {
       },
     })) || [],
 
+    // #2289 (closed by #3250): `export * from` of a barrel that uses `export * as`
+    // must not flag same-named exports in unrelated sibling chains as duplicates.
+    testVersion('>= 6', () => ({
+      code: `
+        export * from './A';
+        export * from './B';
+      `,
+      filename: testFilePath('./issue-2289/index.js'),
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    })) || [],
+
+    // #2002 (closed by #3250): `export * from` of a `export * as` barrel must not
+    // conflict with same-named exports from a sibling barrel.
+    testVersion('>= 6', () => ({
+      code: `
+        export * from './processors';
+        export * from './rules';
+      `,
+      filename: testFilePath('./issue-2002/index.js'),
+      parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    })) || [],
+
     getTSParsers().map((parser) => ({
       code: `
         export default function foo(param: string): boolean;

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -205,6 +205,18 @@ const valid = [
       ecmaVersion: 2020,
     },
   })),
+  // #1845 (closed by #3250): deep access through multiple `export * as` re-exports
+  // must resolve real properties (no false positives).
+  testVersion('>= 6', () => ({
+    code: `
+      import * as alpha from './alpha';
+
+      console.log(alpha.abc.A);
+      console.log(alpha.def.D);
+    `,
+    filename: testFilePath('./issue-1845/consumer.js'),
+    parserOptions: { ecmaVersion: 2020, sourceType: 'module' },
+  })),
   // es2022: Arbitrary module namespace identifier names
   testVersion('>= 8.7', () => ({
     code: "import * as names from './default-export-string';",
@@ -336,6 +348,17 @@ const invalid = [].concat(
     filename: testFilePath('export-star-2/downstream.js'),
     parserOptions: { ecmaVersion: 2020 },
     errors: ["'b' not found in deeply imported namespace 'middle.myName'."],
+  })),
+  // #3250: same fixture via named import — missing property on the re-exported namespace
+  testVersion('>= 6', () => ({
+    code: `
+      import { myName } from './middle';
+
+      console.log(myName.b);
+    `,
+    filename: testFilePath('export-star-2/downstream.js'),
+    parserOptions: { ecmaVersion: 2020 },
+    errors: ["'b' not found in imported namespace 'myName'."],
   })),
 );
 


### PR DESCRIPTION
Adds load-bearing regression tests for the `export * as`-related bugs fixed in #3250. Each was verified by temp-reverting `src/exportMap/specifier.js` + `src/exportMap/visitor.js` to the pre-`#3250` state and confirming each test fails:

- **#2289** (`tests/src/rules/export.js`): `export * from` of barrels that use `export * as` must not false-flag same-named exports in unrelated sibling chains. 
  - Pre-`#3250` flagged `Multiple exports of name 'X'`.
- **#2002** (`tests/src/rules/export.js`): Same bug class, slightly different shape mixing barrels (one using `export * as`).
  - Pre-`#3250` flagged `Multiple exports of name 'remark'`.
- **#1845** (`tests/src/rules/namespace.js`): Deep access (`alpha.abc.A` / `alpha.def.D`) through multiple `export * as` re-exports must resolve real properties.
  - Pre-`#3250` flagged both as not found.
- **Named-import-side complement to `#3250`** (`tests/src/rules/namespace.js`): `import { myName } from "./middle"; console.log(myName.b)` invalid case. Fills in the named-import entry point alongside `#3250`'s existing `middle.myName.b` test (which uses `import * as middle`).

Three new fixture directories (`tests/files/issue-{1845,2002,2289}`). 