### PR TITLE
[Tests] Increase timeout for flaky-on-macOS test.

### DIFF
--- a/tests/src/cli.js
+++ b/tests/src/cli.js
@@ -119,7 +119,8 @@ describe('CLI regression tests', function () {
       }
     });
 
-    it('throws an error on invalid JSON', () => {
+    it('throws an error on invalid JSON', function () {
+      this.timeout(10000); // slow on old Node + macOS CI
       const invalidJSON = './tests/files/just-json-files/invalid.json';
       if (eslint) {
         return eslint.lintFiles([invalidJSON]).then((results) => {


### PR DESCRIPTION
This test sometimes times out on macOS (similar to 154a5e0ef89b4a95e6b3fcb844bc9b7fdbce3030).