### PR TITLE
[New] support wildcard patterns in `import/core-modules` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - support eslint v10 ([#3230], thanks [@rasmi])
 - [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247], thanks [@mixelburg] [@etyrrell22])
 - [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])
+- support wildcard patterns in the `import/core-modules` setting ([#3274], thanks [@andymai])
 
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
@@ -1205,6 +1206,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3274]: https://github.com/import-js/eslint-plugin-import/pull/3274
 [#3262]: https://github.com/import-js/eslint-plugin-import/pull/3262
 [#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250
 [#3230]: https://github.com/import-js/eslint-plugin-import/pull/3230
@@ -1850,6 +1852,7 @@ for info on changes for earlier releases.
 [@alexgorbatchev]: https://github.com/alexgorbatchev
 [@amsardesai]: https://github.com/amsardesai
 [@andreubotella]: https://github.com/andreubotella
+[@andymai]: https://github.com/andymai
 [@AndrewLeedham]: https://github.com/AndrewLeedham
 [@AndrewRayCode]: https://github.com/AndrewRayCode
 [@andyogo]: https://github.com/andyogo

--- a/README.md
+++ b/README.md
@@ -404,6 +404,21 @@ core module:
 }
 ```
 
+Wildcard patterns are supported to match multiple modules, using `*` as a wildcard:
+
+```jsonc
+// .eslintrc
+{
+  "settings": {
+    "import/core-modules": [
+      "electron",
+      "@my-monorepo/*", // matches @my-monorepo/package-a, @my-monorepo/package-b, etc.
+      "@my-*/*", // matches @my-org/package, @my-company/package, etc.
+    ],
+  },
+}
+```
+
 In Electron's specific case, there is a shared config named `electron`
 that specifies this for you.
 

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -1,6 +1,7 @@
 import { isAbsolute as nodeIsAbsolute, relative, resolve as nodeResolve } from 'path';
 import { statSync } from 'fs';
 import isCoreModule from 'is-core-module';
+import minimatch from 'minimatch';
 
 import resolve from 'eslint-module-utils/resolve';
 import { getContextPackagePath } from './packagePath';
@@ -33,7 +34,9 @@ export function isBuiltIn(name, settings, path) {
   if (path || !name) { return false; }
   const base = baseModule(name);
   const extras = settings && settings['import/core-modules'] || [];
-  return isCoreModule(base) || extras.indexOf(base) > -1;
+  return isCoreModule(base)
+    || extras.indexOf(base) > -1
+    || extras.some((pattern) => pattern.includes('*') && minimatch(base, pattern));
 }
 
 const moduleRegExp = /^\w/;

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -36,7 +36,7 @@ export function isBuiltIn(name, settings, path) {
   const extras = settings && settings['import/core-modules'] || [];
   return isCoreModule(base)
     || extras.indexOf(base) > -1
-    || extras.some((pattern) => pattern.includes('*') && minimatch(base, pattern));
+    || extras.some((pattern) => typeof pattern === 'string' && pattern.includes('*') && minimatch(base, pattern, { nocomment: true, nonegate: true }));
 }
 
 const moduleRegExp = /^\w/;

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -192,6 +192,18 @@ describe('importType(name)', function () {
     expect(importType('@my-monorepo/package-b/nested/module', wildcardContext)).to.equal('builtin');
   });
 
+  it('does not apply negation or comment glob semantics to core module patterns', function () {
+    const negatedContext = testContext({ 'import/core-modules': ['!@my-monorepo/*'] });
+    expect(importType('@other-org/package', negatedContext)).to.equal('external');
+    expect(importType('@my-monorepo/package-a', negatedContext)).to.equal('external');
+  });
+
+  it('does not throw on non-string entries in core modules', function () {
+    const bogusContext = testContext({ 'import/core-modules': [42, null, '@my-monorepo/*'] });
+    expect(importType('@my-monorepo/package-a', bogusContext)).to.equal('builtin');
+    expect(importType('@other-org/package', bogusContext)).to.equal('external');
+  });
+
   it('should support mixing exact matches and wildcards in core modules', function () {
     const mixedContext = testContext({ 'import/core-modules': ['electron', '@my-monorepo/*', '@specific/package'] });
 

--- a/tests/src/core/importType.js
+++ b/tests/src/core/importType.js
@@ -162,6 +162,50 @@ describe('importType(name)', function () {
     expect(importType('@org/foobar/some/path/to/resource.json', scopedContext)).to.equal('builtin');
   });
 
+  it("should return 'builtin' for wildcard patterns in core modules", function () {
+    // Test basic wildcard patterns
+    const wildcardContext = testContext({ 'import/core-modules': ['@my-monorepo/*'] });
+    expect(importType('@my-monorepo/package-a', wildcardContext)).to.equal('builtin');
+    expect(importType('@my-monorepo/package-b', wildcardContext)).to.equal('builtin');
+    expect(importType('@my-monorepo/some-long-package-name', wildcardContext)).to.equal('builtin');
+
+    // Test that non-matching patterns return external
+    expect(importType('@other-org/package', wildcardContext)).to.equal('external');
+    expect(importType('regular-package', wildcardContext)).to.equal('external');
+    expect(importType('@my-monorepo-but-not-scoped/package', wildcardContext)).to.equal('external');
+  });
+
+  it("should return 'builtin' for wildcard patterns with multiple wildcards", function () {
+    const multiWildcardContext = testContext({ 'import/core-modules': ['@my-*/*'] });
+    expect(importType('@my-org/package', multiWildcardContext)).to.equal('builtin');
+    expect(importType('@my-company/package', multiWildcardContext)).to.equal('builtin');
+    expect(importType('@my-test/package', multiWildcardContext)).to.equal('builtin');
+
+    // Should not match different patterns
+    expect(importType('@other-org/package', multiWildcardContext)).to.equal('external');
+    expect(importType('my-org/package', multiWildcardContext)).to.equal('external');
+  });
+
+  it("should return 'builtin' for resources inside wildcard core modules", function () {
+    const wildcardContext = testContext({ 'import/core-modules': ['@my-monorepo/*'] });
+    expect(importType('@my-monorepo/package-a/some/path/to/resource.json', wildcardContext)).to.equal('builtin');
+    expect(importType('@my-monorepo/package-b/nested/module', wildcardContext)).to.equal('builtin');
+  });
+
+  it('should support mixing exact matches and wildcards in core modules', function () {
+    const mixedContext = testContext({ 'import/core-modules': ['electron', '@my-monorepo/*', '@specific/package'] });
+
+    // Exact matches should work
+    expect(importType('electron', mixedContext)).to.equal('builtin');
+    expect(importType('@specific/package', mixedContext)).to.equal('builtin');
+
+    // Wildcard matches should work
+    expect(importType('@my-monorepo/any-package', mixedContext)).to.equal('builtin');
+
+    // Non-matches should be external
+    expect(importType('@other/package', mixedContext)).to.equal('external');
+  });
+
   it("should return 'external' for module from 'node_modules' with default config", function () {
     expect(importType('resolve', context)).to.equal('external');
   });

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -156,6 +156,23 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "@generated/bar/and/sub/path"',
       settings: { 'import/core-modules': ['@generated/bar'] },
     }),
+    // Test wildcard patterns in core-modules
+    test({
+      code: 'import "@my-monorepo/package-a"',
+      settings: { 'import/core-modules': ['@my-monorepo/*'] },
+    }),
+    test({
+      code: 'import "@my-monorepo/package-b/nested/module"',
+      settings: { 'import/core-modules': ['@my-monorepo/*'] },
+    }),
+    test({
+      code: 'import "@my-org/any-package"',
+      settings: { 'import/core-modules': ['@my-*/*'] },
+    }),
+    test({
+      code: 'import "@namespace/any-package"',
+      settings: { 'import/core-modules': ['@namespace/*', 'specific-module'] },
+    }),
     // check if "rxjs" dependency declaration fix the "rxjs/operators subpackage
     test({
       code: 'import "rxjs/operators"',


### PR DESCRIPTION
## Summary

Addresses https://github.com/import-js/eslint-plugin-import/issues/1281

Recreation of #3200, which became unrecoverable after I deleted the fork — apologies for the churn. This is the final state of that PR (post-review), rebased onto current `main`, with both review comments addressed:

- Uses `minimatch` (already a dependency) instead of dynamic regex construction, per [review feedback](https://github.com/import-js/eslint-plugin-import/pull/3200#discussion_r2216629001)
- The matching is inlined directly in `isBuiltIn` — no wrapper function, per [review feedback](https://github.com/import-js/eslint-plugin-import/pull/3200#discussion_r2218951225)

## Changes

- `src/core/importType.js`: patterns in `import/core-modules` containing `*` are matched with `minimatch` (exact matches still use `indexOf` first)
- Tests for basic wildcards (`@my-monorepo/*`), multiple wildcards (`@my-*/*`), mixed exact + wildcard lists, and subpaths of wildcard-matched modules
- `no-extraneous-dependencies` rule tests for wildcard core-modules
- README example of wildcard usage

## Test plan

- [x] All existing tests pass
- [x] New tests in `tests/src/core/importType.js` and `tests/src/rules/no-extraneous-dependencies.js`

## Notes

- Non-string entries in the setting are ignored (previously `indexOf` tolerated them; `pattern.includes` would have thrown), and minimatch's `!` negation / `#` comment semantics are disabled (`nonegate`/`nocomment`) so a pattern like `!@foo/*` can't accidentally match everything.
- **Known limitation**: `eslint-module-utils`' `resolve` still does an exact-match `Set.has()` on `import/core-modules` ([`utils/resolve.js`](https://github.com/import-js/eslint-plugin-import/blob/main/utils/resolve.js#L155)), so wildcard entries are honored by `importType`-based rules but not by resolver-based ones like `no-unresolved`. Happy to extend this to `eslint-module-utils` in this PR or a follow-up if that's the preferred direction.
