### PR TITLE
fix(deps): bump semver to ^7.5.2 (CVE-2022-25883)

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "object.fromentries": "^2.0.8",
     "object.groupby": "^1.0.3",
     "object.values": "^1.2.1",
-    "semver": "^6.3.1",
+    "semver": "^7.5.2",
     "string.prototype.trimend": "^1.0.9",
     "tsconfig-paths": "^3.15.0"
   }


### PR DESCRIPTION
## Summary

Bumps `semver` dependency from `^6.3.1` to `^7.5.2` to address CVE-2022-25883 (ReDoS vulnerability).

- **CVE**: CVE-2022-25883 / GHSA-c2qf-rxjj-qqgw
- **Severity**: Moderate (CVSS 5.3)
- **Affected**: `semver < 7.5.2`
- **Fix**: Upgrade to `semver ^7.5.2`

The vulnerable `semver` version is flagged by security scanners (npm audit, pnpm audit, Snyk, Dependabot) in downstream projects that consume this package.

## Test plan
- [ ] Existing test suite passes
- [ ] No breaking changes (semver v7 API is backwards compatible with v6 for the methods used here)