### PR TITLE
[actions] update `codecov/codecov-action` to v7

### DIFF
--- a/.github/workflows/eslint-8+.yml
+++ b/.github/workflows/eslint-8+.yml
@@ -68,7 +68,7 @@ jobs:
           skip-ls-check: true
       - run: npm run pretest
       - run: npm run tests-only
-      - uses: codecov/codecov-action@v3.1.5
+      - uses: codecov/codecov-action@v7.0.0
 
   node:
     name: 'eslint 8+'

--- a/.github/workflows/eslint-old.yml
+++ b/.github/workflows/eslint-old.yml
@@ -102,7 +102,7 @@ jobs:
           skip-ls-check: true
       - run: npm run pretest
       - run: npm run tests-only
-      - uses: codecov/codecov-action@v3.1.5
+      - uses: codecov/codecov-action@v7.0.0
 
   node:
     name: 'eslint 2 - 7'

--- a/.github/workflows/native-wsl.yml
+++ b/.github/workflows/native-wsl.yml
@@ -151,7 +151,7 @@ jobs:
         }
 
     - name: codecov
-      uses: codecov/codecov-action@v3.1.5
+      uses: codecov/codecov-action@v7.0.0
 
   windows:
     runs-on: ubuntu-latest

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -54,7 +54,7 @@ jobs:
           after_install: npm run copy-metafiles && ./tests/dep-time-travel.sh && cd ${{ matrix.package }} && npm install
           skip-ls-check: true
       - run: cd ${{ matrix.package }} && npm run tests-only
-      - uses: codecov/codecov-action@v3.1.5
+      - uses: codecov/codecov-action@v7.0.0
 
   packages:
     name: 'packages: all tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Tests] add parser version guards for ESLint v10 (TS_NEW / ANGULAR / BABEL_NEW) ([#3230], thanks [@rasmi])
 - [Tests] cover ESLint 10 `getTokenOrComment` and `listFilesToProcess` API fallbacks ([#3230], thanks [@captaindonald])
 - [Docs] `no-unused-modules`: Fix docs of `ignoreUnusedTypeExports` option ([#3233], thanks [@ej612])
+- [actions] update `codecov/codecov-action` to v7, for reliable tokenless coverage uploads from fork PRs ([#3262], thanks [@captaindonald])
 
 ## [2.32.0] - 2025-06-20
 
@@ -1203,6 +1204,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3262]: https://github.com/import-js/eslint-plugin-import/pull/3262
 [#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250
 [#3230]: https://github.com/import-js/eslint-plugin-import/pull/3230
 [#3247]: https://github.com/import-js/eslint-plugin-import/pull/3247


### PR DESCRIPTION
Follow-up to #3230 (ESLint v10) coverage work.

`v3.1.5` is the last v3 release. v4 made the upload token effectively required and broke tokenless coverage uploads from fork PRs of public repos — the reason this action was pinned back. v5 restored reliable tokenless fork-PR uploads; v7 is the current release.

Fork PRs cannot read repository secrets, so they have always relied on tokenless uploads. Against the sunset v3 endpoint those uploads were frequently rate-limited/dropped, so version-specific code covered only by certain matrix jobs appeared uncovered in the merged head report (~19 upload sessions on the head vs ~40 on the base in #3230). Upgrading makes uploads reliable.

This bumps `codecov/codecov-action@v3.1.5` -> `v7.0.0` in all four coverage-uploading workflows.
