### PR TITLE
export: handle type-only star re-exports separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247], thanks [@mixelburg] [@etyrrell22])
 
 ### Fixed
+- [`export`]: Fixed false positives for duplicate exports when a value export and `export type *` expose the same name. ([#3260], [#3136], thanks [@mykola-mokhnach] [@morgan-coded])
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
 - [`no-duplicates`]: avoid false positives for TypeScript namespace and default type imports that cannot be merged ([#3195], thanks [@sjh9714] [@robyoder])
 - ExportMap: resolve export * as ns re-exports under modern parsers ([#3250], thanks [@rasmi] [@JounQin] [@butterybread])
@@ -1195,6 +1196,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3260]: https://github.com/import-js/eslint-plugin-import/pull/3260
 [#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250
 [#3247]: https://github.com/import-js/eslint-plugin-import/pull/3247
 [#3246]: https://github.com/import-js/eslint-plugin-import/pull/3246
@@ -1212,6 +1214,7 @@ for info on changes for earlier releases.
 [#3152]: https://github.com/import-js/eslint-plugin-import/pull/3152
 [#3151]: https://github.com/import-js/eslint-plugin-import/pull/3151
 [#3138]: https://github.com/import-js/eslint-plugin-import/pull/3138
+[#3136]: https://github.com/import-js/eslint-plugin-import/issues/3136
 [#3129]: https://github.com/import-js/eslint-plugin-import/pull/3129
 [#3128]: https://github.com/import-js/eslint-plugin-import/pull/3128
 [#3127]: https://github.com/import-js/eslint-plugin-import/pull/3127
@@ -2029,6 +2032,7 @@ for info on changes for earlier releases.
 [@msvab]: https://github.com/msvab
 [@mulztob]: https://github.com/mulztob
 [@mx-bernhard]: https://github.com/mx-bernhard
+[@mykola-mokhnach]: https://github.com/mykola-mokhnach
 [@Nfinished]: https://github.com/Nfinished
 [@nickofthyme]: https://github.com/nickofthyme
 [@nicolashenry]: https://github.com/nicolashenry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 - [`export`]: Fixed false positives for duplicate exports when a value export and `export type *` expose the same name. ([#3260], [#3136], thanks [@mykola-mokhnach] [@morgan-coded])
+- [`export`]: Fixed false positives for duplicate exports when a value export and a type-only named re-export (`export type { x }` or `export { type x }`) expose the same name. ([#3136], thanks [@mykola-mokhnach] [@ljharb])
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
 - [`no-duplicates`]: avoid false positives for TypeScript namespace and default type imports that cannot be merged ([#3195], thanks [@sjh9714] [@robyoder])
 - ExportMap: resolve export * as ns re-exports under modern parsers ([#3250], thanks [@rasmi] [@JounQin] [@butterybread])

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -142,10 +142,14 @@ module.exports = {
       },
 
       ExportSpecifier(node) {
+        // `export type { x }` sets exportKind on the declaration; `export { type x }` sets it on the specifier.
+        // Either way the name belongs to the type namespace and must not clash with a value re-export.
+        const isType = node.exportKind === 'type' || node.parent.exportKind === 'type';
         addNamed(
           node.exported.name || node.exported.value,
           node.exported,
           getParent(node.parent),
+          isType,
         );
       },
 

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -194,7 +194,7 @@ module.exports = {
         remoteExports.forEach((v, name) => {
           if (name !== 'default') {
             any = true; // poor man's filter
-            addNamed(name, node, parent);
+            addNamed(name, node, parent, node.exportKind === 'type');
           }
         });
 

--- a/tests/files/export-type-star/m.ts
+++ b/tests/files/export-type-star/m.ts
@@ -1,0 +1,3 @@
+export interface Foo {}
+
+export function f(foo: Foo): void {}

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -351,6 +351,27 @@ context('TypeScript', function () {
           ...parserConfig,
         }) : [],
 
+        // https://github.com/import-js/eslint-plugin-import/issues/3136
+        // Named type-only re-exports (`export type { x }`) and inline type specifiers
+        // (`export { type x }`) also land in the type namespace, so they must not be
+        // reported as duplicates of a same-named value re-export.
+        typescriptEslintParserSatisfies('>= 5.54') ? test({
+          code: `
+            export { f } from './m';
+            export type { f } from './m';
+          `,
+          filename: testFilePath('export-type-star/index.ts'),
+          ...parserConfig,
+        }) : [],
+        typescriptEslintParserSatisfies('>= 5.54') ? test({
+          code: `
+            export { f } from './m';
+            export { type f } from './m';
+          `,
+          filename: testFilePath('export-type-star/index.ts'),
+          ...parserConfig,
+        }) : [],
+
         semver.satisfies(eslintPkg.version, '>= 6') ? [
           test({
             code: `

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -1,4 +1,4 @@
-import { test, testFilePath, SYNTAX_CASES, getTSParsers, testVersion } from '../utils';
+import { test, testFilePath, SYNTAX_CASES, getTSParsers, testVersion, typescriptEslintParserSatisfies } from '../utils';
 
 import { RuleTester } from '../rule-tester';
 import eslintPkg from 'eslint/package.json';
@@ -336,6 +336,20 @@ context('TypeScript', function () {
           filename: testFilePath('typescript-d-ts/file-2.ts'),
           ...parserConfig,
         }),
+
+        // https://github.com/import-js/eslint-plugin-import/issues/3136
+        // `export type *` re-exports names into the type namespace, so they must
+        // not be reported as duplicates of a same-named value re-export.
+        // `export type *` is TypeScript 5.0 syntax, first parsed by `@typescript-eslint/parser` 5.54,
+        // so this is gated on the parser version (below), not on the TypeScript version.
+        typescriptEslintParserSatisfies('>= 5.54') ? test({
+          code: `
+            export { f } from './m';
+            export type * from './m';
+          `,
+          filename: testFilePath('export-type-star/index.ts'),
+          ...parserConfig,
+        }) : [],
 
         semver.satisfies(eslintPkg.version, '>= 6') ? [
           test({


### PR DESCRIPTION
Problem I saw:
The `export` rule could report a duplicate export when a value export and a type-only star re-export exposed the same name.
One small shape that hit it was:
export { f } from './m'
export type * from './m'
That should not collide, since the second export is type-only. Thanks @mykola-mokhnach for the report.
What I changed:
I passed the `ExportAllDeclaration` export kind through to the named export tracking.
That keeps plain `export *` in the value side, but puts `export type *` in the type side.
How I checked it:
The focused regression test failed before the fix and passed after it.
I also ran:
npm run mocha -- tests/src/rules/export.js
npm run tests-only
ESLint was clean on the changed files.
Closes #3136