### PR TITLE
Report qs instead of @types/qs for extraneous deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - ExportMap: resolve export * as ns re-exports under modern parsers ([#3250], thanks [@rasmi] [@JounQin] [@butterybread])
 - [`order`]: make the alphabetize comparator transitive for sibling/parent imports in the same group, so the autofix converges under Node 25's updated V8 sort ([#3235], thanks [@Sekhmet])
 - [`no-duplicates`]: remove extra space when merging import specifiers ([#3246], thanks [@mixelburg] [@shastaxc])
+- [`no-extraneous-dependencies`]: report runtime package name, not `@types/*`, when an import resolves via a `@types` devDependency ([#3208], thanks [@morgan-coded] [@cakoose] [@JounQin])
 
 ### Changed
 - [Docs] `no-unused-modules`: Fix docs of `ignoreUnusedTypeExports` option ([#3233], thanks [@ej612])
@@ -1201,6 +1202,7 @@ for info on changes for earlier releases.
 [#3236]: https://github.com/import-js/eslint-plugin-import/pull/3236
 [#3235]: https://github.com/import-js/eslint-plugin-import/issues/3235
 [#3233]: https://github.com/import-js/eslint-plugin-import/pull/3233
+[#3208]: https://github.com/import-js/eslint-plugin-import/issues/3208
 [#3195]: https://github.com/import-js/eslint-plugin-import/issues/3195
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191
 [#3173]: https://github.com/import-js/eslint-plugin-import/pull/3173
@@ -1863,6 +1865,7 @@ for info on changes for earlier releases.
 [@brendo]: https://github.com/brendo
 [@brettz9]: https://github.com/brettz9
 [@butterybread]: https://github.com/butterybread
+[@cakoose]: https://github.com/cakoose
 [@chabb]: https://github.com/chabb
 [@Chamion]: https://github.com/Chamion
 [@charlessuh]: https://github.com/charlessuh
@@ -2018,6 +2021,7 @@ for info on changes for earlier releases.
 [@mixelburg]: https://github.com/mixelburg
 [@mlenser]: https://github.com/mlenser
 [@moeriki]: https://github.com/moeriki
+[@morgan-coded]: https://github.com/morgan-coded
 [@mpalmer685]: https://github.com/mpalmer685
 [@mpint]: https://github.com/mpint
 [@mplewis]: https://github.com/mplewis

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -147,6 +147,13 @@ function getModuleRealName(resolved) {
   return getFilePackageName(resolved);
 }
 
+// derive the runtime package a DefinitelyTyped `@types/*` package provides types for,
+// mirroring TypeScript's `getPackageNameFromTypesPackageName`: `@types/babel__core` -> `@babel/core`
+function runtimePackageNameFromTypesPackageName(packageName) {
+  const innerPackageName = packageName.slice('@types/'.length);
+  return innerPackageName.includes('__') ? `@${innerPackageName.replace('__', '/')}` : innerPackageName;
+}
+
 function checkDependencyDeclaration(deps, packageName, declarationStatus) {
   const newDeclarationStatus = declarationStatus || {
     isInDeps: false,
@@ -231,6 +238,11 @@ function reportIfMissing(context, deps, depsOptions, node, name, moduleSystem) {
     ) {
       return;
     }
+  }
+
+  if (realPackageName && realPackageName.startsWith('@types/')) {
+    context.report(node, missingErrorMessage(runtimePackageNameFromTypesPackageName(realPackageName)));
+    return;
   }
 
   if (declarationStatus.isInDevDeps && !depsOptions.allowDevDeps) {

--- a/tests/files/with-resolved-types-dependencies/foo.js
+++ b/tests/files/with-resolved-types-dependencies/foo.js
@@ -1,0 +1,3 @@
+import qs from 'qs';
+
+export default qs;

--- a/tests/files/with-resolved-types-dependencies/node_modules/@babel/core/package.json
+++ b/tests/files/with-resolved-types-dependencies/node_modules/@babel/core/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../../@types/babel__core/index.js"
+}

--- a/tests/files/with-resolved-types-dependencies/node_modules/@types/babel__core/index.js
+++ b/tests/files/with-resolved-types-dependencies/node_modules/@types/babel__core/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/tests/files/with-resolved-types-dependencies/node_modules/@types/babel__core/package.json
+++ b/tests/files/with-resolved-types-dependencies/node_modules/@types/babel__core/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@types/babel__core",
+  "version": "7.20.5",
+  "main": "index.js"
+}

--- a/tests/files/with-resolved-types-dependencies/node_modules/@types/qs/index.js
+++ b/tests/files/with-resolved-types-dependencies/node_modules/@types/qs/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/tests/files/with-resolved-types-dependencies/node_modules/@types/qs/package.json
+++ b/tests/files/with-resolved-types-dependencies/node_modules/@types/qs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@types/qs",
+  "version": "6.9.7",
+  "main": "index.js"
+}

--- a/tests/files/with-resolved-types-dependencies/node_modules/qs/package.json
+++ b/tests/files/with-resolved-types-dependencies/node_modules/qs/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "../@types/qs/index.js"
+}

--- a/tests/files/with-resolved-types-dependencies/package.json
+++ b/tests/files/with-resolved-types-dependencies/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@types/babel__core": "*",
+    "@types/qs": "*"
+  }
+}

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -20,6 +20,7 @@ const packageFileWithSyntaxErrorMessage = (() => {
 })();
 const packageDirWithFlowTyped = path.join(__dirname, '../../files/with-flow-typed');
 const packageDirWithTypescriptDevDependencies = path.join(__dirname, '../../files/with-typescript-dev-dependencies');
+const packageDirWithResolvedTypesDependencies = path.join(__dirname, '../../files/with-resolved-types-dependencies');
 const packageDirMonoRepoRoot = path.join(__dirname, '../../files/monorepo');
 const packageDirMonoRepoWithNested = path.join(__dirname, '../../files/monorepo/packages/nested-package');
 const packageDirWithEmpty = path.join(__dirname, '../../files/empty');
@@ -402,6 +403,27 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       errors: [{
         // missing dependency is chai not alias
         message: "'chai' should be listed in the project's dependencies. Run 'npm i -S chai' to add it",
+      }],
+    }),
+
+    // https://github.com/import-js/eslint-plugin-import/issues/3208
+    // when `qs` resolves only through the `@types/qs` devDependency, the missing
+    // runtime package is `qs`, not the `@types/qs` package the resolver landed on
+    test({
+      code: 'import qs from "qs";',
+      filename: path.join(packageDirWithResolvedTypesDependencies, 'foo.js'),
+      options: [{ packageDir: packageDirWithResolvedTypesDependencies, devDependencies: false }],
+      errors: [{
+        message: "'qs' should be listed in the project's dependencies. Run 'npm i -S qs' to add it",
+      }],
+    }),
+
+    test({
+      code: 'import babel from "@babel/core";',
+      filename: path.join(packageDirWithResolvedTypesDependencies, 'foo.js'),
+      options: [{ packageDir: packageDirWithResolvedTypesDependencies, devDependencies: false }],
+      errors: [{
+        message: "'@babel/core' should be listed in the project's dependencies. Run 'npm i -S @babel/core' to add it",
       }],
     }),
 


### PR DESCRIPTION
`no-extraneous-dependencies` could point at `@types/qs` even though the package a user needs to declare is `qs`.
When resolution lands in an `@types/*` package, the report now uses the runtime package name.
Checked it with the focused mocha run, the red/green case, eslint, and markdownlint.
Closes #3208